### PR TITLE
SafeEdit fast-only; add Pyright gate; restore TDD workflow doc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,17 @@
         "pylint",
         "pip",
         "git"
-    ]
+    ],
+    "chat.mcp.serverSampling": {
+        "SimpleTraderV3/.vscode/mcp.json: st3-workflow": {
+            "allowedModels": [
+                "copilot/claude-sonnet-4.5",
+                "copilot/claude-opus-4.5",
+                "copilot/gemini-2.5-pro",
+                "copilot/gemini-3-flash-preview",
+                "copilot/gemini-3-pro-preview",
+                "copilot/gpt-5.2"
+            ]
+        }
+    }
 }

--- a/docs/development/mcp_server/SAFE_EDIT_TOOL_FLOW_ENFORCEMENT.md
+++ b/docs/development/mcp_server/SAFE_EDIT_TOOL_FLOW_ENFORCEMENT.md
@@ -1,0 +1,341 @@
+# SafeEditTool Integration and Enforced TDD Workflow
+
+**Status:** DRAFT
+**Author:** ST3 Agent (Copilot)
+**Created:** 2025-12-21
+**Last Updated:** 2025-12-21
+**Issues:** #20, #18, #14
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Define how SafeEditTool is integrated into the ST3 development flow, while making correct behavior **tooling-enforced** rather than “agent-mood dependent”.
+
+This document formalizes:
+- How the existing **RED / GREEN / REFACTOR** loop is mapped to tool entry points.
+- Which validations are mandatory at which “choke points” (especially commit/PR/close).
+- A concrete change set for SafeEditTool (performance + granularity).
+
+### 1.2 Scope
+
+**In Scope:**
+- Enforcement rules for the following ST3 tools:
+    - `scaffold_component` (new code creation)
+    - `safe_edit_tool` (editing)
+    - `git_add_or_commit` (commit gate)
+    - `create_pr` (PR gate)
+    - `close_issue` (issue closure gate)
+- A small “policy model” that decides which gates apply based on context (operation + phase + branch + changeset).
+- Minimal new parameters needed to activate enforcement deterministically.
+
+**Out of Scope:**
+- Large refactors across unrelated modules.
+- Changing the overall architecture of the trading platform.
+- GitHub branch protection settings in GitHub UI (this design focuses on **tooling**, not manual repo settings).
+
+### 1.3 Related Documents
+
+- [Core Principles](docs/architecture/CORE_PRINCIPLES.md)
+- [Architectural Shifts](docs/architecture/ARCHITECTURAL_SHIFTS.md)
+- [TDD Workflow](docs/coding_standards/TDD_WORKFLOW.md)
+- [Quality Gates](docs/coding_standards/QUALITY_GATES.md)
+- [Agent Protocol](AGENT_PROMPT.md)
+
+---
+
+## 2. Background
+
+### 2.1 Current State
+
+Today, `safe_edit_tool` can run full QA validation per edit, which creates latency during rapid refactoring and discourages usage. Meanwhile, correctness of the workflow depends too much on whether an agent/human “chooses” the right tool.
+
+We already have a documented flow in [Agent Protocol](AGENT_PROMPT.md):
+- Use `scaffold_*` for creation.
+- Do TDD loop (RED → GREEN → REFACTOR).
+- Use tool priority matrix (never manual if a tool exists).
+
+However, documentation alone cannot enforce behavior.
+
+### 2.2 Problem Statement
+
+We need a deterministic workflow where:
+- The right validations run at the right time (fast feedback during edits, strict gates during commit/PR/close).
+- The process does **not** depend on the “bui” of an agent/human.
+- New files and tests are created through standardized scaffolding.
+- Committing directly to `main` is technically prevented.
+
+### 2.3 Requirements
+
+#### Functional Requirements
+- [ ] **FR1:** SafeEditTool supports multiple validation profiles (fast vs full) to reduce latency.
+- [ ] **FR2:** SafeEditTool strict mode can block only on **critical** findings and/or **newly introduced** findings.
+- [ ] **FR2.1:** In `FAST` profile for Python files, enforce cheap, high-signal formatting rules:
+    - final newline present
+    - no trailing whitespace
+    - max line length 100
+- [ ] **FR3:** `git_add_or_commit` enforces branch protection (cannot commit on `main`/`master`).
+- [ ] **FR4:** `git_add_or_commit` enforces TDD phase gates:
+    - RED: require at least one failing test (or explicitly marked failing test)
+    - GREEN: require tests passing
+    - REFACTOR: require tests passing + quality gates
+- [ ] **FR5:** `create_pr` and/or `close_issue` enforce required artifacts (Issue #14): `walkthrough.md` + `implementation_plan.md`.
+- [ ] **FR6:** `scaffold_component` remains the only supported “new code creation” path for typed components (DTO/worker/adapter/etc) and produces test stubs.
+
+#### Non-Functional Requirements
+- [ ] **NFR1:** Performance - fast edit validation should feel near-instant for single-file edits.
+- [ ] **NFR2:** Determinism - results must be consistent across agents/humans.
+- [ ] **NFR3:** Testability - policy decisions and tool gates are unit-testable (mockable external calls).
+- [ ] **NFR4:** Safety - commit/PR/close gates must remain strict even if edit-time validation is relaxed.
+
+---
+
+## 3. Design
+
+### 3.1 Architecture Position
+
+This design introduces a **Policy Engine** concept that is used by tools to decide what validations (“gates”) must run.
+
+```
+                +-------------------+
+                |  Developer/Agent  |
+                +---------+---------+
+                          |
+                          v
+     +--------------------+--------------------+
+     | Entry Points (ST3 Tools)                |
+     |  - scaffold_component                   |
+     |  - safe_edit_tool                       |
+     |  - git_add_or_commit   (CHOKE POINT)    |
+     |  - create_pr           (CHOKE POINT)    |
+     |  - close_issue         (CHOKE POINT)    |
+     +--------------------+--------------------+
+                          |
+                          v
+                 +--------+--------+
+                 |  Policy Engine  |
+                 +--------+--------+
+                          |
+                          v
+                 +--------+--------+
+                 | Gates / Checks  |
+                 | - tests         |
+                 | - quality       |
+                 | - coverage      |
+                 | - artifacts     |
+                 +-----------------+
+```
+
+Key rule: **Enforcement happens at choke points** (commit/PR/close), not only during editing.
+
+### 3.2 Component Design
+
+#### 3.2.1 Policy Engine (New)
+
+**Purpose:**
+Deterministically map (operation + phase + branch + changeset) → required gates.
+
+**Responsibilities:**
+- Decide which validations must run for a given tool execution.
+- Provide a structured decision that tools can enforce.
+
+**Dependencies:**
+- Repo state introspection (branch name, changed files, staged files).
+- Configuration (thresholds, artifact paths, branch rules).
+
+#### 3.2.2 Gates (Existing + Extended)
+
+**Purpose:**
+Encapsulate checks like unit tests, quality gates, coverage thresholds, and artifact presence.
+
+**Notes:**
+- For edits, use lighter gates (fast/critical-only) when configured.
+- For commit/PR/close, use strict gates.
+
+**Lightweight Edit Gate (Python):**
+Even in `FAST` mode we enforce a tiny set of rules that prevent recurring “paper-cut” issues:
+- Ensure file ends with a final newline.
+- Reject or auto-fix trailing whitespace.
+- Enforce max line length 100.
+
+Rationale: these checks are deterministic, cheap to compute ($O(n)$ over the content), and remove the most frustrating trivial failures while still keeping `FAST` fast.
+
+### 3.3 Data Model
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class TDDPhase(str, Enum):
+    RED = "red"
+    GREEN = "green"
+    REFACTOR = "refactor"
+
+
+class ValidationProfile(str, Enum):
+    FAST = "fast"           # syntax + minimal checks (+ cheap Python formatting gate)
+    CRITICAL = "critical"   # syntax + critical-only
+    FULL = "full"           # full QA manager (tests + lint/type)
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    operation: str  # e.g. "safe_edit", "git_commit", "create_pr", "close_issue", "scaffold"
+    phase: TDDPhase
+    branch: str
+    changed_files: tuple[str, ...]
+    staged_files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allow: bool
+    reasons: tuple[str, ...]
+    required_gates: tuple[str, ...]
+    validation_profile: ValidationProfile
+```
+
+### 3.4 Interface Design
+
+```python
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class IPolicyEngine(Protocol):
+    def decide(self, context: PolicyContext) -> PolicyDecision:
+        """Return a deterministic policy decision for the given context."""
+        ...
+```
+
+Tools use the policy decision to run the required gates and fail early with actionable feedback.
+
+---
+
+## 4. Implementation Plan
+
+### 4.1 Phases
+
+#### Phase 1: Commit Choke Point Enforcement (Highest ROI)
+
+**Goal:** Make correct behavior unavoidable at commit time.
+
+**Tasks:**
+- [ ] Extend `git_add_or_commit` with branch protection: deny commits on `main`/`master`.
+- [ ] Add phase-aware gating logic (RED/GREEN/REFACTOR).
+- [ ] Add a minimal configuration surface (thresholds, branch names, required artifacts).
+
+**Exit Criteria:**
+- [ ] Tool refuses commit on `main`.
+- [ ] GREEN requires passing tests.
+- [ ] REFACTOR requires passing tests + quality gates.
+
+#### Phase 2: SafeEditTool Profiles (Issue #20)
+
+**Goal:** Make SafeEditTool usable in rapid iteration without losing safety.
+
+**Tasks:**
+- [ ] Add `validation_profile` parameter (FAST/CRITICAL/FULL).
+- [ ] Implement `FAST` profile “cheap formatting gate” for Python:
+    - final newline
+    - no trailing whitespace
+    - max line length 100
+- [ ] Implement “new-findings-only” blocking for strict mode (or “critical-only”).
+- [ ] Add short-circuit rules (no-op edits, whitespace-only changes).
+
+**Exit Criteria:**
+- [ ] FAST profile is meaningfully faster than FULL.
+- [ ] Strict mode does not force fixing unrelated legacy issues (when configured).
+
+#### Phase 3: PR/Close Artifact Gates (Issue #14)
+
+**Goal:** Ensure consistent paper trail for completed work.
+
+**Tasks:**
+- [ ] `create_pr` gate: require GREEN (tests pass) + required artifacts exist.
+- [ ] `close_issue` gate: require artifacts + post summary comment with links.
+
+**Exit Criteria:**
+- [ ] Tool refuses PR/close when artifacts are missing.
+
+### 4.2 Testing Strategy
+
+| Test Type | Scope | Target |
+|-----------|-------|--------|
+| Unit | Policy Engine decisions | Cover all phase/operation combinations |
+| Unit | SafeEditTool profiles | FAST vs FULL vs CRITICAL behavior |
+| Unit | Commit gate | branch protection + phase gating |
+| Integration | Tool flows | smoke tests for safe_edit → commit → PR |
+
+---
+
+## 5. Alternatives Considered
+
+### Alternative A
+
+**Description:** Enforce everything only via SafeEditTool (block all edits that violate standards).
+
+**Pros:**
+- Centralized.
+
+**Cons:**
+- Poor UX during refactors (latency, forces unrelated fixes).
+- Does not cover manual edits (humans can bypass tool).
+
+**Decision:** Rejected. Enforcement must live at commit/PR/close choke points.
+
+### Alternative B
+
+**Description:** Enforce only in CI.
+
+**Pros:**
+- Strong and centralized.
+
+**Cons:**
+- Feedback is too late; agents still thrash locally.
+
+**Decision:** Rejected as sole mechanism; acceptable as additional layer.
+
+### Alternative C
+
+**Description:** Git hooks.
+
+**Pros:**
+- Runs locally, unavoidable if installed.
+
+**Cons:**
+- Harder to standardize cross-platform, and agents can bypass.
+
+**Decision:** Not primary; tooling-based choke points are preferred.
+
+---
+
+## 6. Open Questions
+
+- [ ] Where should phase state live: explicit tool parameter, or a repo-backed state (e.g., `.st3/phase.json`)?
+- [ ] How do we reliably detect a “RED commit” (intentionally failing tests) without false positives?
+- [ ] Coverage enforcement strategy: changed-files only vs package thresholds.
+- [ ] Required artifact paths: do we standardize locations per issue/feature branch?
+
+---
+
+## 7. Decision Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2025-12-21 | Enforce via choke points | Commit/PR/close is unavoidable |
+| 2025-12-21 | Add SafeEditTool profiles | Fast iteration without losing safety |
+
+---
+
+## 8. References
+
+- [TDD Workflow](docs/coding_standards/TDD_WORKFLOW.md)
+- [Quality Gates](docs/coding_standards/QUALITY_GATES.md)
+- [Agent Protocol](AGENT_PROMPT.md)

--- a/mcp_server/adapters/git_adapter.py
+++ b/mcp_server/adapters/git_adapter.py
@@ -133,17 +133,20 @@ class GitAdapter:
         except Exception as e:
             raise ExecutionError(f"Failed to delete {branch_name}: {e}") from e
 
-    def stash(self, message: str | None = None) -> None:
+    def stash(self, message: str | None = None, include_untracked: bool = False) -> None:
         """Stash current changes.
 
         Args:
             message: Optional message for the stash entry.
+            include_untracked: Include untracked files in the stash entry.
         """
         try:
+            args: list[str] = ["push"]
+            if include_untracked:
+                args.append("-u")
             if message:
-                self.repo.git.stash("push", "-m", message)
-            else:
-                self.repo.git.stash("push")
+                args.extend(["-m", message])
+            self.repo.git.stash(*args)
         except Exception as e:
             raise ExecutionError(f"Failed to stash changes: {e}") from e
 

--- a/mcp_server/managers/git_manager.py
+++ b/mcp_server/managers/git_manager.py
@@ -92,13 +92,14 @@ class GitManager:
             )
         self.adapter.delete_branch(branch_name, force=force)
 
-    def stash(self, message: str | None = None) -> None:
+    def stash(self, message: str | None = None, include_untracked: bool = False) -> None:
         """Stash current changes.
 
         Args:
             message: Optional message for the stash entry.
+            include_untracked: Include untracked files in the stash entry.
         """
-        self.adapter.stash(message=message)
+        self.adapter.stash(message=message, include_untracked=include_untracked)
 
     def stash_pop(self) -> None:
         """Pop the latest stash entry."""

--- a/mcp_server/tools/git_tools.py
+++ b/mcp_server/tools/git_tools.py
@@ -214,6 +214,10 @@ class GitStashInput(BaseModel):
         default=None,
         description="Optional name for the stash (only for push)"
     )
+    include_untracked: bool = Field(
+        default=False,
+        description="Include untracked files when stashing (git stash push -u)"
+    )
 
 
 class GitStashTool(BaseTool):
@@ -232,7 +236,7 @@ class GitStashTool(BaseTool):
 
     async def execute(self, params: GitStashInput) -> ToolResult:
         if params.action == "push":
-            self.manager.stash(message=params.message)
+            self.manager.stash(message=params.message, include_untracked=params.include_untracked)
             if params.message:
                 return ToolResult.text(f"Stashed changes: {params.message}")
             return ToolResult.text("Stashed current changes")

--- a/mcp_server/tools/issue_tools.py
+++ b/mcp_server/tools/issue_tools.py
@@ -110,9 +110,9 @@ class ListIssuesTool(BaseTool):
 
     async def execute(self, params: ListIssuesInput) -> ToolResult:
         try:
-            state_str = (
-                params.state.value if isinstance(params.state, IssueState) else params.state
-            )
+            # `IssueState` is a typing.Literal alias, not a runtime type.
+            # Pydantic will give us either a string value or None.
+            state_str = params.state
             issues = self.manager.list_issues(
                 state=state_str or "open",
                 labels=params.labels

--- a/tests/unit/mcp_server/adapters/test_git_adapter.py
+++ b/tests/unit/mcp_server/adapters/test_git_adapter.py
@@ -166,6 +166,17 @@ class TestGitAdapterStash:
 
             mock_repo.git.stash.assert_called_once_with("push")
 
+    def test_stash_changes_include_untracked(self) -> None:
+        """Test stash current changes including untracked files (-u)."""
+        with patch("mcp_server.adapters.git_adapter.Repo") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo_class.return_value = mock_repo
+
+            adapter = GitAdapter("/fake/path")
+            adapter.stash(include_untracked=True)
+
+            mock_repo.git.stash.assert_called_once_with("push", "-u")
+
     def test_stash_with_message(self) -> None:
         """Test stash with custom message."""
         with patch("mcp_server.adapters.git_adapter.Repo") as mock_repo_class:
@@ -176,6 +187,19 @@ class TestGitAdapterStash:
             adapter.stash(message="WIP: feature work")
 
             mock_repo.git.stash.assert_called_once_with("push", "-m", "WIP: feature work")
+
+    def test_stash_with_message_include_untracked(self) -> None:
+        """Test stash with message including untracked files (-u)."""
+        with patch("mcp_server.adapters.git_adapter.Repo") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo_class.return_value = mock_repo
+
+            adapter = GitAdapter("/fake/path")
+            adapter.stash(message="WIP: feature work", include_untracked=True)
+
+            mock_repo.git.stash.assert_called_once_with(
+                "push", "-u", "-m", "WIP: feature work"
+            )
 
     def test_stash_pop(self) -> None:
         """Test pop the latest stash."""

--- a/tests/unit/mcp_server/integration/test_all_tools.py
+++ b/tests/unit/mcp_server/integration/test_all_tools.py
@@ -134,7 +134,7 @@ class TestGitToolsIntegration:
             result = await tool.execute(GitStashInput(action="push", message="WIP"))
 
             assert "WIP" in result.content[0]["text"]
-            mock_adapter.return_value.stash.assert_called_with(message="WIP")
+            mock_adapter.return_value.stash.assert_called_with(message="WIP", include_untracked=False)
 
     @pytest.mark.asyncio
     async def test_git_stash_tool_pop_flow(self) -> None:

--- a/tests/unit/mcp_server/managers/test_git_manager.py
+++ b/tests/unit/mcp_server/managers/test_git_manager.py
@@ -151,7 +151,10 @@ class TestGitManagerOperations:
     def test_stash_operations(self, manager: GitManager, mock_adapter: MagicMock) -> None:
         """Test stash delegations."""
         manager.stash("saving work")
-        mock_adapter.stash.assert_called_with(message="saving work")
+        mock_adapter.stash.assert_called_with(message="saving work", include_untracked=False)
+
+        manager.stash("saving work", include_untracked=True)
+        mock_adapter.stash.assert_called_with(message="saving work", include_untracked=True)
 
         manager.stash_pop()
         mock_adapter.stash_pop.assert_called_once()

--- a/tests/unit/tools/test_issue_tools.py
+++ b/tests/unit/tools/test_issue_tools.py
@@ -82,10 +82,9 @@ async def test_get_issue_tool(mock_github_manager):
 @pytest.mark.asyncio
 async def test_close_issue_tool(mock_github_manager):
     tool = CloseIssueTool(manager=mock_github_manager)
-    mock_github_manager.update_issue.return_value = MagicMock(number=5)
+    mock_github_manager.close_issue.return_value = MagicMock(number=5)
     
     # Test with comment
     await tool.execute(CloseIssueInput(issue_number=5, comment="Done"))
-    
-    mock_github_manager.create_comment.assert_called_with(5, "Done")
-    mock_github_manager.update_issue.assert_called_with(5, state="closed")
+
+    mock_github_manager.close_issue.assert_called_with(5, comment="Done")


### PR DESCRIPTION
## Summary
- Make `safe_edit_tool` fast-only (cheap deterministic checks + tiny autofix); reject legacy profile params.
- Extend QA gates to include Pyright for editor/Pylance parity.
- Restore missing TDD workflow documentation and close/update the SafeEdit enforcement design doc (links fixed).

## Notes
- This keeps deep validation out of SafeEdit and moves it toward explicit QA gates / future choke-point enforcement.

Closes #20.