### PR TITLE
Quality gates config catalog + validation models

### DIFF
--- a/.st3/quality.yaml
+++ b/.st3/quality.yaml
@@ -1,0 +1,133 @@
+version: "1.0"
+
+gates:
+  pylint:
+    name: "Pylint"
+    description: "Python linting"
+    execution:
+      command: ["python", "-m", "pylint"]
+      timeout_seconds: 60
+      working_dir: null
+    parsing:
+      strategy: "text_regex"
+      patterns:
+        - name: "rating"
+          regex: "Your code has been rated at ([\\d.]+)/10"
+          flags: ["MULTILINE"]
+          group: 1
+          required: true
+    success:
+      mode: "text_regex"
+      min_score: 10.0
+      require_no_issues: true
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: false
+
+  pyright:
+    name: "Pyright"
+    description: "Type checking"
+    execution:
+      command: ["pyright", "--outputjson"]
+      timeout_seconds: 120
+      working_dir: null
+    parsing:
+      strategy: "json_field"
+      fields:
+        diagnostics: "/generalDiagnostics"
+        error_count: "/summary/errorCount"
+      diagnostics_path: "/generalDiagnostics"
+    success:
+      mode: "json_field"
+      max_errors: 0
+      require_no_issues: true
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: true
+
+  ruff:
+    name: "Ruff"
+    description: "Fast linter"
+    execution:
+      command: ["ruff", "check"]
+      timeout_seconds: 60
+      working_dir: null
+    parsing:
+      strategy: "exit_code"
+    success:
+      mode: "exit_code"
+      exit_codes_ok: [0]
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: true
+      produces_json: false
+
+  black:
+    name: "Black"
+    description: "Python formatting (check mode)"
+    execution:
+      command: ["black", "--check", "."]
+      timeout_seconds: 60
+      working_dir: null
+    parsing:
+      strategy: "exit_code"
+    success:
+      mode: "exit_code"
+      exit_codes_ok: [0]
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: true
+      produces_json: false
+
+  mypy:
+    name: "Mypy"
+    description: "Static type checking"
+    execution:
+      command: ["mypy", "."]
+      timeout_seconds: 120
+      working_dir: null
+    parsing:
+      strategy: "exit_code"
+    success:
+      mode: "exit_code"
+      exit_codes_ok: [0]
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: false
+
+  pytest:
+    name: "Pytest"
+    description: "Unit tests"
+    execution:
+      command: ["pytest", "tests/"]
+      timeout_seconds: 300
+      working_dir: null
+    parsing:
+      strategy: "exit_code"
+    success:
+      mode: "exit_code"
+      exit_codes_ok: [0]
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: false
+
+  bandit:
+    name: "Bandit"
+    description: "Python security linting"
+    execution:
+      command: ["bandit", "-r", "."]
+      timeout_seconds: 120
+      working_dir: null
+    parsing:
+      strategy: "exit_code"
+    success:
+      mode: "exit_code"
+      exit_codes_ok: [0]
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: false

--- a/docs/development/issue49/planning.md
+++ b/docs/development/issue49/planning.md
@@ -18,7 +18,7 @@ Based on research findings (150+ config items across 10 categories), we define *
 | **#50** | `config/workflows.yaml` | PHASE_TEMPLATES, issue types, phase sequences, execution modes | CRITICAL | #42 |
 | **#51** | `config/labels.yaml` | GitHub label definitions, type/priority/status/phase patterns, colors, sync mechanism | CRITICAL | #42 |
 | **#52** | `config/documents.yaml` | TEMPLATES dict, SCOPE_DIRS dict, template paths | MEDIUM | - |
-| **#53** | `config/quality.yaml` | Pylint/Mypy/Pyright configs, timeouts, thresholds, output patterns | HIGH | #18 |
+| **#53** | `.st3/quality.yaml` | Pylint/Mypy/Pyright configs, timeouts, thresholds, output patterns | HIGH | #18 |
 | **#54** | `config/validation.yaml` | RULES dict (5 template types), component validation rules | HIGH | #18 |
 | **#55** | `config/scaffold.yaml` | Valid component types, scaffold phases, file policies | HIGH | #18 |
 | **#56** | `config/git.yaml` | Branch types, TDD phases, commit prefixes, protected branches | MEDIUM | - |
