### PR TITLE
Issue #24: scoped git commits + git_restore tool

### DIFF
--- a/mcp_server/adapters/git_adapter.py
+++ b/mcp_server/adapters/git_adapter.py
@@ -1,7 +1,7 @@
 """Git adapter for the MCP server."""
 from typing import Any
 
-from git import InvalidGitRepositoryError, Repo  # type: ignore[import-untyped]
+from git import InvalidGitRepositoryError, Repo
 
 from mcp_server.config.settings import settings
 from mcp_server.core.exceptions import ExecutionError, MCPSystemError
@@ -12,7 +12,6 @@ class GitAdapter:
 
     def __init__(self, repo_path: str | None = None) -> None:
         """Initialize the Git adapter."""
-        # pylint: disable=no-member
         self.repo_path = repo_path or settings.server.workspace_root
         self._repo: Repo | None = None
 
@@ -188,7 +187,7 @@ class GitAdapter:
             List of stash entry descriptions.
         """
         try:
-            output = self.repo.git.stash("list")
+            output = str(self.repo.git.stash("list"))
             if not output:
                 return []
             return output.strip().split("\n")
@@ -213,11 +212,11 @@ class GitAdapter:
                 args.append("-vv")
 
             # GitPython's repo.git.branch returns the raw string output
-            output = self.repo.git.branch(*args)
+            output = str(self.repo.git.branch(*args))
             if not output:
                 return []
             return [line.strip() for line in output.split("\n") if line.strip()]
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception as e:
             raise ExecutionError(f"Failed to list branches: {e}") from e
 
     def get_diff_stat(self, target: str, source: str = "HEAD") -> str:
@@ -235,8 +234,8 @@ class GitAdapter:
             # Usually strict comparison 'target...source' is better for
             # "what is in source that is not in target"
             # Command: git diff target...source --stat
-            return self.repo.git.diff(f"{target}...{source}", "--stat")
-        except Exception as e:  # pylint: disable=broad-exception-caught
+            return str(self.repo.git.diff(f"{target}...{source}", "--stat"))
+        except Exception as e:
             raise ExecutionError(f"Failed to get diff stat: {e}") from e
 
     def get_recent_commits(self, limit: int = 5) -> list[str]:

--- a/mcp_server/adapters/git_adapter.py
+++ b/mcp_server/adapters/git_adapter.py
@@ -69,14 +69,38 @@ class GitAdapter:
         except Exception as e:
             raise ExecutionError(f"Failed to create branch {branch_name}: {e}") from e
 
-    def commit(self, message: str) -> str:
-        """Commit changes."""
+    def commit(self, message: str, files: list[str] | None = None) -> str:
+        """Commit changes.
+
+        Args:
+            message: Commit message.
+            files: Optional list of file paths to stage and commit. When omitted,
+                stages all changes (equivalent to `git add .`).
+        """
         try:
-            self.repo.git.add(".")
+            if files is None:
+                self.repo.git.add(".")
+            else:
+                self.repo.git.add(*files)
             commit = self.repo.index.commit(message)
             return commit.hexsha
         except Exception as e:
             raise ExecutionError(f"Failed to commit: {e}") from e
+
+    def restore(self, files: list[str], source: str = "HEAD") -> None:
+        """Restore files to a given source ref (default: HEAD).
+
+        This restores both staged and working tree changes for the given files.
+
+        Args:
+            files: List of file paths to restore.
+            source: Git ref to restore from.
+        """
+        try:
+            # Restore both index and working tree from the given source.
+            self.repo.git.restore(f"--source={source}", "--staged", "--worktree", "--", *files)
+        except Exception as e:
+            raise ExecutionError(f"Failed to restore files: {e}") from e
 
     def checkout(self, branch_name: str) -> None:
         """Checkout to an existing branch."""

--- a/mcp_server/core/logging.py
+++ b/mcp_server/core/logging.py
@@ -20,7 +20,7 @@ class StructuredFormatter(logging.Formatter):
         }
 
         if hasattr(record, "props"):
-            log_data.update(record.props)  # type: ignore[attr-defined]
+            log_data.update(record.props)
 
         if record.exc_info:
             log_data["exception"] = self.formatException(record.exc_info)

--- a/mcp_server/managers/git_manager.py
+++ b/mcp_server/managers/git_manager.py
@@ -43,12 +43,24 @@ class GitManager:
         self.adapter.create_branch(full_name)
         return full_name
 
-    def commit_tdd_phase(self, phase: str, message: str) -> str:
-        """Commit changes with TDD phase prefix."""
+    def commit_tdd_phase(self, phase: str, message: str, files: list[str] | None = None) -> str:
+        """Commit changes with TDD phase prefix.
+
+        Args:
+            phase: TDD phase (red/green/refactor).
+            message: Commit message (without prefix).
+            files: Optional list of file paths to stage + commit.
+        """
         if phase not in ["red", "green", "refactor"]:
             raise ValidationError(
                 f"Invalid TDD phase: {phase}",
                 hints=["Use red, green, or refactor"]
+            )
+
+        if files is not None and not files:
+            raise ValidationError(
+                "Files list cannot be empty",
+                hints=["Omit 'files' to commit everything, or provide at least one path"]
             )
 
         prefix_map = {
@@ -58,12 +70,36 @@ class GitManager:
         }
 
         full_message = f"{prefix_map[phase]}: {message}"
-        return self.adapter.commit(full_message)
+        return self.adapter.commit(full_message, files=files)
 
-    def commit_docs(self, message: str) -> str:
-        """Commit changes with docs prefix."""
+    def commit_docs(self, message: str, files: list[str] | None = None) -> str:
+        """Commit changes with docs prefix.
+
+        Args:
+            message: Commit message (without prefix).
+            files: Optional list of file paths to stage + commit.
+        """
+        if files is not None and not files:
+            raise ValidationError(
+                "Files list cannot be empty",
+                hints=["Omit 'files' to commit everything, or provide at least one path"]
+            )
         full_message = f"docs: {message}"
-        return self.adapter.commit(full_message)
+        return self.adapter.commit(full_message, files=files)
+
+    def restore(self, files: list[str], source: str = "HEAD") -> None:
+        """Restore files to a given source ref.
+
+        Args:
+            files: File paths to restore.
+            source: Git ref to restore from (default HEAD).
+        """
+        if not files:
+            raise ValidationError(
+                "Files list cannot be empty",
+                hints=["Provide at least one path to restore"]
+            )
+        self.adapter.restore(files=files, source=source)
 
     def checkout(self, branch_name: str) -> None:
         """Checkout to an existing branch."""

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -35,6 +35,7 @@ from mcp_server.tools.git_tools import (
     GitDeleteBranchTool,
     GitMergeTool,
     GitPushTool,
+    GitRestoreTool,
     GitStashTool,
     GitStatusTool,
 )
@@ -100,6 +101,7 @@ class MCPServer:
             GitMergeTool(),
             GitDeleteBranchTool(),
             GitStashTool(),
+            GitRestoreTool(),
             GitListBranchesTool(),
             GitDiffTool(),
             # Quality tools

--- a/mcp_server/tools/git_tools.py
+++ b/mcp_server/tools/git_tools.py
@@ -7,6 +7,12 @@ from mcp_server.managers.git_manager import GitManager
 from mcp_server.tools.base import BaseTool, ToolResult
 
 
+def _input_schema(args_model: type[BaseModel] | None) -> dict[str, Any]:
+    if args_model is None:
+        return {}
+    return args_model.model_json_schema()
+
+
 class CreateBranchInput(BaseModel):
     """Input for CreateBranchTool."""
     name: str = Field(..., description="Branch name (kebab-case)")
@@ -29,7 +35,7 @@ class CreateBranchTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: CreateBranchInput) -> ToolResult:
         branch_name = self.manager.create_feature_branch(params.name, params.branch_type)
@@ -52,7 +58,7 @@ class GitStatusTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: GitStatusInput) -> ToolResult:
         status = self.manager.get_status()
@@ -95,7 +101,7 @@ class GitCommitTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: GitCommitInput) -> ToolResult:
         if params.phase == "docs":
@@ -135,7 +141,7 @@ class GitRestoreTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: GitRestoreInput) -> ToolResult:
         self.manager.restore(files=params.files, source=params.source)
@@ -161,7 +167,7 @@ class GitCheckoutTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: GitCheckoutInput) -> ToolResult:
         self.manager.checkout(params.branch)
@@ -188,7 +194,7 @@ class GitPushTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: GitPushInput) -> ToolResult:
         status = self.manager.get_status()
@@ -213,7 +219,7 @@ class GitMergeTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: GitMergeInput) -> ToolResult:
         status = self.manager.get_status()
@@ -241,7 +247,7 @@ class GitDeleteBranchTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: GitDeleteBranchInput) -> ToolResult:
         self.manager.delete_branch(params.branch, force=params.force)
@@ -277,7 +283,7 @@ class GitStashTool(BaseTool):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        return self.args_model.model_json_schema()
+        return _input_schema(self.args_model)
 
     async def execute(self, params: GitStashInput) -> ToolResult:
         if params.action == "push":

--- a/mcp_server/tools/git_tools.py
+++ b/mcp_server/tools/git_tools.py
@@ -101,7 +101,11 @@ class GitCommitTool(BaseTool):
         if params.phase == "docs":
             commit_hash = self.manager.commit_docs(params.message, files=params.files)
         else:
-            commit_hash = self.manager.commit_tdd_phase(params.phase, params.message, files=params.files)
+            commit_hash = self.manager.commit_tdd_phase(
+                params.phase,
+                params.message,
+                files=params.files,
+            )
         return ToolResult.text(f"Committed: {commit_hash}")
 
 

--- a/tests/unit/mcp_server/adapters/test_git_adapter.py
+++ b/tests/unit/mcp_server/adapters/test_git_adapter.py
@@ -315,3 +315,14 @@ class TestGitAdapterRestore:
                 "a.py",
                 "b.py",
             )
+
+    def test_restore_wraps_errors_in_execution_error(self) -> None:
+        """Test restore errors are wrapped in ExecutionError."""
+        with patch("mcp_server.adapters.git_adapter.Repo") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.git.restore.side_effect = Exception("Git error")
+            mock_repo_class.return_value = mock_repo
+
+            adapter = GitAdapter("/fake/path")
+            with pytest.raises(ExecutionError, match="restore"):
+                adapter.restore(files=["a.py"], source="HEAD")

--- a/tests/unit/mcp_server/adapters/test_git_adapter.py
+++ b/tests/unit/mcp_server/adapters/test_git_adapter.py
@@ -257,3 +257,61 @@ class TestGitAdapterStash:
 
             with pytest.raises(ExecutionError, match="does not exist"):
                 adapter.delete_branch("nonexistent")
+
+
+class TestGitAdapterCommit:
+    """Tests for git commit functionality."""
+
+    def test_commit_stages_all_when_files_none(self) -> None:
+        """Test commit stages all changes when files is omitted."""
+        with patch("mcp_server.adapters.git_adapter.Repo") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_commit = MagicMock()
+            mock_commit.hexsha = "abc1234"
+            mock_repo.index.commit.return_value = mock_commit
+            mock_repo_class.return_value = mock_repo
+
+            adapter = GitAdapter("/fake/path")
+            result = adapter.commit("msg")
+
+            assert result == "abc1234"
+            mock_repo.git.add.assert_called_once_with(".")
+            mock_repo.index.commit.assert_called_once_with("msg")
+
+    def test_commit_stages_only_given_files(self) -> None:
+        """Test commit stages only provided files."""
+        with patch("mcp_server.adapters.git_adapter.Repo") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_commit = MagicMock()
+            mock_commit.hexsha = "abc1234"
+            mock_repo.index.commit.return_value = mock_commit
+            mock_repo_class.return_value = mock_repo
+
+            adapter = GitAdapter("/fake/path")
+            result = adapter.commit("msg", files=["a.py", "docs/readme.md"])
+
+            assert result == "abc1234"
+            mock_repo.git.add.assert_called_once_with("a.py", "docs/readme.md")
+            mock_repo.index.commit.assert_called_once_with("msg")
+
+
+class TestGitAdapterRestore:
+    """Tests for git restore functionality."""
+
+    def test_restore_calls_git_restore_for_files(self) -> None:
+        """Test restore delegates to `git restore` with correct args."""
+        with patch("mcp_server.adapters.git_adapter.Repo") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo_class.return_value = mock_repo
+
+            adapter = GitAdapter("/fake/path")
+            adapter.restore(files=["a.py", "b.py"], source="HEAD")
+
+            mock_repo.git.restore.assert_called_once_with(
+                "--source=HEAD",
+                "--staged",
+                "--worktree",
+                "--",
+                "a.py",
+                "b.py",
+            )

--- a/tests/unit/mcp_server/integration/test_all_tools.py
+++ b/tests/unit/mcp_server/integration/test_all_tools.py
@@ -18,6 +18,7 @@ from mcp_server.tools.git_tools import (
     GitDeleteBranchTool, GitDeleteBranchInput,
     GitMergeTool, GitMergeInput,
     GitPushTool, GitPushInput,
+    GitRestoreTool, GitRestoreInput,
     GitStashTool, GitStashInput,
     GitStatusTool, GitStatusInput,
 )
@@ -77,7 +78,17 @@ class TestGitToolsIntegration:
             result = await tool.execute(GitCommitInput(phase="green", message="implement feature"))
 
             assert "abc123def" in result.content[0]["text"]
-            mock_adapter.return_value.commit.assert_called_with("feat: implement feature")
+            mock_adapter.return_value.commit.assert_called_with("feat: implement feature", files=None)
+
+    @pytest.mark.asyncio
+    async def test_git_restore_tool_flow(self) -> None:
+        """Test git restore tool complete flow."""
+        with patch("mcp_server.managers.git_manager.GitAdapter") as mock_adapter:
+            tool = GitRestoreTool()
+            result = await tool.execute(GitRestoreInput(files=["a.py"], source="HEAD"))
+
+            assert "Restored" in result.content[0]["text"]
+            mock_adapter.return_value.restore.assert_called_with(files=["a.py"], source="HEAD")
 
     @pytest.mark.asyncio
     async def test_git_checkout_tool_flow(self) -> None:
@@ -372,6 +383,7 @@ class TestToolNames:
             CreateBranchTool(),
             GitStatusTool(),
             GitCommitTool(),
+            GitRestoreTool(),
             GitCheckoutTool(),
             GitPushTool(),
             GitMergeTool(),

--- a/tests/unit/mcp_server/integration/test_all_tools.py
+++ b/tests/unit/mcp_server/integration/test_all_tools.py
@@ -33,8 +33,13 @@ from mcp_server.tools.pr_tools import CreatePRTool, CreatePRInput
 
 # Quality Tools
 from mcp_server.tools.quality_tools import RunQualityGatesTool, RunQualityGatesInput
-from mcp_server.tools.test_tools import RunTestsTool, RunTestsInput
-from mcp_server.tools.validation_tools import ValidateDTOTool, ValidateDTOInput, ValidationTool, ValidationInput
+from mcp_server.tools.test_tools import RunTestsTool
+from mcp_server.tools.validation_tools import (
+    ValidateDTOTool,
+    ValidateDTOInput,
+    ValidationTool,
+    ValidationInput,
+)
 
 
 class TestGitToolsIntegration:
@@ -47,7 +52,9 @@ class TestGitToolsIntegration:
             mock_adapter.return_value.is_clean.return_value = True
 
             tool = CreateBranchTool()
-            result = await tool.execute(CreateBranchInput(name="test-feature", branch_type="feature"))
+            result = await tool.execute(
+                CreateBranchInput(name="test-feature", branch_type="feature")
+            )
 
             assert "feature/test-feature" in result.content[0]["text"]
 
@@ -78,7 +85,10 @@ class TestGitToolsIntegration:
             result = await tool.execute(GitCommitInput(phase="green", message="implement feature"))
 
             assert "abc123def" in result.content[0]["text"]
-            mock_adapter.return_value.commit.assert_called_with("feat: implement feature", files=None)
+            mock_adapter.return_value.commit.assert_called_with(
+                "feat: implement feature",
+                files=None,
+            )
 
     @pytest.mark.asyncio
     async def test_git_restore_tool_flow(self) -> None:
@@ -145,7 +155,10 @@ class TestGitToolsIntegration:
             result = await tool.execute(GitStashInput(action="push", message="WIP"))
 
             assert "WIP" in result.content[0]["text"]
-            mock_adapter.return_value.stash.assert_called_with(message="WIP", include_untracked=False)
+            mock_adapter.return_value.stash.assert_called_with(
+                message="WIP",
+                include_untracked=False,
+            )
 
     @pytest.mark.asyncio
     async def test_git_stash_tool_pop_flow(self) -> None:
@@ -318,13 +331,14 @@ class TestToolSchemas:
         """Verify all Git tools have input schemas."""
         tools = [
             CreateBranchTool(),
-            GitStatusTool(),
-            GitCommitTool(),
             GitCheckoutTool(),
-            GitPushTool(),
-            GitMergeTool(),
-            GitDeleteBranchTool(),
             GitStashTool(),
+            GitStatusTool(),
+            GitRestoreTool(),
+            GitCommitTool(),
+            GitMergeTool(),
+            GitPushTool(),
+            GitDeleteBranchTool(),
         ]
 
         for tool in tools:
@@ -381,14 +395,14 @@ class TestToolNames:
         """Verify all core tools have unique names."""
         tools = [
             CreateBranchTool(),
-            GitStatusTool(),
-            GitCommitTool(),
-            GitRestoreTool(),
             GitCheckoutTool(),
-            GitPushTool(),
-            GitMergeTool(),
-            GitDeleteBranchTool(),
             GitStashTool(),
+            GitStatusTool(),
+            GitRestoreTool(),
+            GitCommitTool(),
+            GitMergeTool(),
+            GitPushTool(),
+            GitDeleteBranchTool(),
             RunQualityGatesTool(),
             ValidateDocTool(),
             ValidationTool(),
@@ -417,13 +431,14 @@ class TestToolNames:
         """Verify all core tools have descriptions."""
         tools = [
             CreateBranchTool(),
-            GitStatusTool(),
-            GitCommitTool(),
             GitCheckoutTool(),
-            GitPushTool(),
-            GitMergeTool(),
-            GitDeleteBranchTool(),
             GitStashTool(),
+            GitStatusTool(),
+            GitRestoreTool(),
+            GitCommitTool(),
+            GitMergeTool(),
+            GitPushTool(),
+            GitDeleteBranchTool(),
             RunQualityGatesTool(),
             ValidateDocTool(),
             ValidationTool(),

--- a/tests/unit/mcp_server/integration/test_git.py
+++ b/tests/unit/mcp_server/integration/test_git.py
@@ -7,12 +7,12 @@ from mcp_server.core.exceptions import PreflightError, ValidationError
 from mcp_server.managers.git_manager import GitManager
 
 
-@pytest.fixture
-def mock_git_adapter():
+@pytest.fixture(name="mock_git_adapter")
+def _mock_git_adapter_fixture() -> Mock:
     """Create a mock GitAdapter for testing."""
     return Mock()
 
-def test_git_manager_create_branch_valid(mock_git_adapter) -> None:
+def test_git_manager_create_branch_valid(mock_git_adapter: Mock) -> None:
     """Test creating a feature branch with valid name on clean working directory."""
     mock_git_adapter.is_clean.return_value = True
     manager = GitManager(adapter=mock_git_adapter)
@@ -22,7 +22,7 @@ def test_git_manager_create_branch_valid(mock_git_adapter) -> None:
     assert branch == "feature/my-feature"
     mock_git_adapter.create_branch.assert_called_with("feature/my-feature")
 
-def test_git_manager_create_branch_dirty(mock_git_adapter) -> None:
+def test_git_manager_create_branch_dirty(mock_git_adapter: Mock) -> None:
     """Test that creating branch fails on dirty working directory."""
     mock_git_adapter.is_clean.return_value = False
     manager = GitManager(adapter=mock_git_adapter)
@@ -30,13 +30,13 @@ def test_git_manager_create_branch_dirty(mock_git_adapter) -> None:
     with pytest.raises(PreflightError):
         manager.create_feature_branch("my-feature")
 
-def test_git_manager_invalid_name(mock_git_adapter) -> None:
+def test_git_manager_invalid_name(mock_git_adapter: Mock) -> None:
     """Test that invalid branch names are rejected."""
     manager = GitManager(adapter=mock_git_adapter)
     with pytest.raises(ValidationError):
         manager.create_feature_branch("Invalid Name")
 
-def test_git_manager_commit_tdd(mock_git_adapter) -> None:
+def test_git_manager_commit_tdd(mock_git_adapter: Mock) -> None:
     """Test TDD commit prefixes message correctly with 'test:' prefix."""
     manager = GitManager(adapter=mock_git_adapter)
     manager.commit_tdd_phase("red", "Added test")

--- a/tests/unit/mcp_server/integration/test_git.py
+++ b/tests/unit/mcp_server/integration/test_git.py
@@ -41,4 +41,4 @@ def test_git_manager_commit_tdd(mock_git_adapter) -> None:
     manager = GitManager(adapter=mock_git_adapter)
     manager.commit_tdd_phase("red", "Added test")
 
-    mock_git_adapter.commit.assert_called_with("test: Added test")
+    mock_git_adapter.commit.assert_called_with("test: Added test", files=None)

--- a/tests/unit/mcp_server/integration/test_qa.py
+++ b/tests/unit/mcp_server/integration/test_qa.py
@@ -14,10 +14,11 @@ def test_qa_manager_run_gates_with_real_file() -> None:
     # Use a real file that is known to be clean
     result = manager.run_quality_gates(["backend/core/enums.py"])
 
-    # Should have both Linting and Type Checking gates
-    assert len(result["gates"]) == 2
+    # Should have Linting, Mypy, and Pyright gates
+    assert len(result["gates"]) == 3
     assert result["gates"][0]["name"] == "Linting"
     assert result["gates"][1]["name"] == "Type Checking"
+    assert result["gates"][2]["name"] == "Pyright"
     # overall_pass depends on actual file quality
     assert isinstance(result["overall_pass"], bool)
 
@@ -35,3 +36,4 @@ async def test_quality_tool_output_format() -> None:
     assert "Overall Pass:" in text
     assert "Linting:" in text
     assert "Type Checking:" in text
+    assert "Pyright:" in text

--- a/tests/unit/mcp_server/managers/test_git_manager.py
+++ b/tests/unit/mcp_server/managers/test_git_manager.py
@@ -1,17 +1,8 @@
-# tests/unit/mcp_server/managers/test_git_manager.py
-"""
-Unit tests for GitManager.
-
-Tests according to TDD principles with comprehensive coverage.
-
-@layer: Tests (Unit)
-@dependencies: [pytest]
-"""
+"""Unit tests for GitManager."""
 # pyright: reportCallIssue=false, reportAttributeAccessIssue=false
 # Suppress Pydantic FieldInfo false positives
 
 # Standard library
-import typing  # noqa: F401
 from unittest.mock import MagicMock
 
 # Third-party
@@ -88,11 +79,6 @@ class TestGitManagerValidation:
         with pytest.raises(ValidationError, match="Cannot delete protected branch"):
             manager.delete_branch("main")
 
-    def _satisfy_typing_policy(self) -> typing.Any:
-        """Use typing to satisfy template policy requirements."""
-        return None
-
-
 class TestGitManagerOperations:
     """Test suite for GitManager operations (commit, merge, stash)."""
 
@@ -117,7 +103,9 @@ class TestGitManagerOperations:
         assert result == "hash123"
         mock_adapter.commit.assert_called_once_with("test: failing test", files=None)
 
-    def test_commit_tdd_phase_with_files_passes_through(self, manager: GitManager, mock_adapter: MagicMock) -> None:
+    def test_commit_tdd_phase_with_files_passes_through(
+        self, manager: GitManager, mock_adapter: MagicMock
+    ) -> None:
         """Test valid TDD commit with files."""
         mock_adapter.commit.return_value = "hash123"
 
@@ -131,7 +119,9 @@ class TestGitManagerOperations:
         manager.commit_docs("update readme")
         mock_adapter.commit.assert_called_once_with("docs: update readme", files=None)
 
-    def test_commit_docs_with_files_passes_through(self, manager: GitManager, mock_adapter: MagicMock) -> None:
+    def test_commit_docs_with_files_passes_through(
+        self, manager: GitManager, mock_adapter: MagicMock
+    ) -> None:
         """Test documentation commit helpers with files."""
         manager.commit_docs("update docs", files=["README.md"])
 
@@ -143,7 +133,7 @@ class TestGitManagerOperations:
 
         mock_adapter.restore.assert_called_once_with(files=["a.py", "b.py"], source="HEAD")
 
-    def test_restore_requires_files(self, manager: GitManager, mock_adapter: MagicMock) -> None:
+    def test_restore_requires_files(self, manager: GitManager) -> None:
         """Test restore operation requires files."""
         with pytest.raises(ValidationError):
             manager.restore(files=[])

--- a/tests/unit/mcp_server/managers/test_git_manager.py
+++ b/tests/unit/mcp_server/managers/test_git_manager.py
@@ -115,12 +115,38 @@ class TestGitManagerOperations:
         result = manager.commit_tdd_phase("red", "failing test")
 
         assert result == "hash123"
-        mock_adapter.commit.assert_called_once_with("test: failing test")
+        mock_adapter.commit.assert_called_once_with("test: failing test", files=None)
+
+    def test_commit_tdd_phase_with_files_passes_through(self, manager: GitManager, mock_adapter: MagicMock) -> None:
+        """Test valid TDD commit with files."""
+        mock_adapter.commit.return_value = "hash123"
+
+        result = manager.commit_tdd_phase("green", "scoped", files=["a.py"])
+
+        assert result == "hash123"
+        mock_adapter.commit.assert_called_once_with("feat: scoped", files=["a.py"])
 
     def test_commit_docs(self, manager: GitManager, mock_adapter: MagicMock) -> None:
         """Test documentation commit helpers."""
         manager.commit_docs("update readme")
-        mock_adapter.commit.assert_called_once_with("docs: update readme")
+        mock_adapter.commit.assert_called_once_with("docs: update readme", files=None)
+
+    def test_commit_docs_with_files_passes_through(self, manager: GitManager, mock_adapter: MagicMock) -> None:
+        """Test documentation commit helpers with files."""
+        manager.commit_docs("update docs", files=["README.md"])
+
+        mock_adapter.commit.assert_called_once_with("docs: update docs", files=["README.md"])
+
+    def test_restore_success(self, manager: GitManager, mock_adapter: MagicMock) -> None:
+        """Test restore operation."""
+        manager.restore(files=["a.py", "b.py"], source="HEAD")
+
+        mock_adapter.restore.assert_called_once_with(files=["a.py", "b.py"], source="HEAD")
+
+    def test_restore_requires_files(self, manager: GitManager, mock_adapter: MagicMock) -> None:
+        """Test restore operation requires files."""
+        with pytest.raises(ValidationError):
+            manager.restore(files=[])
 
     def test_checkout(self, manager: GitManager, mock_adapter: MagicMock) -> None:
         """Test checkout delegation."""


### PR DESCRIPTION
Closes the blocking parts of Issue #24 for Issue #18 enablement.

Changes:
- Add optional iles argument to git_add_or_commit to stage+commit only selected paths.
- Add git_restore(files, source=HEAD) tool (discard local changes on specific files).
- Add Pyright gate to QA manager (Pylance parity) and fix git tool schema generation to be Pyright-safe.

Acceptance criteria coverage:
- Move work off main onto a feature branch without terminal usage (stash + branch creation already supported).
- Create clean, scoped commits (code vs docs) using only ST3 tools.