@@ -37,7 +37,7 @@ Based on research findings (150+ config items across 10 categories), we define *
 - **workflows.yaml**: Core issue type definitions (needed for #42)
 - **labels.yaml**: GitHub integration (needed for #42)
 - **documents.yaml**: Documentation scaffolding (independent)
-- **quality.yaml**: Static analysis gates (needed for #18)
+- **.st3/quality.yaml**: Static analysis gates (needed for #18)
 - **validation.yaml**: Template validation (needed for #18)
 - **scaffold.yaml**: File creation policies (needed for #18)
 - **git.yaml**: Git conventions (independent)
@@ -62,7 +62,7 @@ Epic #49 (Planning)
 
 ```
 Epic #49 (Planning)
-├── Issue #53: quality.yaml (HIGH) → Enables #18 enforcement
+├── Issue #53: .st3/quality.yaml (HIGH) → Enables #18 enforcement
 ├── Issue #54: validation.yaml (HIGH) → Enables #18 enforcement
 └── Issue #55: scaffold.yaml (HIGH) → Enables #18 enforcement
 ```
@@ -201,7 +201,7 @@ The following issues already exist but need scope adjustment:
 | #50 | "Workflow & Issue Type Configuration" | `config/workflows.yaml` only | Update title + body |
 | #51 | "Label Management & GitHub Sync" | `config/labels.yaml` only | Update title + body |
 | #52 | "Validation Rules Configuration" | `config/validation.yaml` only | Update title + body |
-| #53 | "Quality Gates Configuration" | `config/quality.yaml` only | Update title + body |
+| #53 | "Quality Gates Configuration" | `.st3/quality.yaml` only | Update title + body |
 | #54 | "Scaffold Rules Configuration" | `config/scaffold.yaml` only | Update title + body |
 | #55 | "Git Conventions Configuration" | `config/git.yaml` only | Update title + body |
 
@@ -221,7 +221,7 @@ The following issues already exist but need scope adjustment:
 | #50 | `config/workflows.yaml` | PHASE_TEMPLATES, issue types, phases |
 | #51 | `config/labels.yaml` | GitHub labels, sync mechanism |
 | #52 | `config/validation.yaml` | Template validation rules |
-| #53 | `config/quality.yaml` | Quality gates (pylint/mypy/pyright) |
+| #53 | `.st3/quality.yaml` | Quality gates (pylint/mypy/pyright) |
 | #54 | `config/scaffold.yaml` | Scaffold rules, file policies |
 | #55 | `config/git.yaml` | Git conventions (branches, commits, TDD) |
 | NEW #56 | `config/documents.yaml` | Document templates, scopes |
@@ -248,7 +248,7 @@ The following issues already exist but need scope adjustment:
 
 ### Phase 2 - High Priority (Week 2)
 
-1. Complete Issue #53 (quality.yaml)
+1. Complete Issue #53 (.st3/quality.yaml)
 2. Complete Issue #52 (validation.yaml)
 3. Complete Issue #54 (scaffold.yaml)
 4. **Issue #18 enabled** ✅

--- a/docs/development/issue49/research.md
+++ b/docs/development/issue49/research.md
@@ -729,7 +729,7 @@ PHASE_TEMPLATES = config["issue_types"]
 
 ## 9. Open Questions for Planning Phase
 
-1. Should config be split into multiple files (`workflows.yaml`, `labels.yaml`, `quality.yaml`) or monolithic?
+1. Should config be split into multiple files (`workflows.yaml`, `labels.yaml`, `.st3/quality.yaml`) or monolithic?
 2. Should there be environment-specific configs (dev/prod)?
 3. How to handle config migrations (v1.0 ÔåÆ v2.0)?
 4. Should validation happen at import time or on first use?

--- a/docs/development/issue50/discovery.md
+++ b/docs/development/issue50/discovery.md
@@ -400,7 +400,7 @@ engine.transition(branch="feature/42", from_phase="discovery", to_phase="integra
 
 **Explicitly NOT in workflows.yaml:**
 - Validation rules → Issue #52 (validation.yaml)
-- Quality gates → Issue #53 (quality.yaml)
+- Quality gates → Issue #53 (.st3/quality.yaml)
 - Scaffold rules → Issue #54 (scaffold.yaml)
 - Git conventions → Issue #55 (git.yaml)
 - Phase-specific tooling requirements

--- a/docs/development/issue53/research.md
+++ b/docs/development/issue53/research.md
@@ -1,6 +1,6 @@
 # Issue #53 Research: Quality Gates Configuration
 
-**Issue:** Create quality.yaml with quality gate definitions  
+**Issue:** Create .st3/quality.yaml with quality gate definitions  
 **Epic:** #76 - Quality Gates Tooling Implementation (child of Epic #49)  
 **Phase:** Research  
 **Date:** 2026-01-03
@@ -12,10 +12,10 @@
 Document quality gate **tool configurations** only - commands, parsing strategies, timeouts, and capabilities. This research focuses on **WHAT tools exist and HOW they work**, NOT when/where they are enforced.
 
 **SRP Separation:**
-- ✅ **This Issue (#53):** Tool configuration (quality.yaml)
+- ✅ **This Issue (#53):** Tool configuration (.st3/quality.yaml)
 - ❌ **Out of Scope:** Tool enforcement (Epic #18 - policy.yaml)
 
-**Goal:** Create comprehensive tool catalog for quality.yaml with all available gates (Pylint, Mypy, Pyright, Ruff, Coverage, Bandit, Black, etc.).
+**Goal:** Create comprehensive tool catalog for .st3/quality.yaml with all available gates (Pylint, Mypy, Pyright, Ruff, Coverage, Bandit, Black, etc.).
 
 ### 1.1 User-Facing Documentation
 
@@ -107,7 +107,7 @@ Document quality gate **tool configurations** only - commands, parsing strategie
 **File:** [docs/development/issue49/epic.md](../../issue49/epic.md)
 
 **What exists:**
-- **Issue #53** listed as child issue: "Quality gates configuration to quality.yaml"
+- **Issue #53** listed as child issue: "Quality gates configuration to .st3/quality.yaml"
 - Context: Part of MCP Platform Configurability epic
 - Quality Gates identified as hardcoded config item:
   - 150 lines in qa_manager.py
@@ -689,7 +689,7 @@ except Exception as e:
 - Immutable models (frozen=True)
 - No business logic in config file
 
-**Observation:** Successful pattern to follow for quality.yaml.
+**Observation:** Successful pattern to follow for .st3/quality.yaml.
 
 ---
 
@@ -905,7 +905,7 @@ except Exception as e:
 
 ### 13.2 Questions for Planning Phase
 
-1. **Scope:** Should quality.yaml replace 3 gates or all 5 from QUALITY_GATES.md?
+1. **Scope:** Should .st3/quality.yaml replace 3 gates or all 5 from QUALITY_GATES.md?
 2. **Pyright:** Should we document Pyright in user guide, or remove from QAManager?
 3. **Pytest:** Is test execution a quality gate, or separate concern?
 4. **Execution Mode:** Should continue-on-error be configurable, or always enabled?
@@ -969,7 +969,7 @@ except Exception as e:
 - ⏭️ Establish success criteria
 
 **What remains for Design:**
-- ⏭️ Design quality.yaml schema
+- ⏭️ Design .st3/quality.yaml schema
 - ⏭️ Design Pydantic models
 - ⏭️ Design generic gate execution architecture
 - ⏭️ Design output parser dispatch

--- a/docs/development/issue76/design.md
+++ b/docs/development/issue76/design.md
@@ -1,0 +1,448 @@
+# Issue #76 Design: Quality Gates Tooling (quality.yaml + models)
+
+**Status:** DRAFT
+**Author:** GitHub Copilot
+**Created:** 2026-01-08
+**Last Updated:** 2026-01-08
+**Issue:** #76
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Define the **configuration-layer design** for quality gate tooling:
+- A `.st3/quality.yaml` schema that describes quality gate tools (catalog)
+- Pydantic models that validate that schema (consistent with Epic #49 patterns)
+- Parsing strategy abstractions suitable for a future generic executor
+
+This document intentionally does **not** implement the schema/models, nor refactor the current executor.
+
+### 1.2 Scope
+
+**In Scope:**
+- `.st3/quality.yaml` schema design (tool definitions only; no enforcement policy)
+- Pydantic model structure and validation rules
+- Design of parsing strategy options (`text_regex`, `json_field`, `exit_code`)
+- Design of generic execution patterns (documentation-level)
+
+**Out of Scope:**
+- Enforcement fields (e.g., `required`, `enabled`, `phase`) and enforcement logic (Epic #18)
+- Refactoring `mcp_server/managers/qa_manager.py` or changing runtime behavior
+- Activating Ruff/Coverage/Bandit/Black in runtime execution (future issues)
+
+### 1.3 Related Documents
+
+- [Research baseline](./research.md)
+- [Planning](./planning.md)
+- [Issue #53 research](../issue53/research.md)
+- [Quality gates standard](../../coding_standards/QUALITY_GATES.md)
+
+---
+
+## 2. Background
+
+### 2.1 Current State (facts)
+
+- Current executor: `mcp_server/managers/qa_manager.py` hardcodes 3 gates (Pylint/Mypy/Pyright) with per-gate parsing and timeouts.
+- Current MCP wrapper: `mcp_server/tools/quality_tools.py` exposes `run_quality_gates(files=[...])`.
+- A validator (`mcp_server/validation/python_validator.py`) consumes QAManager output shape.
+- Config file `.st3/quality.yaml` does not exist in this repo yet.
+
+### 2.2 Problem Statement
+
+Quality gate tool definitions are currently embedded in code (command shapes, timeouts, parsing logic). This makes adding or adjusting gates high-friction and mixes configuration concerns with execution/enforcement concerns.
+
+Issue #76 requires a **configuration layer** that can be validated independently (today), and that enables a later executor refactor (future issue) without enforcing “when/where” policies (Epic #18).
+
+### 2.3 Requirements
+
+#### Functional Requirements
+- [ ] **FR1:** Define a schema for `.st3/quality.yaml` that can express ≥7 tool definitions: Pylint, Mypy, Pyright, Ruff, Coverage, Bandit, Black.
+- [ ] **FR2:** Schema must represent execution information (command, timeout, working_dir) and parsing strategy choice.
+- [ ] **FR3:** Schema must represent success/failure determination as part of tool definition (tooling, not enforcement).
+- [ ] **FR4:** Schema must explicitly avoid enforcement fields (no `required`, no `phase`, no `enabled`).
+- [ ] **FR5:** Pydantic models must validate the schema with clear error messages.
+
+#### Non-Functional Requirements
+- [ ] **NFR1:** Compatibility — design must not require changing `QAManager` in this epic.
+- [ ] **NFR2:** Testability — model validation should be unit-testable to 100% coverage.
+- [ ] **NFR3:** Maintainability — adding a new tool should be primarily a YAML change, not a new Python method.
+
+---
+
+## 3. Design
+
+### 3.1 Architecture Position
+
+This epic defines the **configuration layer** and a **design-only execution layer pattern**.
+
+```
+┌───────────────────────────────┐
+│ Enforcement (Epic #18)        │  OUT OF SCOPE
+│ - phases / required gates     │
+└───────────────┬───────────────┘
+                │ uses
+┌───────────────▼───────────────┐
+│ Config Layer (THIS EPIC)      │  IN SCOPE
+│ - .st3/quality.yaml         │
+│ - Pydantic models + loader    │
+└───────────────┬───────────────┘
+                │ used by
+┌───────────────▼───────────────┐
+│ Execution Layer (FUTURE)      │  OUT OF SCOPE
+│ - generic executor            │
+│ - parser dispatch             │
+└───────────────────────────────┘
+```
+
+### 3.2 Schema Design: `.st3/quality.yaml`
+
+#### 3.2.1 Top-level structure
+
+Proposed top-level keys:
+- `version: str`
+- `gates: { <gate_id>: <QualityGate> }`
+
+`gate_id` is a stable identifier (e.g., `pylint`, `mypy`, `pyright`, `ruff`, `coverage`, `bandit`, `black`).
+
+#### 3.2.2 Gate structure
+
+Each `QualityGate` has:
+- `name: str` — display name
+- `description: str` — short explanation
+- `execution: ExecutionConfig`
+- `parsing: ParsingConfig`
+- `success: SuccessCriteria`
+- `capabilities: CapabilitiesMetadata`
+
+No enforcement fields are allowed.
+
+#### 3.2.3 ExecutionConfig
+
+Fields:
+- `command: list[str]` (non-empty; first element is executable/module runner)
+- `timeout_seconds: int` (> 0)
+- `working_dir: str | null` (optional)
+
+Notes:
+- `command` is a list (not a single string) to avoid shell escaping issues and to be consistent with `subprocess.run([...])`.
+
+#### 3.2.4 ParsingConfig
+
+`strategy` is an enum:
+- `text_regex` — parse plain text output
+- `json_field` — parse JSON output and extract fields by path
+- `exit_code` — no parsing needed; rely on exit code
+
+Strategy-specific fields:
+
+`text_regex`:
+- `patterns: list[RegexPattern]`
+
+`RegexPattern` (B2):
+- `name: str` — stable identifier for the extracted value (e.g., `rating`, `total`)
+- `regex: str` — Python-style regex pattern
+- `flags: list[str] | null` — optional; allowed values: `IGNORECASE`, `MULTILINE`, `DOTALL`
+- `group: int | str | null` — optional; capture group index (e.g., `1`) or named group (e.g., `score`)
+- `required: bool` — default `true`; if true, missing match should be treated as invalid output (future executor concern)
+
+`json_field`:
+- `fields: dict[str, str]` mapping logical names to JSON Pointer paths (C2, RFC 6901)
+  - Example: `error_count: /summary/errorCount`
+  - Example: `diagnostics: /generalDiagnostics`
+- `diagnostics_path: str | null` (optional) — JSON Pointer path to a list of diagnostic items
+
+`exit_code`:
+- no additional fields
+
+#### 3.2.5 SuccessCriteria
+
+Success criteria is part of *tool definition* (what “pass” means for that tool), without expressing enforcement (when/where it is required).
+
+A2 (contained flexibility):
+- `success.mode` is kept for explicitness, **but must exactly equal** `parsing.strategy`.
+- This avoids ambiguous “mixed signal” semantics while keeping the schema extensible.
+
+Fields:
+- `mode: str` — enum: `text_regex` | `json_field` | `exit_code`
+  - Validation rule: `success.mode == parsing.strategy`
+- Optional numeric thresholds, depending on `mode`:
+  - `exit_codes_ok: list[int]` (default `[0]`) — used when `mode=exit_code`
+  - `max_errors: int | null` — used when `mode` yields a count
+  - `min_score: float | null` — used when `mode` yields a score
+  - `require_no_issues: bool` (default `true`)
+
+Non-goal (v1): Multi-signal success (e.g., parse JSON for reporting but decide on exit code) is intentionally not modeled here.
+
+#### 3.2.6 CapabilitiesMetadata
+
+Fields (metadata only):
+- `file_types: list[str]` (e.g., `[".py"]`)
+- `supports_autofix: bool`
+- `produces_json: bool`
+
+---
+
+### 3.3 Pydantic Model Design
+
+Models (names follow Issue #76):
+- `QualityConfig`
+  - `version: str`
+  - `gates: dict[str, QualityGate]`
+- `QualityGate`
+  - `name`, `description`, `execution`, `parsing`, `success`, `capabilities`
+- `ExecutionConfig`
+- `ParsingConfig` (discriminated union by `strategy`)
+- `SuccessCriteria`
+- `CapabilitiesMetadata`
+
+Validation rules (non-exhaustive):
+- `version` must be non-empty.
+- `gates` must be non-empty.
+- `command` must be non-empty; all elements must be non-empty strings.
+- `timeout_seconds` must be > 0.
+- Enforce “no enforcement fields” by schema/model strictness (reject unknown fields).
+
+Immutability:
+- Models should be frozen/immutable to match config pattern expectations.
+
+---
+
+### 3.4 Parsing Strategies (Design)
+
+This epic defines parsing abstractions; actual parsing/execution is implemented in a future issue.
+
+- **text_regex:** for tools that output human text with stable patterns (typical for pylint/mypy).
+- **json_field:** for tools that emit JSON (`pyright --outputjson`).
+- **exit_code:** for tools where exit code is sufficient (e.g., `ruff check`, `black --check`, `bandit`).
+
+---
+
+### 3.5 Examples (7+ gates)
+
+These are examples of how the schema can represent the required catalog. These examples do not imply runtime activation today.
+
+```yaml
+version: "1.0"
+
+gates:
+  pylint:
+    name: "Pylint"
+    description: "Python linting"
+    execution:
+      command: ["python", "-m", "pylint", "--enable=all", "--max-line-length=100", "--output-format=text"]
+      timeout_seconds: 60
+      working_dir: null
+    parsing:
+      strategy: "text_regex"
+      patterns:
+        - name: "rating"
+          regex: "Your code has been rated at ([\\d.]+)/10"
+    success:
+      mode: "text_regex"
+      min_score: 10.0
+      require_no_issues: true
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: false
+
+  mypy:
+    name: "Mypy"
+    description: "Static type checking"
+    execution:
+      command: ["python", "-m", "mypy", "--strict", "--no-error-summary"]
+      timeout_seconds: 60
+      working_dir: null
+    parsing:
+      strategy: "text_regex"
+      patterns:
+        - name: "error_line"
+          regex: "^(.+?):(\\d+): (error|warning): (.+)$"
+    success:
+      mode: "text_regex"
+      max_errors: 0
+      require_no_issues: false
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: false
+
+  pyright:
+    name: "Pyright"
+    description: "Type checking (Pylance parity)"
+    execution:
+      command: ["pyright", "--outputjson"]
+      timeout_seconds: 120
+      working_dir: null
+    parsing:
+      strategy: "json_field"
+      fields:
+        diagnostics: "/generalDiagnostics"
+    success:
+      mode: "json_field"
+      max_errors: 0
+      require_no_issues: true
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: true
+
+  ruff:
+    name: "Ruff"
+    description: "Fast linter (catalog entry)"
+    execution:
+      command: ["ruff", "check"]
+      timeout_seconds: 60
+      working_dir: null
+    parsing:
+      strategy: "exit_code"
+    success:
+      mode: "exit_code"
+      exit_codes_ok: [0]
+      require_no_issues: true
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: true
+      produces_json: false
+
+  black:
+    name: "Black"
+    description: "Formatter check (catalog entry)"
+    execution:
+      command: ["black", "--check"]
+      timeout_seconds: 60
+      working_dir: null
+    parsing:
+      strategy: "exit_code"
+    success:
+      mode: "exit_code"
+      exit_codes_ok: [0]
+      require_no_issues: true
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: true
+      produces_json: false
+
+  bandit:
+    name: "Bandit"
+    description: "Security scanning (catalog entry)"
+    execution:
+      command: ["bandit", "-r"]
+      timeout_seconds: 120
+      working_dir: null
+    parsing:
+      strategy: "exit_code"
+    success:
+      mode: "exit_code"
+      exit_codes_ok: [0]
+      require_no_issues: true
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: false
+
+  coverage:
+    name: "Coverage"
+    description: "Coverage reporting via pytest-cov (catalog entry)"
+    execution:
+      command: ["pytest", "--cov=backend", "--cov-report=term-missing"]
+      timeout_seconds: 300
+      working_dir: null
+    parsing:
+      strategy: "text_regex"
+      patterns:
+        - name: "total"
+          regex: "TOTAL\\s+\\d+\\s+\\d+\\s+(\\d+)%"
+    success:
+      mode: "text_regex"
+      require_no_issues: false
+    capabilities:
+      file_types: [".py"]
+      supports_autofix: false
+      produces_json: false
+```
+
+---
+
+## 4. Implementation Notes (Non-Goals)
+
+Implementation is out of scope for the design phase.
+
+- See planning for sequencing and deliverables: `docs/development/issue76/planning.md`.
+- This design should enable a later executor refactor without requiring schema changes.
+
+---
+
+## 5. Alternatives Considered
+
+### Alternative A: Minimal YAML with tool-specific freeform fields
+
+**Description:** Allow each gate to define arbitrary keys with minimal validation.
+
+**Pros:**
+- Very flexible
+- Minimal model work
+
+**Cons:**
+- Weak validation
+- Harder to evolve and document
+
+**Decision:** Rejected; Issue #76 requires strong validation and consistent patterns.
+
+### Alternative B: Strict schema with discriminated unions for parsing and success
+
+**Description:** A small set of well-defined strategies with strict validation.
+
+**Pros:**
+- Clear extensibility patterns
+- Strong validation and better error messages
+
+**Cons:**
+- Requires upfront design work
+
+**Decision:** Chosen.
+
+---
+
+## 6. Open Questions
+
+Resolved decisions (to unblock implementation/TDD):
+- **A2:** `success.mode` is required and must equal `parsing.strategy`.
+- **B2:** `RegexPattern` includes optional `flags`, `group`, and `required`.
+- **C2:** JSON extraction uses JSON Pointer paths (RFC 6901).
+
+Resolved (contained) decisions for v1:
+- **C2a:** JSON Pointer usage allows array indexing (e.g., `/generalDiagnostics/0/rule`) because it is part of RFC 6901. Model validation will only ensure the value is a non-empty string that starts with `/` (or is exactly `/`).
+- **B2a:** `RegexPattern.required` may be `false` (optional patterns). In v1, this only affects validation strictness in config parsing (i.e., it is allowed in YAML); runtime semantics are deferred to the future executor.
+
+Remaining open questions (future executor/policy):
+- If `RegexPattern.required=false`, should a missing match still be reported as a warning vs silently ignored? (executor behavior, out of scope here)
+
+---
+
+## 7. Decision Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-01-08 | Use YAML + Pydantic models | Consistent with Epic #49 patterns; strong validation |
+| 2026-01-08 | Use 3 parsing strategies | Matches Issue #76 guidance; covers current + catalog tools |
+| 2026-01-08 | A2: `success.mode` must equal `parsing.strategy` | Keep explicitness but prevent mixed-signal semantics |
+| 2026-01-08 | B2: RegexPattern supports flags/group/required | Make regex parsing robust without executor coupling |
+| 2026-01-08 | C2: JSON Pointer paths for JSON extraction | Standardized paths incl. arrays; clear validation |
+| 2026-01-08 | C2a: Allow JSON Pointer array indexing | RFC 6901 supports arrays; keep v1 validation simple |
+| 2026-01-08 | B2a: Allow optional regex patterns | Keep schema flexible; executor semantics deferred |
+| 2026-01-08 | Exclude enforcement fields | SRP boundary per Issue #76; enforcement belongs to Epic #18 |
+
+---
+
+## 8. References
+
+- `docs/development/issue76/research.md`
+- `docs/development/issue76/planning.md`
+- `docs/development/issue53/research.md`
+- `docs/coding_standards/QUALITY_GATES.md`
+
+(Note: links above are relative in section 1.3; references here are paths for grep/navigation.)

--- a/docs/development/issue76/planning.md
+++ b/docs/development/issue76/planning.md
@@ -1,0 +1,134 @@
+# Issue #76 Planning: Quality Gates Tooling Implementation
+
+**Status:** IN PROGRESS
+
+**Created:** 2026-01-08
+
+**Issue:** #76
+
+---
+
+## 1. Scope (from Issue #76)
+
+### In scope (this epic)
+- Create `.st3/quality.yaml` containing a catalog of quality gate tool definitions (≥7 tools).
+- Implement Pydantic validation models for the configuration (frozen/immutable, Epic #49 style).
+- Document generic execution patterns and output parsing strategies (design documentation only).
+
+### Out of scope (explicit non-goals)
+- Enforcement policies / phase requirements (belongs to Epic #18).
+- Refactor `mcp_server/managers/qa_manager.py` or change runtime execution behavior.
+- Activating Ruff/Coverage/Bandit/Black in runtime execution (future issues after executor refactor).
+
+---
+
+## 2. Current State Summary (facts)
+
+- `mcp_server/managers/qa_manager.py` currently hardcodes 3 gates (Pylint/Mypy/Pyright) with parsing + timeouts.
+- `mcp_server/tools/quality_tools.py` exposes MCP tool `run_quality_gates` with only `files: list[str]`.
+- `mcp_server/validation/python_validator.py` consumes QAManager output shape.
+- `.st3/quality.yaml` does not exist yet (no `config/` directory in repo currently).
+
+---
+
+## 3. Planning Goal
+
+Produce a clear, minimal, testable path to deliver the epic outcomes **without touching the current executor**.
+
+This planning phase ends when:
+- We have a clear list of deliverables and acceptance criteria.
+- We have an agreed set of files to add and tests to write.
+- We have identified the decisions that must be made in the design phase.
+
+---
+
+## 4. Deliverables (what this branch should contain)
+
+### 4.1 Configuration
+- `.st3/quality.yaml`
+  - Contains ≥7 gate definitions as a catalog, including:
+    - Implemented in current executor: Pylint, Mypy, Pyright
+    - Catalog/configured for future activation: Ruff, Coverage, Bandit, Black
+  - Contains only tooling configuration (no enforcement fields like required/phase/enabled).
+
+### 4.2 Pydantic models + loader
+- New module(s) under `mcp_server/config/` to:
+  - Define `QualityConfig` root model
+  - Define nested models for execution/parsing/capabilities metadata
+  - Load YAML from `.st3/quality.yaml`
+  - Provide clear validation errors
+  - Follow existing style patterns (see `mcp_server/config/workflows.py` and `mcp_server/config/label_config.py`).
+
+### 4.3 Tests
+- Unit tests targeting:
+  - Valid config loads
+  - Invalid config rejected with clear error messages
+  - Field-level validation (e.g., command non-empty, timeout > 0)
+  - Parsing strategy model validation
+
+Success requirement: 100% coverage on validation logic for the config models.
+
+### 4.4 Documentation (design-only outputs)
+- A schema reference and examples for `.st3/quality.yaml`.
+- A guide describing the supported parsing strategy types (conceptual, not code).
+- A generic “executor pattern” description (design only, no QAManager changes in this epic).
+
+---
+
+## 5. Work Breakdown (planning-level)
+
+### Phase A: Design (next phase after planning)
+- Define the `.st3/quality.yaml` schema.
+- Define model hierarchy and validation rules.
+- Define parsing strategy representations.
+- Define documentation structure.
+
+### Phase B: Implementation (after design approval)
+- Add `.st3/quality.yaml`.
+- Add Pydantic models and loader under `mcp_server/config/`.
+- Add unit tests.
+- Add docs for schema + parsing strategies + execution patterns.
+
+### Phase C: Verification
+- Run unit tests.
+- Run quality gates on modified Python files.
+
+---
+
+## 6. Acceptance Criteria (for this epic)
+
+### Configuration
+- `.st3/quality.yaml` exists and includes ≥7 gate definitions.
+- YAML validates against Pydantic models.
+- No enforcement policy fields present.
+
+### Models
+- Models are immutable/frozen (consistent with Epic #49 patterns).
+- Validation rejects invalid configs with clear error messages.
+- Validation logic has 100% test coverage.
+
+### Documentation
+- Schema reference document exists and matches models.
+- Parsing strategy guide exists with examples.
+- Generic execution patterns doc exists (design-only; no runtime changes).
+
+### Safety boundary
+- No behavioral change to `mcp_server/managers/qa_manager.py` in this epic.
+
+---
+
+## 7. Design Decisions Required (to be made in Design Phase)
+
+These are intentionally not decided in planning:
+- Exact YAML structure (keys, naming, nesting).
+- How to represent parsing strategies (e.g., `text_regex` vs `json_field` vs `exit_code`).
+- How to represent capabilities metadata (and which fields are required vs optional).
+- Where documentation should live and exact doc structure.
+
+---
+
+## 8. Next Step
+
+Move to design phase and produce:
+- `docs/development/issue76/design.md` (schema + model design + examples)
+

--- a/docs/development/issue76/research.md
+++ b/docs/development/issue76/research.md
@@ -1,0 +1,159 @@
+# Issue #76 Research: Quality Gates Tooling (Configuration Layer)
+
+**Issue:** #76 – Epic: Quality Gates Tooling Implementation
+
+**Date:** 2026-01-08
+
+---
+
+## 1. Research Objective (Scope = Research)
+
+This document is the **research** baseline for Issue #76.
+
+It aims to be **self-contained** for this branch by collecting:
+- The exact scope boundaries from Issue #76
+- Current implementation facts (what exists today)
+- The concrete gaps that motivate the work
+- The validated findings from Issue #53 research (as inputs)
+
+This research explicitly does **not**:
+- Propose sequencing / milestones / work breakdown (planning)
+- Decide a schema structure (design)
+- Implement or refactor execution (coding)
+
+---
+
+## 2. Primary Scope Statement (from Issue #76)
+
+Issue #76 scope states:
+
+**In scope (today):**
+- `.st3/quality.yaml` with tool definitions
+- Pydantic models for validation
+- Generic execution patterns (documentation)
+- Output parsing strategies (documentation)
+
+**Out of scope (today):**
+- Enforcement policies / phase requirements (Epic #18)
+- QAManager refactor / changing actual runtime execution
+- Integrating additional gates into QAManager runtime (future issues)
+
+---
+
+## 3. Current State in This Repo (Facts)
+
+### 3.1 Current execution implementation
+
+File: `mcp_server/managers/qa_manager.py`
+
+Observed behavior:
+- Input: list of paths
+- Pre-check: missing file paths cause an early failing gate result
+- Filtering: only `.py` files are executed; non-`.py` are skipped and reported
+- Current gates executed:
+  1. Linting (Pylint)
+  2. Type Checking (Mypy)
+  3. Pyright
+- Execution style:
+  - subprocess-based
+  - continue-on-error (all gates run)
+  - timeouts: 60s / 60s / 120s
+- Parsing:
+  - Pylint: text parsing and rating extraction
+  - Mypy: text parsing of errors
+  - Pyright: JSON parsing via `--outputjson` (defensive parsing)
+
+### 3.2 Tool wrapper
+
+File: `mcp_server/tools/quality_tools.py`
+
+Observed behavior:
+- MCP tool `run_quality_gates` accepts **only** `files: list[str]`.
+- Tool calls `QAManager.run_quality_gates(files)` and formats output as text.
+
+### 3.3 Validator consumption
+
+File: `mcp_server/validation/python_validator.py`
+
+Observed behavior:
+- Calls `QAManager.run_quality_gates([scan_path])`.
+- Translates gate issues into `ValidationIssue` objects.
+- Extracts numeric score from the "Linting" gate score string if present.
+
+Implication:
+- The shape of QAManager results (gate names, score formatting, issue fields) is an external contract for validators.
+
+---
+
+## 4. Documentation vs Implementation (Facts)
+
+### 4.1 Manual quality standard describes 5 gates
+
+File: `docs/coding_standards/QUALITY_GATES.md`
+
+Observed:
+- Describes **5 mandatory gates** for DTO workflow (3x pylint checks + mypy + pytest).
+
+### 4.2 Current QAManager executes 3 gates
+
+File: `mcp_server/managers/qa_manager.py`
+
+Observed:
+- Executes 3 gates (Pylint/Mypy/Pyright) and does not run pytest as a gate.
+
+### 4.3 MCP tools documentation mismatch
+
+File: `docs/mcp_server/TOOLS.md`
+
+Observed:
+- Documents `run_quality_gates` with optional params (`include_tests`, `gates`) that are **not present** in `mcp_server/tools/quality_tools.py`.
+
+---
+
+## 5. Issue #53 Research Findings (Validated Inputs)
+
+File: `docs/development/issue53/research.md`
+
+Issue #53 established the baseline facts motivating externalization:
+- ~24 hardcoded configuration points exist across the current gates (command shape, timeout, parsing rules, etc.)
+- Gate execution code has significant gate-specific logic and duplication
+- Parsing strategies needed include at least:
+  - text+regex parsing (pylint/mypy patterns)
+  - JSON parsing (pyright)
+- Ruff and Coverage are configured at project level but not currently enforced by QAManager
+- Documentation and implementation have drift (manual vs automated gate sets)
+
+Important note:
+- Issue #76 requires a catalog of **≥7 tools** in `.st3/quality.yaml` (Pylint, Mypy, Pyright, Ruff, Coverage, Bandit, Black), but adding these to runtime is explicitly a future concern.
+
+---
+
+## 6. Existing “Config + Validation” Patterns in Repo
+
+The repo already has examples of YAML + Pydantic patterns:
+
+- `.st3/workflows.yaml` loaded by `mcp_server/config/workflows.py`
+- `.st3/labels.yaml` loaded by `mcp_server/config/label_config.py`
+
+Observed properties worth noting (fact-only):
+- YAML is loaded and validated by Pydantic models.
+- Errors are raised with explicit messages when config is missing/invalid.
+
+---
+
+## 7. Research Outputs (What Planning/Design Can Rely On)
+
+From Issue #76 + Issue #53 + current codebase inspection, planning/design can rely on:
+- Current execution layer exists and must not be refactored under this epic.
+- A configuration layer is missing (`.st3/quality.yaml` does not exist yet in this repo).
+- There is documented expectation of 5 gates, but implemented automation is 3 gates.
+- Tools docs describe parameters that the implemented tool does not accept.
+- Validators consume QAManager output shape.
+
+---
+
+## 8. Open Questions (For Planning/Design; No Answers Here)
+
+- Should `.st3/quality.yaml` mirror the **current executor gates** (3) and add additional catalog entries (≥7) as disabled/unimplemented metadata, or represent a broader conceptual set?
+- Should the documentation drift be corrected as part of this epic (docs-only), or deferred?
+- How strictly should model validation enforce command non-emptiness, timeout constraints, and parsing configuration without adding enforcement policy fields?

--- a/mcp_server/config/quality_config.py
+++ b/mcp_server/config/quality_config.py
@@ -1,0 +1,209 @@
+"""Quality gates tooling configuration (.st3/quality.yaml).
+
+This module defines Pydantic models and a loader for the quality gates tool catalog.
+It validates tool definitions only (commands/parsing/success/capabilities) and
+explicitly does not model enforcement policy (Epic #18).
+
+Quality Requirements:
+- Pylint: 10/10 (strict)
+- Mypy: strict mode passing
+- Coverage: 100% for this module
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal, TypeAlias
+
+import yaml  # type: ignore[import-untyped]
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+RegexFlag = Literal["IGNORECASE", "MULTILINE", "DOTALL"]
+
+
+class ExecutionConfig(BaseModel):
+    """How to execute a gate tool."""
+
+    command: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Subprocess argv list (non-empty).",
+    )
+    timeout_seconds: int = Field(
+        ...,
+        gt=0,
+        description="Timeout in seconds (must be > 0).",
+    )
+    working_dir: str | None = Field(
+        default=None,
+        description="Optional working directory for execution.",
+    )
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class RegexPattern(BaseModel):
+    """Regex extraction pattern used by text-based parsers."""
+
+    name: str = Field(..., min_length=1)
+    regex: str = Field(..., min_length=1)
+    flags: list[RegexFlag] = Field(default_factory=list)
+    group: int | str | None = Field(default=None)
+    required: bool = Field(default=True)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class TextRegexParsing(BaseModel):
+    """Parse plain text output using regex patterns."""
+
+    strategy: Literal["text_regex"]
+    patterns: list[RegexPattern] = Field(..., min_length=1)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def _validate_json_pointer(pointer: str) -> str:
+    """Validate a JSON Pointer string (RFC 6901).
+
+    Minimal v1 validation per design doc: allow exactly '/', or strings that start
+    with '/'. (Array segments are allowed; executor semantics are out of scope.)
+    """
+    if pointer == "/":
+        return pointer
+    if not pointer.startswith("/"):
+        raise ValueError("Invalid JSON Pointer. Must start with '/' (RFC 6901)")
+    if not pointer.strip():
+        raise ValueError("Invalid JSON Pointer. Must be non-empty")
+    return pointer
+
+
+class JsonFieldParsing(BaseModel):
+    """Parse JSON output and extract fields via JSON Pointer paths (RFC 6901)."""
+
+    strategy: Literal["json_field"]
+    fields: dict[str, str] = Field(..., min_length=1)
+    diagnostics_path: str | None = Field(default=None)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    @field_validator("fields")
+    @classmethod
+    def validate_fields_pointers(cls, value: dict[str, str]) -> dict[str, str]:
+        """Validate JSON pointers for each named field extraction."""
+        for key, pointer in value.items():
+            if not key.strip():
+                raise ValueError("JSON field key must be non-empty")
+            _validate_json_pointer(pointer)
+        return value
+
+    @field_validator("diagnostics_path")
+    @classmethod
+    def validate_diagnostics_pointer(cls, value: str | None) -> str | None:
+        """Validate the optional diagnostics path JSON pointer."""
+        if value is None:
+            return None
+        return _validate_json_pointer(value)
+
+
+class ExitCodeParsing(BaseModel):
+    """No parsing; rely on exit code only."""
+
+    strategy: Literal["exit_code"]
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+ParsingConfig: TypeAlias = Annotated[
+    TextRegexParsing | JsonFieldParsing | ExitCodeParsing,
+    Field(discriminator="strategy"),
+]
+
+
+class SuccessCriteria(BaseModel):
+    """Defines pass/fail criteria for a tool.
+
+    A2: This model keeps an explicit `mode`, but it must match the parsing strategy
+    for a given gate (validated in QualityGate).
+    """
+
+    mode: Literal["text_regex", "json_field", "exit_code"]
+
+    exit_codes_ok: list[int] = Field(default_factory=lambda: [0])
+    max_errors: int | None = Field(default=None)
+    min_score: float | None = Field(default=None)
+    require_no_issues: bool = Field(default=True)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class CapabilitiesMetadata(BaseModel):
+    """Metadata about what a gate applies to / can do."""
+
+    file_types: list[str] = Field(..., min_length=1)
+    supports_autofix: bool
+    produces_json: bool
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class QualityGate(BaseModel):
+    """Single quality gate tool definition."""
+
+    name: str = Field(..., min_length=1)
+    description: str = Field(default="")
+    execution: ExecutionConfig
+    parsing: ParsingConfig
+    success: SuccessCriteria
+    capabilities: CapabilitiesMetadata
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    @model_validator(mode="after")
+    def validate_success_matches_strategy(self) -> "QualityGate":
+        """Enforce A2: success.mode must match parsing.strategy."""
+        if self.success.mode != self.parsing.strategy:
+            raise ValueError(
+                "success.mode must match parsing.strategy "
+                f"({self.success.mode} != {self.parsing.strategy})"
+            )
+        return self
+
+
+class QualityConfig(BaseModel):
+    """Root quality gates configuration."""
+
+    version: str = Field(..., min_length=1)
+    gates: dict[str, QualityGate] = Field(..., min_length=1)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> "QualityConfig":
+        """Load configuration from YAML.
+
+        Args:
+            path: Path to .st3/quality.yaml (default: .st3/quality.yaml)
+
+        Returns:
+            Validated QualityConfig instance.
+
+        Raises:
+            FileNotFoundError: Config file not found.
+            ValidationError: Schema validation failed.
+        """
+        if path is None:
+            path = Path(".st3/quality.yaml")
+
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Quality config not found: {path}\n"
+                "Expected location: .st3/quality.yaml\n"
+                "Hint: Add .st3/quality.yaml to define available gate tools"
+            )
+
+        with open(path, "r", encoding="utf-8") as file_handle:
+            data = yaml.safe_load(file_handle)
+
+        return cls(**data)

--- a/tests/unit/mcp_server/config/test_quality_config.py
+++ b/tests/unit/mcp_server/config/test_quality_config.py
@@ -1,0 +1,273 @@
+"""Tests for quality gates configuration (QualityConfig and related models).
+
+Scope:
+- YAML loading (valid YAML, missing file, invalid YAML)
+- Schema validation (required fields, forbidden extra fields)
+- Strategy validation (parsing strategy discriminated union)
+- Success validation (`success.mode` must match `parsing.strategy`)
+- JSON Pointer validation (RFC 6901-style basic constraints)
+
+Quality Requirements:
+- Pylint: 10/10
+- Mypy: strict mode passing
+- Coverage: 100% for mcp_server/config/quality_config.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+from pydantic import ValidationError
+
+from mcp_server.config.quality_config import QualityConfig, QualityGate
+
+
+@pytest.fixture(name="quality_yaml_path")
+def fixture_quality_yaml_path(tmp_path: Path) -> Path:
+    """Create a valid quality.yaml fixture."""
+    config_data = {
+        "version": "1.0",
+        "gates": {
+            "pylint": {
+                "name": "Pylint",
+                "description": "Python linting",
+                "execution": {
+                    "command": ["python", "-m", "pylint"],
+                    "timeout_seconds": 60,
+                    "working_dir": None,
+                },
+                "parsing": {
+                    "strategy": "text_regex",
+                    "patterns": [
+                        {
+                            "name": "rating",
+                            "regex": "Your code has been rated at ([\\d.]+)/10",
+                            "flags": ["MULTILINE"],
+                            "group": 1,
+                            "required": True,
+                        }
+                    ],
+                },
+                "success": {
+                    "mode": "text_regex",
+                    "min_score": 10.0,
+                    "require_no_issues": True,
+                },
+                "capabilities": {
+                    "file_types": [".py"],
+                    "supports_autofix": False,
+                    "produces_json": False,
+                },
+            },
+            "pyright": {
+                "name": "Pyright",
+                "description": "Type checking",
+                "execution": {
+                    "command": ["pyright", "--outputjson"],
+                    "timeout_seconds": 120,
+                    "working_dir": None,
+                },
+                "parsing": {
+                    "strategy": "json_field",
+                    "fields": {
+                        "diagnostics": "/generalDiagnostics",
+                        "error_count": "/summary/errorCount",
+                    },
+                    "diagnostics_path": "/generalDiagnostics",
+                },
+                "success": {
+                    "mode": "json_field",
+                    "max_errors": 0,
+                    "require_no_issues": True,
+                },
+                "capabilities": {
+                    "file_types": [".py"],
+                    "supports_autofix": False,
+                    "produces_json": True,
+                },
+            },
+            "ruff": {
+                "name": "Ruff",
+                "description": "Fast linter",
+                "execution": {
+                    "command": ["ruff", "check"],
+                    "timeout_seconds": 60,
+                    "working_dir": None,
+                },
+                "parsing": {"strategy": "exit_code"},
+                "success": {"mode": "exit_code", "exit_codes_ok": [0]},
+                "capabilities": {
+                    "file_types": [".py"],
+                    "supports_autofix": True,
+                    "produces_json": False,
+                },
+            },
+        },
+    }
+
+    yaml_path = tmp_path / "quality.yaml"
+    with open(yaml_path, "w", encoding="utf-8") as file_handle:
+        yaml.dump(config_data, file_handle)
+
+    return yaml_path
+
+
+@pytest.fixture(name="invalid_yaml_path")
+def fixture_invalid_yaml_path(tmp_path: Path) -> Path:
+    """Create malformed YAML file."""
+    yaml_path = tmp_path / "invalid.yaml"
+    yaml_path.write_text("invalid: yaml: content: [unclosed", encoding="utf-8")
+    return yaml_path
+
+
+class TestQualityConfigLoading:
+    """Test QualityConfig.load() behavior."""
+
+    def test_load_valid_yaml(self, quality_yaml_path: Path) -> None:
+        """Loads YAML and returns a QualityConfig."""
+        config = QualityConfig.load(quality_yaml_path)
+        assert isinstance(config, QualityConfig)
+        assert config.version == "1.0"
+        assert set(config.gates) == {"pylint", "pyright", "ruff"}
+
+    def test_load_missing_file(self, tmp_path: Path) -> None:
+        """Raises FileNotFoundError for missing file."""
+        missing_path = tmp_path / "does_not_exist.yaml"
+        with pytest.raises(FileNotFoundError) as exc_info:
+            QualityConfig.load(missing_path)
+        assert str(missing_path) in str(exc_info.value)
+
+    def test_load_invalid_yaml(self, invalid_yaml_path: Path) -> None:
+        """Raises when YAML parsing fails."""
+        with pytest.raises((yaml.YAMLError, ValidationError, ValueError)):
+            QualityConfig.load(invalid_yaml_path)
+
+
+class TestQualityConfigValidation:
+    """Test schema validation rules."""
+
+    def test_gates_must_be_non_empty(self) -> None:
+        """Reject empty gates map."""
+        with pytest.raises(ValidationError):
+            QualityConfig(version="1.0", gates={})
+
+    def test_forbid_extra_fields_on_gate(self) -> None:
+        """Reject enforcement-like fields (extra keys) on QualityGate."""
+        with pytest.raises(ValidationError) as exc_info:
+            QualityGate.model_validate(
+                {
+                    "name": "X",
+                    "description": "",
+                    "execution": {
+                        "command": ["x"],
+                        "timeout_seconds": 1,
+                        "working_dir": None,
+                    },
+                    "parsing": {"strategy": "exit_code"},
+                    "success": {"mode": "exit_code", "exit_codes_ok": [0]},
+                    "capabilities": {
+                        "file_types": [".py"],
+                        "supports_autofix": False,
+                        "produces_json": False,
+                    },
+                    "enabled": True,
+                }
+            )
+
+        error_text = str(exc_info.value).lower()
+        assert "extra" in error_text or "forbidden" in error_text
+
+    def test_success_mode_must_match_parsing_strategy(self) -> None:
+        """Reject success.mode != parsing.strategy."""
+        with pytest.raises(ValidationError):
+            QualityConfig.model_validate(
+                {
+                    "version": "1.0",
+                    "gates": {
+                        "ruff": {
+                            "name": "Ruff",
+                            "description": "",
+                            "execution": {
+                                "command": ["ruff", "check"],
+                                "timeout_seconds": 1,
+                                "working_dir": None,
+                            },
+                            "parsing": {"strategy": "exit_code"},
+                            "success": {"mode": "text_regex", "exit_codes_ok": [0]},
+                            "capabilities": {
+                                "file_types": [".py"],
+                                "supports_autofix": True,
+                                "produces_json": False,
+                            },
+                        }
+                    },
+                }
+            )
+
+    def test_json_pointer_must_start_with_slash(self) -> None:
+        """Reject JSON fields that are not JSON Pointers."""
+        with pytest.raises(ValidationError):
+            QualityConfig.model_validate(
+                {
+                    "version": "1.0",
+                    "gates": {
+                        "pyright": {
+                            "name": "Pyright",
+                            "description": "",
+                            "execution": {
+                                "command": ["pyright", "--outputjson"],
+                                "timeout_seconds": 1,
+                                "working_dir": None,
+                            },
+                            "parsing": {
+                                "strategy": "json_field",
+                                "fields": {"diagnostics": "generalDiagnostics"},
+                            },
+                            "success": {"mode": "json_field", "max_errors": 0},
+                            "capabilities": {
+                                "file_types": [".py"],
+                                "supports_autofix": False,
+                                "produces_json": True,
+                            },
+                        }
+                    },
+                }
+            )
+
+    def test_regex_flags_are_validated(self) -> None:
+        """Reject unsupported regex flags."""
+        with pytest.raises(ValidationError):
+            QualityConfig.model_validate(
+                {
+                    "version": "1.0",
+                    "gates": {
+                        "pylint": {
+                            "name": "Pylint",
+                            "description": "",
+                            "execution": {
+                                "command": ["python", "-m", "pylint"],
+                                "timeout_seconds": 1,
+                                "working_dir": None,
+                            },
+                            "parsing": {
+                                "strategy": "text_regex",
+                                "patterns": [
+                                    {
+                                        "name": "rating",
+                                        "regex": "x",
+                                        "flags": ["NOT_A_FLAG"],
+                                    }
+                                ],
+                            },
+                            "success": {"mode": "text_regex", "min_score": 0.0},
+                            "capabilities": {
+                                "file_types": [".py"],
+                                "supports_autofix": False,
+                                "produces_json": False,
+                            },
+                        }
+                    },
+                }
+            )


### PR DESCRIPTION
Implements the quality gates configuration layer.

- Adds `.st3/quality.yaml` catalog (≥7 tools)
- Adds `mcp_server/config/quality_config.py` Pydantic models + loader
- Adds unit tests for load/validation
- Updates docs to reference `.st3/quality.yaml`

Related:
- #76 (config layer; closed)
- #53 (execution layer follow-up)
