### PR TITLE
feat(mcp-server): redesign create_issue tool — structured body, config-driven labels (#149)

### DIFF
--- a/.st3/contributors.yaml
+++ b/.st3/contributors.yaml
@@ -1,0 +1,4 @@
+version: "1.0"
+contributors: []
+# Schema: { login: str, name: str (optional) }
+# Populate manually or via future sync tooling.

--- a/.st3/git.yaml
+++ b/.st3/git.yaml
@@ -49,3 +49,6 @@ commit_types:
 
 # Conventions #9-11: Default base branch for PR creation
 default_base_branch: main
+
+# Convention #12: Issue title maximum length (Issue #149)
+issue_title_max_length: 72

--- a/.st3/issues.yaml
+++ b/.st3/issues.yaml
@@ -1,0 +1,36 @@
+version: "1.0"
+issue_types:
+  - name: feature
+    workflow: feature
+    label: "type:feature"
+  - name: bug
+    workflow: bug
+    label: "type:bug"
+  - name: hotfix
+    workflow: hotfix
+    label: "type:bug"
+  - name: refactor
+    workflow: refactor
+    label: "type:refactor"
+  - name: docs
+    workflow: docs
+    label: "type:docs"
+  - name: chore
+    workflow: feature
+    label: "type:chore"
+  - name: epic
+    workflow: epic
+    label: "type:epic"
+required_label_categories:
+  - type
+  - priority
+  - scope
+optional_label_inputs:
+  is_epic:
+    type: bool
+    label: "type:epic"
+    behavior: "Overrides type:* label from issue_type"
+  parent_issue:
+    type: int
+    label_pattern: "parent:{value}"
+    description: "Applies parent:{issue_number} label (e.g., parent:91)"

--- a/.st3/labels.yaml
+++ b/.st3/labels.yaml
@@ -22,10 +22,6 @@ labels:
     color: "1D76DB"
     description: "New functionality or capability"
   
-  - name: "type:enhancement"
-    color: "A2EEEF"
-    description: "Improvement to existing feature"
-  
   - name: "type:bug"
     color: "D73A4A"
     description: "Something isn't working"

--- a/.st3/labels.yaml
+++ b/.st3/labels.yaml
@@ -10,10 +10,10 @@ freeform_exceptions:
 # Dynamic label patterns - validated but not pre-created
 # These labels are created on-demand when needed
 label_patterns:
-  - pattern: "^parent:issue-\\d+$"
+  - pattern: "^parent:\\d+$"
     description: "Parent issue reference for child issues"
     color: "EDEDED"
-    example: "parent:issue-18"
+    example: "parent:91"
 
 labels:
   # TYPE - Issue Classification (7 labels)
@@ -45,6 +45,10 @@ labels:
   - name: "type:epic"
     color: "5319E7"
     description: "Large feature with multiple sub-issues"
+  
+  - name: "type:chore"
+    color: "7057FF"
+    description: "Maintenance tasks and housekeeping"
   
   # PRIORITY - Urgency Level (5 labels)
   # How important/urgent is this work
@@ -107,24 +111,6 @@ labels:
   - name: "phase:documentation"
     color: "0075CA"
     description: "Documentation phase"
-  
-  # STATUS - Current State (4 labels)
-  # What's blocking or what action is needed
-  - name: "status:blocked"
-    color: "D73A4A"
-    description: "Blocked by external dependency"
-  
-  - name: "status:in-progress"
-    color: "0E8A16"
-    description: "Currently being worked on"
-  
-  - name: "status:needs-info"
-    color: "D876E3"
-    description: "Needs more information"
-  
-  - name: "status:ready"
-    color: "FBCA04"
-    description: "Ready for review/merge"
   
   # SCOPE - Impact Area (6 labels)
   # Which part of the system is affected

--- a/.st3/labels.yaml
+++ b/.st3/labels.yaml
@@ -133,3 +133,19 @@ labels:
   - name: "scope:documentation"
     color: "BFD4F2"
     description: "Documentation scope"
+
+# ---------------------------------------------------------------------------
+# CHANGELOG
+# ---------------------------------------------------------------------------
+# v1.0  (Issue #149 — Redesign create_issue tool)
+#   REMOVED: status:* label category (status:open, status:in-progress,
+#             status:closed, status:blocked) — workflow state is tracked via
+#             GitHub issue state + phase:* labels instead of explicit status
+#             labels. This avoids label proliferation and state drift.
+#   CHANGED: parent:{n} is now a dynamic label pattern (see label_patterns
+#             above) rather than a pre-created label. Labels are created
+#             on-demand when a parent_issue is provided to create_issue.
+#             Pattern: "^parent:\\d+$", color: EDEDED, example: "parent:91"
+#   ADDED:   label_patterns section — declares dynamic label patterns that
+#            are validated by regex but not pre-created in the repository.
+# ---------------------------------------------------------------------------

--- a/.st3/milestones.yaml
+++ b/.st3/milestones.yaml
@@ -1,0 +1,4 @@
+version: "1.0"
+milestones: []
+# Schema: { number: int, title: str, state: "open"|"closed" }
+# Populate manually or via future sync tooling.

--- a/.st3/projects.json
+++ b/.st3/projects.json
@@ -460,5 +460,21 @@
     "skip_reason": null,
     "parent_branch": null,
     "created_at": "2026-02-14T20:01:14.099861+00:00"
+  },
+  "149": {
+    "issue_title": "Redesign create_issue tool: structured input, config-driven validation, Jinja2 body scaffolding",
+    "workflow_name": "feature",
+    "execution_mode": "interactive",
+    "required_phases": [
+      "research",
+      "planning",
+      "design",
+      "tdd",
+      "integration",
+      "documentation"
+    ],
+    "skip_reason": null,
+    "parent_branch": "main",
+    "created_at": "2026-02-18T14:34:40.512360+00:00"
   }
 }

--- a/.st3/scopes.yaml
+++ b/.st3/scopes.yaml
@@ -1,0 +1,8 @@
+version: "1.0"
+scopes:
+  - architecture
+  - mcp-server
+  - platform
+  - tooling
+  - workflow
+  - documentation

--- a/agent.md
+++ b/agent.md
@@ -55,11 +55,29 @@ Don't guess the phase or status. **Query the system:**
 
 **Workflow Sequence:**
 ```
-1. create_issue          → Create GitHub issue (labels validated against .st3/labels.yaml)
+1. create_issue(issue_type, title, priority, scope, body) → Create GitHub issue (labels assembled from config, body rendered via Jinja2)
 2. create_branch         → Create feature/bug/docs/refactor/hotfix branch
 3. git_checkout          → Switch to new branch  
 4. initialize_project    → Set up workflow, phase state, parent tracking
 5. get_project_plan      → Verify workflow phases loaded
+```
+
+**Example `create_issue` call (all required fields):**
+```python
+create_issue(
+    issue_type="feature",
+    title="Add Redis caching to strategy loader",
+    priority="high",
+    scope="mcp-server",
+    body={
+        "problem": "Strategy loader re-reads YAML on every call, causing latency spikes.",
+        "expected": "Cached reads with TTL, invalidated on file change.",
+        "context": "Observed on high-frequency backtests (>500 calls/s)."
+    }
+    # Optional: is_epic=False, parent_issue=76, milestone="v1.0.0", assignees=["alice"]
+)
+# → Creates issue with labels: type:feature, priority:high, scope:mcp-server
+# → Returns: issue #47: Add Redis caching to strategy loader
 ```
 
 **Workflow Types (from `.st3/workflows.yaml`):**
@@ -186,7 +204,7 @@ force_phase_transition(
 ### GitHub Issues
 | Action | ✅ USE THIS | ❌ NEVER USE |
 |--------|-------------|------------|
-| Create issue | `create_issue(title, body, labels, assignees, milestone)` | GitHub CLI / manual |
+| Create issue | `create_issue(issue_type, title, priority, scope, body, is_epic?, parent_issue?, milestone?, assignees?)` | GitHub CLI / manual |
 | List issues | `list_issues(state, labels)` | `run_in_terminal("gh issue list")` |
 | Get issue details | `get_issue(issue_number)` | `run_in_terminal("gh issue view")` |
 | Update issue | `update_issue(issue_number, title, body, state, labels)` | GitHub CLI / manual |

--- a/docs/development/issue149/SESSIE_OVERDRACHT_20260218.md
+++ b/docs/development/issue149/SESSIE_OVERDRACHT_20260218.md
@@ -1,0 +1,150 @@
+# Sessie Overdracht — 18 februari 2026
+
+**Branch:** `feature/149-redesign-create-issue-tool`
+**Issue:** #149 Redesign `create_issue` tool: structured input, config-driven validation, Jinja2 body scaffolding
+**Date:** 2026-02-18
+**Focus:** Cycles 5 & 6 + integration phase volledig afgerond; tool live in productie
+**Status:** Branch clean; integration fase voltooid; documentatie fase open
+
+---
+
+## Wat er gedaan is deze sessie
+
+### Cycle 5 — Label assembly (volledig)
+
+- **RED** (`9843b1e`): 25 tests in `tests/unit/tools/test_create_issue_label_assembly.py`
+  - Dekt: `type:*` labels per `issue_type`, `is_epic` override naar `type:epic`, `hotfix` → `type:bug`, `scope:*`, `priority:*`, `phase:*` (eerste workflow-fase), `parent:N`, volledige label-set tellingen
+- **GREEN** (`7b3c93f`): Nieuw `WorkflowConfig` singleton + `_assemble_labels()` in `CreateIssueTool`
+  - Nieuw bestand: `mcp_server/config/workflow_config.py`
+  - `WorkflowEntry(**v)` (niet `WorkflowEntry(name=k, **v)`) — YAML heeft al `name:` field
+  - `execute()` wired: `labels = self._assemble_labels(params)`
+  - Quality gates 5/5 pass
+
+### Cycle 6 — Error handling (volledig + gap fix)
+
+- **RED** (`7f46810`): 11 tests in `tests/unit/tools/test_create_issue_errors.py`
+  - Dekt: `ExecutionError` → `ToolResult.error`, `jinja2.TemplateError` → `ToolResult.error` met actionable bericht, `ValueError` (uit `_assemble_labels`) → `ToolResult.error`, geen lekkende exceptions
+- **GREEN** (`4a08a7d`): Expliciete `except jinja2.TemplateError` in `execute()` met bericht: `"Body rendering failed: {e}. Check that issue.md.jinja2 exists..."`
+- **Gap fix** (`ba8a67f`): `ValueError` uit `_assemble_labels()` werd niet gecatcht — toegevoegd als `except ValueError as e: return ToolResult.error(f"Label assembly failed: {e}.")`
+
+Volgorde exception handlers in `execute()`:
+```python
+except jinja2.TemplateError as e: ...
+except ValueError as e: ...
+except ExecutionError as e: ...
+```
+
+### Integration phase (volledig)
+
+- Fase transitie: `tdd → integration` uitgevoerd
+- **Commit** (`1046d5b`): `tests/integration/test_create_issue_e2e.py` — 7 tests, allemaal groen
+
+**Test resultaten:**
+
+| Scenario | Test | Resultaat |
+|----------|------|-----------|
+| Minimal input | `type:feature`, `scope:tooling`, `priority:low`, `phase:research` op GitHub | ✅ |
+| Full options | `type:epic`, `parent:149`, `scope:mcp-server`, `priority:medium`, `phase:research` | ✅ |
+| Validatie | Ongeldig `issue_type` geweigerd vóór API call | ✅ |
+| Validatie | Ongeldige `scope` geweigerd vóór API call | ✅ |
+| Validatie | Ongeldige `priority` geweigerd vóór API call | ✅ |
+| Validatie | Titel te lang geweigerd vóór API call | ✅ |
+| Milestone | Lege `milestones.yaml` → permissief (Risk #2 planning.md) | ✅ |
+
+**Live test:** Issue #157 aangemaakt via MCP tool call — volledig geautomatiseerd met nieuw schema (`issue_type`, `priority`, `scope`, `body`).
+
+---
+
+## Huidige staat van de code
+
+### Gewijzigde bestanden (t.o.v. main)
+
+| Bestand | Wijziging |
+|---------|----------|
+| `mcp_server/tools/issue_tools.py` | `CreateIssueInput` + `CreateIssueTool` volledig herontwikkeld |
+| `mcp_server/config/workflow_config.py` | Nieuw — `WorkflowConfig.from_file()` singleton |
+| `mcp_server/config/issue_config.py` | `IssueConfig` singleton (cycle 1) |
+| `mcp_server/config/scope_config.py` | `ScopeConfig` singleton (cycle 1) |
+| `mcp_server/config/milestone_config.py` | `MilestoneConfig` singleton — permissief bij lege lijst |
+| `mcp_server/config/contributor_config.py` | `ContributorConfig` singleton (cycle 1) |
+| `.st3/issues.yaml` | Nieuw — issue type definities + workflow mapping |
+| `.st3/scopes.yaml` | Nieuw — geldige scopes |
+| `.st3/labels.yaml` | Cleanup: `status:*` verwijderd, `parent:N` patroon, `type:chore` toegevoegd |
+| `.st3/git.yaml` | `issue_title_max_length: 72` toegevoegd |
+| `tests/unit/tools/test_create_issue_label_assembly.py` | Nieuw — 25 tests |
+| `tests/unit/tools/test_create_issue_errors.py` | Nieuw — 11 tests |
+| `tests/integration/test_create_issue_e2e.py` | Nieuw — 7 e2e tests |
+
+### Nieuw `CreateIssueInput` schema
+
+```python
+CreateIssueInput(
+    issue_type="feature",   # valideert tegen issues.yaml
+    title="...",            # max 72 chars (git.yaml)
+    priority="medium",      # valideert tegen labels.yaml priority categorie
+    scope="mcp-server",     # valideert tegen scopes.yaml
+    body=IssueBody(problem="..."),  # gerenderd via issue.md.jinja2
+    is_epic=False,          # optioneel — override type label naar type:epic
+    parent_issue=None,      # optioneel — voegt parent:N label toe
+    milestone=None,         # optioneel — permissief als milestones.yaml leeg
+    assignees=None,         # optioneel — valideert tegen contributors.yaml
+)
+```
+
+Labels worden **intern geassembleerd** — caller geeft geen labels mee.
+
+### Eerste fasen per workflow (workflows.yaml)
+
+| issue_type | workflow | eerste fase | phase label |
+|-----------|----------|-------------|-------------|
+| feature | feature | research | `phase:research` |
+| bug | bug | research | `phase:research` |
+| hotfix | hotfix | tdd | `phase:tdd` |
+| refactor | refactor | research | `phase:research` |
+| docs | docs | planning | `phase:planning` |
+| chore | feature | research | `phase:research` |
+| epic | epic | research | `phase:research` |
+
+---
+
+## Commit history deze branch
+
+```
+1046d5b  feat: integration smoke tests for CreateIssueTool — real GitHub API validation (7/7 pass)
+ba8a67f  fix: catch ValueError from _assemble_labels() in execute() (cycle 6 gap)
+4a08a7d  feat: explicit jinja2.TemplateError handling in execute() with actionable message (cycle 6)
+7f46810  test: error handling contract for execute() — TemplateError, ExecutionError, ValueError (cycle 6)
+7b3c93f  feat: add WorkflowConfig + _assemble_labels() in CreateIssueTool; wire into execute() (cycle 5)
+9843b1e  test: label assembly rules for _assemble_labels() and execute() forwarding (cycle 5)
+6c76c81  fix(cycle4): priority validation config-driven via LabelConfig; pass params.milestone in execute()
+004431b  feat: refactor CreateIssueInput: structured schema (cycle 4)
+7bffc41  test: CreateIssueInput schema tests (cycle 4)
+8c82fd2  feat: IssueBody model and _render_body() in CreateIssueTool (cycle 3)
+81e87d9  test: IssueBody + _render_body tests (cycle 3)
+5e96f61  feat: remove type:enhancement from labels.yaml (cycle 2)
+ee8c31e  test: test type:enhancement removed from labels.yaml (cycle 2)
+e21e3cb  feat: update labels.yaml — remove status labels, numeric parent pattern, type:chore (cycle 2)
+625b98a  test: labels.yaml convention tests (cycle 2)
+```
+
+---
+
+## Open: Documentation phase
+
+Nog te doen per `planning.md`:
+
+1. **`agent.md` §2.1** — werksequentie bijwerken: `create_issue(issue_type, title, priority, scope, body)` (vervangt `create_issue(title, body, labels)`)
+2. **`agent.md` §2.1 voorbeeld** — concreet voorbeeld met alle verplichte velden toevoegen
+3. **Config reference docs** — korte beschrijving per nieuw `.st3/` bestand in `docs/reference/`
+4. **Inline docstrings** — `CreateIssueInput`, `IssueBody`, `_assemble_labels()`, `_render_body()` volledig gedocumenteerd
+5. **`labels.yaml` CHANGELOG** — verwijdering `status:*` en wijziging `parent:*` patroon vastleggen
+
+---
+
+## Aandachtspunten voor volgende sessie
+
+- **Smoke issues opruimen**: Issues #155, #156 (aangemaakt door integration tests), #157 (live test) kunnen gesloten worden
+- **`milestones.yaml` leeg**: Validatie momenteel permissief — pas strict als milestones.yaml gevuld wordt (Risk #2)
+- **`contributors.yaml` leeg**: Zelfde situatie — valideert niet zolang lijst leeg is
+- **agent.md §2.1**: Oude `create_issue` signature staat er nog in — misleidend voor nieuwe sessies, prioriteit in docs fase
+- **Breaking change**: Alle bestaande callers die `labels=[...]` meegaven werken niet meer — maar er zijn geen andere callers in codebase gevonden

--- a/docs/development/issue149/design.md
+++ b/docs/development/issue149/design.md
@@ -1,0 +1,457 @@
+<!-- docs/development/issue149/design.md -->
+<!-- template=design version=5827e841 created=2026-02-18 updated=2026-02-18 -->
+# Design: Redesign create_issue Tool (Issue #149)
+
+**Status:** DRAFT
+**Version:** 1.0
+**Last Updated:** 2026-02-18
+
+---
+
+## Purpose
+
+Define the detailed technical design for the redesigned `create_issue` tool: new config singleton classes, Pydantic schema reshape, internal label assembly, and Jinja2 body rendering.
+
+## Scope
+
+**In Scope:**
+- `mcp_server/tools/issue_tools.py`
+- `mcp_server/config/issue_config.py` (new)
+- `mcp_server/config/scope_config.py` (new)
+- `mcp_server/config/milestone_config.py` (new)
+- `mcp_server/config/contributor_config.py` (new)
+- `.st3/issues.yaml`
+- `.st3/scopes.yaml`
+- `.st3/milestones.yaml` (new, empty)
+- `.st3/contributors.yaml` (new, empty)
+- `.st3/labels.yaml` (cleanup: remove `status:*`, fix `parent:*` pattern, add `type:chore`)
+- `.st3/git.yaml` (add `issue_title_max_length: 72`)
+
+**Out of Scope:**
+- `get_issue` / `list_issues` (issue #150)
+- `create_branch` enrichment (issue #116)
+- GitHub Projects integration
+- Retroactive issue renaming
+
+## Prerequisites
+
+- [docs/development/issue149/research.md](docs/development/issue149/research.md)
+- [docs/development/issue149/planning.md](docs/development/issue149/planning.md)
+- [mcp_server/config/git_config.py](mcp_server/config/git_config.py) — singleton pattern to replicate
+- [mcp_server/scaffolding/templates/concrete/issue.md.jinja2](mcp_server/scaffolding/templates/concrete/issue.md.jinja2) — body template
+
+---
+
+## 1. Problem Statement
+
+`CreateIssueInput` currently accepts free-form, unvalidated input: title has no length constraint, body is a raw string, and labels are unchecked. There is no enforced convention for issue type, scope, or priority. This makes automated issue creation convention-blind and produces inconsistent GitHub issues that violate labelling standards.
+
+---
+
+## 2. Requirements
+
+### 2.1 Functional
+
+| ID | Requirement |
+|----|-------------|
+| REQ-F1 | `CreateIssueInput` must require `issue_type`, validated against `issues.yaml`; unknown values produce `ValidationError` with list of valid types |
+| REQ-F2 | `title` must have max length from `git.yaml` (`issue_title_max_length: 72`) |
+| REQ-F3 | `priority` required, validated against `labels.yaml` `priority:*` category |
+| REQ-F4 | `scope` required, validated against `scopes.yaml` names |
+| REQ-F5 | `body` required as `IssueBody` instance (not `str`); `problem` field required within `IssueBody` |
+| REQ-F6 | `is_epic=True` must override `type:*` label to `type:epic` regardless of `issue_type` |
+| REQ-F7 | `parent_issue >= 1` must produce label `parent:{n}`; values `< 1` must be rejected |
+| REQ-F8 | `milestone` must be validated against `milestones.yaml` (permissive when list empty) |
+| REQ-F9 | `assignees` must be validated against `contributors.yaml` (permissive when list empty) |
+| REQ-F10 | Tool must automatically set `phase:*` label from first phase of `issue_type`'s workflow |
+| REQ-F11 | `IssueBody` must be rendered to GitHub issue body markdown via `issue.md.jinja2` |
+| REQ-F12 | `labels.yaml` must not contain `status:*` labels |
+| REQ-F13 | `labels.yaml` `parent:*` pattern must be `^parent:\d+$` (not `^parent:issue-\d+$`) |
+| REQ-F14 | `labels.yaml` must contain `type:chore` label |
+
+### 2.2 Non-Functional
+
+| ID | Requirement |
+|----|-------------|
+| REQ-NF1 | All new Python files scaffolded via `scaffold_artifact` |
+| REQ-NF2 | All Pydantic models exposed via MCP must have `json_schema_extra` with ≥ 2 examples |
+| REQ-NF3 | All test functions have `-> None` return type annotation |
+| REQ-NF4 | Fixtures injecting other fixtures use `@pytest.fixture(name="x")` with private `_x` function name |
+| REQ-NF5 | All config singletons follow `GitConfig.from_file()` pattern |
+| REQ-NF6 | All `@field_validator` methods are synchronous |
+| REQ-NF7 | Quality gates pass after each TDD cycle: Ruff format, lint, type check, pytest, coverage ≥ 90% |
+| REQ-NF8 | `execute()` handles `ValidationError`, `ExecutionError`, and rendering errors via `ToolResult.error()` with actionable messages |
+
+---
+
+## 3. Design Options Considered
+
+### Option A: Tool-layer only (chosen)
+
+Structured fields in `CreateIssueInput`. Label assembly and body rendering in `CreateIssueTool.execute()`. Config singletons in `mcp_server/config/`. Manager and adapter unchanged.
+
+**Pros:** Minimal blast radius. Manager API stable. Config is mockable. Tool layer is the correct boundary for input normalisation.
+**Cons:** `execute()` grows — mitigated by extracting `_assemble_labels()` and `_render_body()` as private helpers.
+
+### Option B: Manager-layer label assembly
+
+Move label assembly into `GitHubManager.create_issue()`.
+
+**Cons:** Manager becomes aware of project conventions (violates SRP). Manager should not depend on `labels.yaml` or `issues.yaml`.
+
+### Option C: Separate `LabelAssembler` service
+
+Extract label assembly into a standalone service class.
+
+**Cons:** Over-engineering for 6 label derivation rules. Private helpers on the tool are sufficient and independently testable.
+
+**Decision: Option A** — tool-layer only, minimum blast radius, config singletons stay in `mcp_server/config/`.
+
+---
+
+## 4. Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | `issue_type` is required (not optional) | No sensible default exists. An optional with a default would silently allow convention violations. |
+| D2 | `labels` field removed entirely from `CreateIssueInput` | Free-form labels bypass all validation. Structured derivation guarantees label conventions. |
+| D3 | `body` changes from `str` to `IssueBody` nested Pydantic model | Ensures consistent GitHub issue structure. `issue.md.jinja2` is already tested. Breaking change accepted per planning. |
+| D4 | `scopes.yaml` contains only scope names (no `label` field) | `labels.yaml` is SSOT for label existence. Label derived by convention: `scope:{name}`. |
+| D5 | `milestones.yaml` and `contributors.yaml` start empty; validation is permissive when list is empty | Prevents blocking issue creation before files are populated. Documented as known limitation. |
+| D6 | `is_epic=True` overrides `type:*` to `type:epic` (one type label per issue) | Two type labels are ambiguous for tooling. `get_issue` (#150) must identify type unambiguously. |
+| D7 | `phase:*` label derived from first workflow phase in `issues.yaml` → `workflows.yaml` | Phase is a workflow-state concern, not an authoring concern. |
+
+---
+
+## 5. Design
+
+### 5.1 Config Singleton Layer
+
+All four new config classes follow the `GitConfig.from_file()` pattern:
+
+```python
+@classmethod
+def from_file(cls, path: Path | None = None) -> "IssueConfig":
+    resolved = path or Path(".st3/issues.yaml")
+    data = yaml.safe_load(resolved.read_text())
+    return cls.model_validate(data)
+```
+
+#### `IssueConfig` (`.st3/issues.yaml`)
+
+```python
+class IssueTypeEntry(BaseModel):
+    workflow: str
+    description: str | None = None
+
+class IssueConfig(BaseModel):
+    issue_types: dict[str, IssueTypeEntry]
+```
+
+**`.st3/issues.yaml` schema:**
+
+```yaml
+issue_types:
+  feature:
+    workflow: feature
+    description: "New capability"
+  bug:
+    workflow: bug
+  hotfix:
+    workflow: hotfix
+  refactor:
+    workflow: refactor
+  docs:
+    workflow: docs
+  chore:
+    workflow: feature
+    description: "Maintenance task (maps to feature workflow)"
+  epic:
+    workflow: epic
+```
+
+#### `ScopeConfig` (`.st3/scopes.yaml`)
+
+```python
+class ScopeEntry(BaseModel):
+    description: str | None = None
+
+class ScopeConfig(BaseModel):
+    scopes: dict[str, ScopeEntry]
+```
+
+No `label` field — label is `scope:{name}` by convention.
+
+#### `MilestoneConfig` (`.st3/milestones.yaml`)
+
+```python
+class MilestoneEntry(BaseModel):
+    title: str
+
+class MilestoneConfig(BaseModel):
+    milestones: list[MilestoneEntry] = []
+```
+
+Starts empty. Validation permissive when `milestones` is `[]`.
+
+#### `ContributorConfig` (`.st3/contributors.yaml`)
+
+```python
+class ContributorEntry(BaseModel):
+    github_username: str
+
+class ContributorConfig(BaseModel):
+    contributors: list[ContributorEntry] = []
+```
+
+Starts empty. Validation permissive when `contributors` is `[]`.
+
+---
+
+### 5.2 `IssueBody` Nested Model
+
+```python
+class IssueBody(BaseModel):
+    problem: str                        # required
+    expected: str | None = None
+    actual: str | None = None
+    context: str | None = None
+    steps_to_reproduce: str | None = None
+    related_docs: str | None = None
+```
+
+Maps directly to the variables consumed by `issue.md.jinja2`.
+
+---
+
+### 5.3 Redesigned `CreateIssueInput`
+
+```python
+class CreateIssueInput(BaseModel):
+    model_config = ConfigDict(...)
+
+    issue_type: str
+    title: str
+    priority: str
+    scope: str
+    body: IssueBody
+
+    # Optional label-producing fields
+    is_epic: bool = False
+    parent_issue: int | None = None
+    milestone: str | None = None
+    assignees: list[str] | None = None
+
+    @field_validator("issue_type")
+    @classmethod
+    def validate_issue_type(cls, v: str) -> str: ...
+
+    @field_validator("title")
+    @classmethod
+    def validate_title_length(cls, v: str) -> str: ...
+
+    @field_validator("priority")
+    @classmethod
+    def validate_priority(cls, v: str) -> str: ...
+
+    @field_validator("scope")
+    @classmethod
+    def validate_scope(cls, v: str) -> str: ...
+
+    @field_validator("parent_issue")
+    @classmethod
+    def validate_parent_issue(cls, v: int | None) -> int | None: ...
+```
+
+`json_schema_extra` provides ≥ 2 usage examples per REQ-NF2.
+
+---
+
+### 5.4 Label Assembly
+
+`_assemble_labels()` is a private method on `CreateIssueTool`. It is pure (no side effects) and independently testable.
+
+**Assembly rules (in order):**
+
+```
+type_label     = "type:epic"              if is_epic
+               = "type:{issue_type}"      otherwise
+scope_label    = "scope:{scope}"
+priority_label = "priority:{priority}"
+phase_label    = "phase:{first_phase}"    from workflows.yaml via issue_type → workflow
+parent_label   = "parent:{n}"            if parent_issue is not None
+```
+
+```mermaid
+flowchart TD
+    A[CreateIssueInput] --> B{is_epic?}
+    B -- Yes --> C[type:epic]
+    B -- No  --> D["type:{issue_type}"]
+    C --> E[Collect labels]
+    D --> E
+    E --> F["scope:{scope}"]
+    F --> G["priority:{priority}"]
+    G --> H[Lookup first phase\nvia IssueConfig + WorkflowConfig]
+    H --> I["phase:{first_phase}"]
+    I --> J{parent_issue set?}
+    J -- Yes --> K["parent:{n}"]
+    J -- No  --> L[Done]
+    K --> L
+```
+
+---
+
+### 5.5 Body Rendering
+
+`_render_body()` uses `issue.md.jinja2`. The rendering approach depends on whether `JinjaRenderer` supports inline usage (verified in cycle 3). Fallback is direct `jinja2.Environment`.
+
+```mermaid
+flowchart LR
+    A[IssueBody] -->|to_dict| B[template_vars]
+    B --> C{JinjaRenderer\nsupports inline?}
+    C -- Yes --> D[JinjaRenderer.render\nissue.md.jinja2]
+    C -- No  --> E[jinja2.Environment\ndirect render]
+    D --> F[rendered_body: str]
+    E --> F
+```
+
+---
+
+### 5.6 `CreateIssueTool.execute()` Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant CIT as CreateIssueTool
+    participant Input as CreateIssueInput
+    participant Cfg as Config Singletons
+    participant LabelAsm as _assemble_labels()
+    participant Renderer as _render_body()
+    participant GHM as GitHubManager
+
+    Agent->>CIT: execute(args)
+    CIT->>Input: model_validate(args)
+    Input->>Cfg: IssueConfig / ScopeConfig / GitConfig
+    Input-->>CIT: validated input (or ValidationError)
+    CIT->>LabelAsm: _assemble_labels(input)
+    LabelAsm-->>CIT: list[str] labels
+    CIT->>Renderer: _render_body(input.body)
+    Renderer-->>CIT: str body_markdown
+    CIT->>GHM: create_issue(title, body_markdown, labels, milestone, assignees)
+    GHM-->>CIT: Issue
+    CIT-->>Agent: ToolResult.ok(issue_url)
+```
+
+---
+
+### 5.7 `.st3/` YAML Changes
+
+#### `.st3/git.yaml`
+
+Add field:
+```yaml
+issue_title_max_length: 72
+```
+
+#### `.st3/labels.yaml`
+
+- **Remove** all `status:*` labels (4 labels)
+- **Update** `freeform_exceptions` pattern: `^parent:issue-\d+$` → `^parent:\d+$`
+- **Add** `type:chore` label
+
+#### `.st3/issues.yaml`
+
+New file — see schema in §5.1. Includes `optional_label_inputs` section:
+
+```yaml
+optional_label_inputs:
+  is_epic:
+    label: "type:epic"
+    description: "Overrides type:* when True"
+  parent_issue:
+    label_pattern: "parent:{n}"
+    description: "Applies parent:{n} label"
+```
+
+#### `.st3/scopes.yaml`
+
+New file. Initially populated with known project scopes:
+
+```yaml
+scopes:
+  core:
+    description: "Core trading engine"
+  config:
+    description: "Configuration layer"
+  tools:
+    description: "MCP tool layer"
+  workers:
+    description: "Worker layer"
+  dtos:
+    description: "Data transfer objects"
+  tests:
+    description: "Test infrastructure"
+  docs:
+    description: "Documentation"
+  ci:
+    description: "CI/CD pipeline"
+```
+
+---
+
+## 6. Config Dependency Map
+
+```mermaid
+flowchart TD
+    CIT[CreateIssueTool] --> Input[CreateIssueInput]
+    Input --> IC[IssueConfig\n.st3/issues.yaml]
+    Input --> SC[ScopeConfig\n.st3/scopes.yaml]
+    Input --> GC[GitConfig\n.st3/git.yaml]
+    Input --> LC[LabelsConfig\n.st3/labels.yaml]
+    CIT --> MC[MilestoneConfig\n.st3/milestones.yaml]
+    CIT --> CC[ContributorConfig\n.st3/contributors.yaml]
+    IC --> WC[WorkflowConfig\n.st3/workflows.yaml]
+    WC -->|first phase| PhaseLabel["phase:{first_phase}"]
+```
+
+---
+
+## 7. Affected Files
+
+| File | Change Type |
+|------|-------------|
+| `mcp_server/tools/issue_tools.py` | Modify — reshape `CreateIssueInput`, add `IssueBody`, add private helpers |
+| `mcp_server/config/issue_config.py` | New (scaffold) |
+| `mcp_server/config/scope_config.py` | New (scaffold) |
+| `mcp_server/config/milestone_config.py` | New (scaffold) |
+| `mcp_server/config/contributor_config.py` | New (scaffold) |
+| `.st3/issues.yaml` | New |
+| `.st3/scopes.yaml` | New |
+| `.st3/milestones.yaml` | New (empty) |
+| `.st3/contributors.yaml` | New (empty) |
+| `.st3/labels.yaml` | Modify — remove `status:*`, fix `parent:*` pattern, add `type:chore` |
+| `.st3/git.yaml` | Modify — add `issue_title_max_length` |
+| `tests/unit/config/test_issue_config.py` | New (scaffold) |
+| `tests/unit/config/test_scope_config.py` | New (scaffold) |
+| `tests/unit/config/test_milestone_config.py` | New (scaffold) |
+| `tests/unit/config/test_contributor_config.py` | New (scaffold) |
+| `tests/unit/tools/test_issue_tools.py` | Modify — update existing tests + add new |
+
+---
+
+## 8. Open Questions
+
+1. Does `JinjaRenderer.render()` support inline invocation (no file output, returns string)? If not, fall back to direct `jinja2.Environment`. Verify in cycle 3.
+2. Should `MilestoneConfig` and `ContributorConfig` expose a `sync_from_github()` stub (not implemented) as a documented future extension point? Recommendation: yes — `NotImplemented` stub with docstring.
+
+---
+
+## 9. Related Documents
+
+- [docs/development/issue149/research.md](docs/development/issue149/research.md)
+- [docs/development/issue149/planning.md](docs/development/issue149/planning.md)
+- [docs/coding_standards/CODE_STYLE.md](docs/coding_standards/CODE_STYLE.md)
+- [docs/coding_standards/QUALITY_GATES.md](docs/coding_standards/QUALITY_GATES.md)
+- [mcp_server/config/git_config.py](mcp_server/config/git_config.py)
+- [mcp_server/tools/git_tools.py](mcp_server/tools/git_tools.py)
+- [mcp_server/scaffolding/templates/concrete/issue.md.jinja2](mcp_server/scaffolding/templates/concrete/issue.md.jinja2)

--- a/docs/development/issue149/planning.md
+++ b/docs/development/issue149/planning.md
@@ -1,0 +1,293 @@
+<!-- docs/development/issue149/planning.md -->
+<!-- template=planning version=1.0 created=2026-02-18 updated=2026-02-18 -->
+# Planning — Issue #149: Redesign `create_issue` Tool
+
+**Status:** draft
+**Version:** 1.1
+**Last Updated:** 2026-02-18
+
+---
+
+## Purpose
+
+Break down the redesign of `create_issue` into logical, independently testable TDD cycles. Each cycle produces a shippable increment. Integration and documentation phases are explicitly planned.
+
+## Scope
+
+**In Scope:**
+- `mcp_server/tools/issue_tools.py`
+- `mcp_server/config/` — new config classes
+- `.st3/issues.yaml`, `.st3/scopes.yaml`, `.st3/milestones.yaml`, `.st3/contributors.yaml`
+- `.st3/labels.yaml` — cleanup (`status:*` removal, `parent:*` pattern, `type:chore`)
+- `.st3/git.yaml` — `issue_title_max_length` addition
+- `tests/unit/tools/test_issue_tools.py`
+- `tests/unit/mcp_server/integration/test_github.py`
+- `tests/unit/mcp_server/integration/test_all_tools.py`
+
+**Out of Scope:**
+- `get_issue` / `list_issues` alignment → issue #150
+- `create_branch` enrichment → issue #116
+- GitHub Projects integration
+- Retroactive issue title renaming (manual task)
+- Sync tooling for milestones/contributors
+
+## Prerequisites
+
+- Research complete → [docs/development/issue149/research.md](research.md)
+- `issues.yaml`, `scopes.yaml`, `milestones.yaml`, `contributors.yaml` do not yet exist
+- `labels.yaml` requires cleanup (cycle 2)
+
+## Summary
+
+The `create_issue` tool currently accepts free-form, unvalidated input. This plan divides the work into 6 TDD cycles plus integration and documentation phases. Cycle 1 establishes the config infrastructure. Cycles 2–6 incrementally build the new `CreateIssueInput` and `CreateIssueTool`. Each cycle closes with all quality gates passing before the next begins.
+
+---
+
+## Cycle Dependencies
+
+```
+Cycle 1 (config infra) ──────────────────────┐
+                                              ├─→ Cycle 3 (IssueBody) ──→ Cycle 4 (schema) ──→ Cycle 5 (label assembly)
+Cycle 2 (labels.yaml cleanup) ───────────────┘                                                       │
+                                                                                                      └──→ Cycle 6 (error handling)
+```
+
+---
+
+## Coding Standards Requirements (apply to every cycle)
+
+> These requirements derive from `docs/coding_standards/` and apply to **every** cycle. They are not repeated per cycle but must be applied consciously at each RED/GREEN/REFACTOR step.
+
+- **Scaffolding first:** All new Python files (`*_config.py`, `test_*.py`) are created via `scaffold_artifact` — never manually. Templates auto-generate module headers (`@layer`, `@dependencies`, `@responsibilities`), import structure, and class skeleton.
+- **Test functions:** All test functions have `-> None` return type (Gate 1 ANN rule).
+- **Fixture pattern:** Fixtures that inject other fixtures use `@pytest.fixture(name="x")` with a private function name `_x` (avoids W0621 name collision).
+- **Quality gate closure:** Every cycle closes by running `run_quality_gates` over all modified files: Ruff format → Ruff lint → type check → pytest → coverage ≥ 90%.
+- **`json_schema_extra`:** All Pydantic models exposed via MCP (tool inputs) must include at least 2 examples in `json_schema_extra`.
+
+---
+
+## TDD Cycles
+
+---
+
+### Cycle 1 — Config infrastructure: new YAML files + singleton classes
+
+**Goal:** Introduce `issues.yaml`, `scopes.yaml`, `milestones.yaml`, `contributors.yaml` and corresponding config classes following the `GitConfig.from_file()` singleton pattern.
+
+**Deliverables:**
+- `.st3/issues.yaml`
+- `.st3/scopes.yaml`
+- `.st3/milestones.yaml`
+- `.st3/contributors.yaml`
+- `mcp_server/config/issue_config.py`
+- `mcp_server/config/scope_config.py`
+- `mcp_server/config/milestone_config.py`
+- `mcp_server/config/contributor_config.py`
+- `tests/unit/config/test_issue_config.py`
+- `tests/unit/config/test_scope_config.py`
+- `tests/unit/config/test_milestone_config.py`
+- `tests/unit/config/test_contributor_config.py`
+
+**RED — Failing tests first:**
+> Create test files via `scaffold_artifact(artifact_type="test", ...)`. All test functions `-> None`. Fixtures use `@pytest.fixture(name="...")` with private name and a temporary YAML file (see pattern in `test_git_tools_config.py`).
+
+- `IssueConfig.from_file()` loads and validates the `issue_types` list
+- `IssueConfig` raises on unknown issue type
+- `IssueConfig.get_workflow(issue_type)` returns the correct workflow name
+- `IssueConfig.get_label(issue_type)` returns the correct `type:*` label (including `hotfix → type:bug`)
+- `IssueConfig` loads the `optional_label_inputs` section correctly
+- `ScopeConfig.from_file()` loads and validates scopes (names only, no labels)
+- `ScopeConfig.has_scope(name)` returns `True`/`False`
+- `MilestoneConfig.from_file()` loads (empty list is valid)
+- `MilestoneConfig.validate_milestone(title)` returns `True` when list is empty (permissive when unpopulated)
+- `ContributorConfig.from_file()` loads (empty list is valid)
+- `ContributorConfig.validate_assignee(login)` returns `True` when list is empty (permissive when unpopulated)
+
+**GREEN:**
+- Scaffold `.st3/issues.yaml`, `.st3/scopes.yaml`, `.st3/milestones.yaml`, `.st3/contributors.yaml` (YAML files)
+- Scaffold `mcp_server/config/issue_config.py` via `scaffold_artifact(artifact_type="component", ...)` — module header auto-generated
+- Same for `scope_config.py`, `milestone_config.py`, `contributor_config.py`
+- Implement `IssueConfig`, `ScopeConfig`, `MilestoneConfig`, `ContributorConfig` (fill in methods)
+- **Quality gates:** run `run_quality_gates` over all new files (Ruff format + lint + type check + pytest + coverage)
+
+---
+
+### Cycle 2 — `labels.yaml` cleanup
+
+**Goal:** Align `labels.yaml` with the new conventions: remove `status:*`, update the `parent:*` pattern, add `type:chore`.
+
+**Deliverables:**
+- `.st3/labels.yaml` (updated)
+- `tests/unit/config/test_labels_yaml_conventions.py`
+
+**RED:**
+> Create test file via `scaffold_artifact`. All test functions `-> None`.
+
+- `status:blocked`, `status:in-progress`, `status:needs-info`, `status:ready` are **not** present in `labels.yaml`
+- `parent:*` pattern is `^parent:\d+$` (not `^parent:issue-\d+$`)
+- `parent:*` example is `parent:91` (not `parent:issue-18`)
+- `type:chore` label exists in the TYPE section of `labels.yaml`
+
+**GREEN:**
+- Remove the `status:*` section from `.st3/labels.yaml`
+- Update the `label_patterns` entry: pattern and example
+- Add `type:chore` to the TYPE section
+- **Quality gates:** run `run_quality_gates` over `test_labels_yaml_conventions.py`
+
+---
+
+### Cycle 3 — `IssueBody` nested model + Jinja2 rendering
+
+**Goal:** Introduce `IssueBody` Pydantic model and verify that `CreateIssueTool` can render it to markdown via `issue.md.jinja2`.
+
+**Deliverables:**
+- `IssueBody` class in `mcp_server/tools/issue_tools.py`
+- `_render_body()` helper in `CreateIssueTool`
+- `tests/unit/tools/test_issue_body.py`
+
+**RED:**
+> Create test file via `scaffold_artifact`. All test functions `-> None`.
+
+- `IssueBody` requires the `problem` field
+- All optional fields default to `None`
+- Rendering `IssueBody` via `issue.md.jinja2` produces a `## Problem` section
+- Rendering with `expected`/`actual`/`context`/`steps_to_reproduce` produces the correct sections
+- Rendering with `related_docs: list[str]` produces a Related Documentation section (list of links/items)
+- Rendering with only `problem` produces minimal valid markdown
+
+**GREEN:**
+- Implement `IssueBody` in `mcp_server/tools/issue_tools.py` — add `json_schema_extra` with ≥ 2 examples (minimal body + full body)
+- Implement `_render_body(body: IssueBody) -> str` in `CreateIssueTool` via `JinjaRenderer`
+- **Quality gates:** run `run_quality_gates` over modified files (Ruff format + lint + type check + pytest)
+
+---
+
+### Cycle 4 — `CreateIssueInput` schema refactor
+
+**Goal:** Replace the current `CreateIssueInput` with the new schema: required `issue_type`, `title` (max 72 chars), `priority`, `scope`, `body` (`IssueBody`), and optional `is_epic`, `parent_issue`, `milestone`, `assignees`. Remove the `labels` field. Update all existing test call sites.
+
+**Deliverables:**
+- Updated `CreateIssueInput` in `mcp_server/tools/issue_tools.py`
+- `issue_title_max_length: 72` added to `.st3/git.yaml`
+- Updated `tests/unit/tools/test_issue_tools.py`
+- Updated `tests/unit/mcp_server/integration/test_all_tools.py`
+- Updated `tests/unit/mcp_server/integration/test_github.py`
+
+**RED:**
+- `issue_type` is required, validated against `IssueConfig`
+- Unknown `issue_type` raises `ValidationError` with a hint listing valid values
+- `title` is required, max 72 chars (from `git.yaml`)
+- `title` exceeding 72 chars raises `ValidationError`
+- `priority` is required, validated against `labels.yaml` `priority:*`
+- `scope` is required, validated against `ScopeConfig` (valid: `architecture`, `mcp-server`, `platform`, `tooling`, `workflow`, `documentation`)
+- `body` is required, must be an `IssueBody` instance
+- `is_epic` optional bool, default `False`
+- `parent_issue` optional, rejects values `< 1`
+- `milestone` optional, validated against `MilestoneConfig` (always valid when list is empty)
+- `assignees` optional list, each value validated against `ContributorConfig` (always valid when list is empty)
+- `CreateIssueInput(title=..., body="string")` raises `ValidationError` (breaking change confirmed)
+
+**GREEN:**
+- Refactor `CreateIssueInput` with new fields, `@field_validator`s, and `json_schema_extra` with ≥ 2 examples (minimal input + full input)
+- Add `issue_title_max_length: 72` to `.st3/git.yaml`
+- Update all three existing test files (replace call sites, add `-> None` where missing)
+- **Quality gates:** run `run_quality_gates` over all modified files (Ruff format + lint + type check + pytest + coverage)
+
+---
+
+### Cycle 5 — Label assembly in `CreateIssueTool.execute()`
+
+**Goal:** Implement internal label derivation: assemble the full label list from structured inputs before passing to `GitHubManager`. The tool no longer accepts or forwards free-form labels.
+
+**Deliverables:**
+- `_assemble_labels()` in `CreateIssueTool`
+- Updated `execute()` in `CreateIssueTool`
+- `tests/unit/tools/test_create_issue_label_assembly.py`
+
+**RED:**
+- `issue_type='feature'` → `type:feature` label
+- `issue_type='hotfix'` → `type:bug` label (not `type:hotfix`) — via `IssueConfig.get_label()`
+- `is_epic=True` → `type:epic` label, overrides `issue_type` label
+- `parent_issue=91` → `parent:91` label
+- `scope='tooling'` → `scope:tooling` label
+- `priority='medium'` → `priority:medium` label
+- Automatic `phase:*` label derived from the first workflow phase of the issue type
+- `body` is rendered to a markdown string before passing to `GitHubManager`
+- Tool forwards **no** free `labels` to `GitHubManager`
+
+**GREEN:**
+- Implement `_assemble_labels()` using `IssueConfig`, `ScopeConfig`, and `workflows.yaml` first-phase lookup
+- Wire `_assemble_labels()` and `_render_body()` into `execute()`
+- **Quality gates:** run `run_quality_gates` over all modified files (Ruff format + lint + type check + pytest + coverage)
+
+---
+
+### Cycle 6 — Error handling + ToolResult contract
+
+**Goal:** All validation errors and GitHub API errors produce `ToolResult.error()` with actionable messages. No raw exceptions leak to the caller.
+
+**Deliverables:**
+- Updated `execute()` error handling in `CreateIssueTool`
+- `tests/unit/tools/test_create_issue_errors.py`
+
+**RED:**
+- Pydantic `ValidationError` on unknown `issue_type` → `ToolResult.error` with hint about valid values
+- `ExecutionError` from `GitHubManager` → `ToolResult.error`
+- `JinjaRenderer` failure → `ToolResult.error` (no unhandled exception)
+- Milestone not in `milestones.yaml` → `ToolResult.error` before API call
+
+**GREEN:**
+- Add `try/except` in `execute()` for `ValidationError`, `ExecutionError`, and rendering failures
+- Error messages reference valid config values
+- **Quality gates:** run `run_quality_gates` over all modified files (Ruff format + lint + type check + pytest + coverage ≥ 90% full suite)
+
+---
+
+## Integration Phase
+
+> Goal: real-world validation against the live GitHub API. No unit tests — proof of correct tool integration.
+
+**Deliverables:**
+- `tests/integration/test_create_issue_e2e.py`
+- Manual verification script (or pytest mark `integration`) covering:
+  - Create issue with minimal input → correct issue visible on GitHub with the right labels
+  - Create issue with all options → all labels applied correctly
+  - Invalid input → tool refuses before GitHub API call
+  - Milestone validation → known milestone accepted, unknown refused
+
+**Approach:**
+- Tests run against a test repository (not production)
+- Marker: `@pytest.mark.integration` — excluded from standard CI run
+- Results documented manually in `docs/development/issue149/integration_smoke_test.md`
+
+---
+
+## Documentation Phase
+
+**Deliverables:**
+
+1. **`agent.md` §2.1 workflow sequence** — update `create_issue` call signature in the workflow table: `create_issue(issue_type, title, priority, scope, body)` (replaces current `create_issue(title, body, labels)`)
+2. **`agent.md` §2.1 example call** — add a concrete example with all required fields
+3. **Config reference docs** — brief description of each new `.st3/` config file added to `docs/reference/` (one entry per file: purpose, structure, who owns it)
+4. **Inline docstrings** — `CreateIssueInput`, `IssueBody`, `_assemble_labels()`, `_render_body()` fully documented
+5. **`labels.yaml` CHANGELOG** — record removal of `status:*` and `parent:*` pattern change
+
+---
+
+## Risks
+
+1. `JinjaRenderer` interface is scaffolding-oriented — may need adjustment for inline use inside a tool
+2. `milestones.yaml` and `contributors.yaml` start empty — validation is a no-op until populated; document this explicitly
+3. Breaking change on `body` field (`str → IssueBody`) affects all existing callers — coordinate update in cycle 4
+
+---
+
+## Related Docs
+
+- [docs/development/issue149/research.md](research.md)
+- `.st3/labels.yaml`, `.st3/workflows.yaml`
+- `mcp_server/config/git_config.py` (singleton pattern reference)
+- `mcp_server/tools/git_tools.py` (validator pattern reference)
+- `mcp_server/scaffolding/templates/concrete/issue.md.jinja2`
+- `docs/coding_standards/CODE_STYLE.md`
+- Issue #150 (consumer), Issue #116 (consumer)

--- a/docs/development/issue149/research.md
+++ b/docs/development/issue149/research.md
@@ -1,0 +1,247 @@
+<!-- docs/development/issue149/research.md -->
+<!-- template=research version=1.0 created=2026-02-18 updated=2026-02-18 -->
+# Research — Issue #149: Redesign `create_issue` Tool
+
+**Status:** complete
+**Version:** 1.1
+**Last Updated:** 2026-02-18
+
+---
+
+## Purpose
+
+Map the current `create_issue` implementation, identify all gaps versus desired conventions, and define the full set of changes needed including new config infrastructure.
+
+## Scope
+
+**In Scope:**
+- `mcp_server/tools/issue_tools.py` — `CreateIssueInput`, `CreateIssueTool`
+- `mcp_server/managers/github_manager.py` — `create_issue()`
+- `.st3/labels.yaml` — `status:*` removal, `parent:*` pattern change
+- `.st3/workflows.yaml` — first-phase derivation per issue type
+- `mcp_server/scaffolding/templates/concrete/issue.md.jinja2` — body rendering
+- All test files that instantiate `CreateIssueInput`
+
+**Out of Scope:**
+- `get_issue` / `list_issues` alignment → issue #150
+- `create_branch` issue_number param → issue #116
+- GitHub Projects integration
+- Retroactive issue title renaming (manual task, no tooling)
+
+## Prerequisites
+
+- `.st3/labels.yaml` (existing)
+- `.st3/workflows.yaml` (existing)
+- `mcp_server/scaffolding/templates/concrete/issue.md.jinja2` (existing, tested)
+- New files: `issues.yaml`, `scopes.yaml`, `milestones.yaml`, `contributors.yaml` (created in this issue)
+
+---
+
+## Problem Statement
+
+The current `create_issue` tool accepts a free-form `title` (no length limit, no prefix enforcement), unvalidated `labels: list[str]`, a raw string `body` with no structure, and has no awareness of issue types, scopes, milestones, or assignees beyond forwarding them to the GitHub API unchecked. This makes automated issue creation convention-blind.
+
+---
+
+## Findings
+
+### Current `CreateIssueInput` Schema
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `title` | `str` | ✅ | none |
+| `body` | `str` | ✅ | none |
+| `labels` | `list[str] \| None` | ❌ | none |
+| `milestone` | `int \| None` | ❌ | none |
+| `assignees` | `list[str] \| None` | ❌ | none |
+
+### Call Sites (breakage surface)
+
+All existing call sites use only `title` + `body`. All three break when `issue_type`, `scope`, and `priority` become required fields:
+
+| File | Call |
+|------|------|
+| `tests/unit/tools/test_issue_tools.py:31` | `CreateIssueInput(title="New Issue", body="Description")` |
+| `tests/unit/mcp_server/integration/test_all_tools.py:284` | `CreateIssueInput(title=..., body=...)` |
+| `tests/unit/mcp_server/integration/test_github.py:48` | `CreateIssueInput(title="New Issue", body="Body")` |
+
+No production code outside `issue_tools.py` instantiates `CreateIssueInput` directly.
+
+### Infrastructure to Reuse
+
+| Component | Reuse |
+|-----------|-------|
+| `GitConfig.from_file()` singleton | Replicate for `IssueConfig`, `ScopeConfig`, `MilestoneConfig`, `ContributorConfig` |
+| `@field_validator("branch_type")` in `CreateBranchInput` | Same pattern for `issue_type`, `scope`, `priority` |
+| `issue.md.jinja2` template | Existing, tested — render `IssueBody` via this template |
+| `JinjaRenderer` in `mcp_server/scaffolding/` | Reuse for body rendering in `execute()` |
+
+---
+
+## New Config File Schemas
+
+### `.st3/issues.yaml`
+
+```yaml
+version: "1.0"
+issue_types:
+  - name: feature
+    workflow: feature
+    label: "type:feature"
+  - name: bug
+    workflow: bug
+    label: "type:bug"
+  - name: hotfix
+    workflow: hotfix
+    label: "type:bug"
+  - name: refactor
+    workflow: refactor
+    label: "type:refactor"
+  - name: docs
+    workflow: docs
+    label: "type:docs"
+  - name: chore
+    workflow: feature
+    label: "type:chore"
+  - name: epic
+    workflow: epic
+    label: "type:epic"
+required_label_categories:
+  - type
+  - priority
+  - scope
+
+optional_label_inputs:
+  is_epic:
+    type: bool
+    label: "type:epic"
+    behavior: "Overrides type:* label from issue_type"
+  parent_issue:
+    type: int
+    label_pattern: "parent:{value}"
+    description: "Applies parent:{issue_number} label (e.g., parent:91)"
+```
+
+Issue types are aligned with Conventional Commits (`git.yaml`):
+`feature=feat, bug=fix, hotfix=fix(urgent), refactor=refactor, docs=docs, chore=chore, epic=container`
+
+Dropped: `enhancement` (ambiguous — use feature or refactor), `technical-debt` + `housekeeping` (merged into `chore`).
+
+Note: `hotfix` maps to `label: "type:bug"` (not `type:hotfix`) — this non-obvious mapping is the reason the `label` field exists in `issues.yaml`. For scopes, no such exception exists, so no label field appears there.
+
+### `.st3/scopes.yaml`
+
+```yaml
+version: "1.0"
+scopes:
+  - architecture
+  - mcp-server
+  - platform
+  - tooling
+  - workflow
+  - documentation
+```
+
+Name `scopes.yaml` (not `projects.yaml`) — avoids confusion with GitHub Projects.
+
+**No `label` field in `scopes.yaml`.** `labels.yaml` is SSOT for label existence (name, colour, description). The tool derives `scope:{name}` by convention — no explicit mapping needed. Compare: `git.yaml` only has `branch_types: [feature, fix, ...]` without label references. Adding a `label` field would violate SSOT and duplicate `labels.yaml`.
+
+**Exception in `issues.yaml`:** the `label` field is justified there because `hotfix` maps to `type:bug` (not `type:hotfix`). No such exceptions exist for scopes, so the field is omitted.
+
+### `.st3/milestones.yaml`
+
+```yaml
+version: "1.0"
+milestones: []
+# { number: int, title: str, state: open|closed }
+```
+
+### `.st3/contributors.yaml`
+
+```yaml
+version: "1.0"
+contributors: []
+# { login: str, name: str }
+```
+
+---
+
+## New `CreateIssueInput` Schema
+
+| Field | Type | Required | Validation | Effect |
+|-------|------|----------|------------|--------|
+| `issue_type` | `str` | ✅ | `issues.yaml` | → `type:*` label + initial `phase:*` label |
+| `title` | `str` | ✅ | max 72 chars (`git.yaml`) | — |
+| `priority` | `str` | ✅ | `labels.yaml` `priority:*` | → `priority:*` label |
+| `scope` | `str` | ✅ | `scopes.yaml` | → `scope:*` label |
+| `body` | `IssueBody` | ✅ | nested model, rendered via Jinja2 | — |
+| `is_epic` | `bool` | ❌ | — | overrides `issue_type` to `type:epic` internally |
+| `parent_issue` | `int \| None` | ❌ | `>= 1` | → `parent:{n}` label |
+| `milestone` | `str \| None` | ❌ | `milestones.yaml` | — |
+| `assignees` | `list[str] \| None` | ❌ | each value against `contributors.yaml` | — |
+
+**Removed:** `labels` (free field) — fully derived from the structured fields above.
+
+## `IssueBody` Nested Model
+
+```python
+class IssueBody(BaseModel):
+    problem: str                           # required
+    expected: str | None = None
+    actual: str | None = None
+    context: str | None = None
+    steps_to_reproduce: str | None = None
+    related_docs: list[str] | None = None
+```
+
+Rendered via `issue.md.jinja2` in `CreateIssueTool.execute()` before forwarding to `GitHubManager`.
+
+---
+
+## Label Assembly Logic (internal to `execute()`)
+
+```
+1. issue_type → issues.yaml lookup → get_label(issue_type) → type:* label
+2. is_epic=True → override: type:epic label (replaces type:* from step 1)
+3. scope → scopes.yaml lookup → scope:* label
+4. priority → direct → priority:* label
+5. parent_issue=N → parent:N label
+6. phase → first phase of workflow from issues.yaml → workflows.yaml → phase:* label (automatic, never exposed to caller)
+```
+
+---
+
+## `labels.yaml` Changes Required
+
+- Remove `status:*` category entirely (4 labels: `status:blocked`, `status:in-progress`, `status:needs-info`, `status:ready`) — phase:* covers workflow state
+- Update `parent:*` pattern: `^parent:issue-\d+$` → `^parent:\d+$` (example: `parent:91`)
+- Add `type:chore` label to the TYPE section
+
+---
+
+## Validator Patterns
+
+All config-driven validators follow the `GitConfig.from_file()` singleton pattern and are implemented as synchronous `@field_validator` methods. Milestone and assignee validation happens in `execute()` (pre-API-call, against local yaml).
+
+---
+
+## Open Questions
+
+1. Milestone validation: only against `milestones.yaml` (local, no live API call) — accepted.
+2. `is_epic=True` overrides `issue_type` to `epic` internally — no dual type labels.
+3. `contributors.yaml` initially populated manually; sync tooling is a future enhancement.
+
+---
+
+## References
+
+- Issue #149
+- Issue #116 (consumer of `get_issue` — depends on #150)
+- Issue #150 (consumer of new label structure)
+- `.st3/labels.yaml`, `.st3/workflows.yaml`
+- `mcp_server/tools/issue_tools.py`
+- `mcp_server/managers/github_manager.py`
+- `mcp_server/scaffolding/templates/concrete/issue.md.jinja2`
+- `mcp_server/tools/git_tools.py` (validator pattern reference)
+- `mcp_server/config/git_config.py` (singleton config pattern reference)
+- `docs/coding_standards/CODE_STYLE.md`

--- a/docs/reference/mcp/MCP_TOOLS.md
+++ b/docs/reference/mcp/MCP_TOOLS.md
@@ -45,7 +45,7 @@ Full CRUD for GitHub issues with filtering and updates.
 
 | Tool | Purpose | Parameters | Returns |
 |------|---------|------------|---------|
-| **CreateIssueTool** | Create new issue | `title`, `body`, `labels` (optional), `milestone_number` (optional), `assignees` (optional) | Issue number, URL |
+| **CreateIssueTool** | Create new issue | **Required:** `issue_type` (feature/bug/hotfix/refactor/docs/chore/epic), `title`, `priority` (critical/high/medium/low/triage), `scope` (architecture/mcp-server/platform/tooling/workflow/documentation), `body` ({`problem`, `expected`?, `actual`?, `context`?, `steps_to_reproduce`?, `related_docs`?}) · **Optional:** `is_epic` (bool), `parent_issue` (int), `milestone` (title string), `assignees` (list) | Issue number, URL |
 | **ListIssuesTool** | List issues with filters | `state` (open/closed/all), `labels` (optional list) | Formatted list with numbers, titles, labels |
 | **GetIssueTool** | Get issue details | `issue_number` | Full issue data, acceptance criteria extracted |
 | **CloseIssueTool** | Close issue | `issue_number`, `comment` (optional) | Confirmation message |
@@ -292,8 +292,7 @@ File: `.vscode/mcp.json`
 4. close_issue issue_number=47 comment="Fixed in PR #124"
 ```
 
-Labels are assembled automatically from `issue_type`, `priority`, `scope` and optional flags
-(`is_epic`, `parent_issue`). Do not pass a `labels` list — the tool enforces label policy from
+Labels are assembled automatically from the required and optional fields. Do not pass a `labels` list — the tool enforces label policy from
 `.st3/issues.yaml` and `.st3/labels.yaml`. `body` is a structured object (not a free-form string);
 `problem` is the only required field.
 

--- a/docs/reference/mcp/MCP_TOOLS.md
+++ b/docs/reference/mcp/MCP_TOOLS.md
@@ -276,19 +276,33 @@ File: `.vscode/mcp.json`
 ### Issue Lifecycle Management
 
 ```
-1. create_issue title="Bug: Memory leak" body="..." labels=["bug", "critical"]
-   → Returns: issue_number=47
+1. create_issue(
+     issue_type="bug",
+     title="Bug: Memory leak in cache layer",
+     priority="high",
+     scope="mcp-server",
+     body={"problem": "Memory grows unbounded after 1h of operation.",
+           "steps_to_reproduce": "1. Start server\n2. Run 1000 requests",
+           "expected": "Stable memory usage", "actual": "RSS grows to 2GB"},
+     milestone="v1.0.0"
+   )
+   → Returns: Created issue #47: Bug: Memory leak in cache layer
 2. update_issue issue_number=47 state=in-progress
 3. (Create PR linked to issue)
 4. close_issue issue_number=47 comment="Fixed in PR #124"
 ```
 
+Labels are assembled automatically from `issue_type`, `priority`, `scope` and optional flags
+(`is_epic`, `parent_issue`). Do not pass a `labels` list — the tool enforces label policy from
+`.st3/issues.yaml` and `.st3/labels.yaml`. `body` is a structured object (not a free-form string);
+`problem` is the only required field.
+
 ### Release Milestone Workflow
 
 ```
 1. create_milestone title="v1.0.0" description="First stable release" due_on="2025-12-31T00:00:00Z"
-2. create_issue title="Feature A" milestone_number=1
-3. create_issue title="Feature B" milestone_number=1
+2. create_issue issue_type="feature" title="Feature A" priority="medium" scope="platform" body={"problem": "..."} milestone="v1.0.0"
+3. create_issue issue_type="feature" title="Feature B" priority="medium" scope="platform" body={"problem": "..."} milestone="v1.0.0"
 4. (As features complete)
 5. update_issue issue_number=X state=closed
 6. (When all done)

--- a/mcp_server/config/contributor_config.py
+++ b/mcp_server/config/contributor_config.py
@@ -1,0 +1,89 @@
+"""Contributor configuration model (Issue #149).
+
+Purpose: Config-driven assignee validation — permissive when list empty.
+Source: .st3/contributors.yaml
+Pattern: Singleton with ClassVar (matches GitConfig pattern)
+"""
+
+from pathlib import Path
+from typing import ClassVar, Optional
+
+import yaml
+from pydantic import BaseModel
+
+
+class ContributorEntry(BaseModel):
+    """Single contributor entry from contributors.yaml."""
+
+    login: str
+    name: str | None = None
+
+
+class ContributorConfig(BaseModel):
+    """Contributor validation configuration.
+
+    Validates assignee logins against known contributors.
+    Permissive (always passes) when contributors list is empty — this is
+    intentional: the file starts empty and is populated manually.
+    Loaded from .st3/contributors.yaml. Singleton per process.
+    """
+
+    singleton_instance: ClassVar[Optional["ContributorConfig"]] = None
+
+    version: str
+    contributors: list[ContributorEntry] = []
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def validate_assignee(self, login: str) -> bool:
+        """Return True if login is a known contributor, or if list is empty (permissive).
+
+        Args:
+            login: GitHub login to check (case-sensitive).
+
+        Returns:
+            True when list is empty (permissive) or login matches a known contributor.
+        """
+        if not self.contributors:
+            return True
+        return any(c.login == login for c in self.contributors)
+
+    # ------------------------------------------------------------------
+    # Singleton factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_file(cls, path: str = ".st3/contributors.yaml") -> "ContributorConfig":
+        """Load config from YAML file (singleton pattern).
+
+        Args:
+            path: Path to contributors.yaml file.
+
+        Returns:
+            ContributorConfig singleton instance.
+
+        Raises:
+            FileNotFoundError: If contributors.yaml doesn't exist.
+        """
+        if cls.singleton_instance is not None:
+            return cls.singleton_instance
+
+        config_path = Path(path)
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Contributor config not found: {path}. "
+                f"Create .st3/contributors.yaml (empty list is valid)."
+            )
+
+        with open(config_path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+
+        cls.singleton_instance = cls(**data)
+        return cls.singleton_instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset singleton (for testing only)."""
+        cls.singleton_instance = None

--- a/mcp_server/config/git_config.py
+++ b/mcp_server/config/git_config.py
@@ -88,6 +88,11 @@ class GitConfig(BaseModel):
         default="main", description="Default base branch for PR creation"
     )
 
+    # Convention #12: Issue title maximum length (Issue #149)
+    issue_title_max_length: int = Field(
+        default=72, description="Maximum allowed length for issue titles", ge=1
+    )
+
     # Compiled regex (cached after validation)
     _compiled_pattern: ClassVar[re.Pattern[str] | None] = None
 

--- a/mcp_server/config/issue_config.py
+++ b/mcp_server/config/issue_config.py
@@ -1,0 +1,128 @@
+"""Issue configuration model (Issue #149).
+
+Purpose: Config-driven issue type conventions — maps issue_type to workflow and type:* label.
+Source: .st3/issues.yaml
+Pattern: Singleton with ClassVar (matches GitConfig pattern)
+"""
+
+from pathlib import Path
+from typing import Any, ClassVar, Optional
+
+import yaml
+from pydantic import BaseModel
+
+
+class IssueTypeEntry(BaseModel):
+    """Single issue type entry from issues.yaml."""
+
+    name: str
+    workflow: str
+    label: str  # e.g. "type:bug" — hotfix maps to "type:bug", not "type:hotfix"
+
+
+class IssueConfig(BaseModel):
+    """Issue conventions configuration.
+
+    Maps issue types to workflows and type:* labels.
+    Loaded from .st3/issues.yaml. Singleton per process.
+    """
+
+    singleton_instance: ClassVar[Optional["IssueConfig"]] = None
+
+    version: str
+    issue_types: list[IssueTypeEntry]
+    required_label_categories: list[str] = []
+    optional_label_inputs: dict[str, Any] = {}
+
+    # Internal lookup built after validation
+    _index: ClassVar[dict[str, IssueTypeEntry]] = {}
+
+    def model_post_init(self, __context: Any) -> None:  # noqa: ANN401
+        """Build name → entry lookup index."""
+        IssueConfig._index = {entry.name: entry for entry in self.issue_types}
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def get_workflow(self, issue_type: str) -> str:
+        """Return workflow name for the given issue type.
+
+        Args:
+            issue_type: Issue type name (e.g. "feature", "hotfix").
+
+        Returns:
+            Workflow name (e.g. "feature", "hotfix").
+
+        Raises:
+            ValueError: If issue_type is not in issues.yaml.
+        """
+        entry = IssueConfig._index.get(issue_type)
+        if entry is None:
+            valid = sorted(IssueConfig._index)
+            raise ValueError(f"Unknown issue type: '{issue_type}'. Valid types: {valid}")
+        return entry.workflow
+
+    def get_label(self, issue_type: str) -> str:
+        """Return the type:* label for the given issue type.
+
+        Note: 'hotfix' returns 'type:bug' (not 'type:hotfix').
+
+        Args:
+            issue_type: Issue type name.
+
+        Returns:
+            Label string (e.g. "type:bug", "type:feature").
+
+        Raises:
+            ValueError: If issue_type is not in issues.yaml.
+        """
+        entry = IssueConfig._index.get(issue_type)
+        if entry is None:
+            valid = sorted(IssueConfig._index)
+            raise ValueError(f"Unknown issue type: '{issue_type}'. Valid types: {valid}")
+        return entry.label
+
+    def has_issue_type(self, issue_type: str) -> bool:
+        """Return True if the issue type is defined in issues.yaml."""
+        return issue_type in IssueConfig._index
+
+    # ------------------------------------------------------------------
+    # Singleton factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_file(cls, path: str = ".st3/issues.yaml") -> "IssueConfig":
+        """Load config from YAML file (singleton pattern).
+
+        Args:
+            path: Path to issues.yaml file.
+
+        Returns:
+            IssueConfig singleton instance.
+
+        Raises:
+            FileNotFoundError: If issues.yaml doesn't exist.
+            ValueError: If YAML is invalid or validation fails.
+        """
+        if cls.singleton_instance is not None:
+            return cls.singleton_instance
+
+        config_path = Path(path)
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Issue config not found: {path}. "
+                f"Create .st3/issues.yaml with issue type conventions."
+            )
+
+        with open(config_path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+
+        cls.singleton_instance = cls(**data)
+        return cls.singleton_instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset singleton (for testing only)."""
+        cls.singleton_instance = None
+        cls._index = {}

--- a/mcp_server/config/milestone_config.py
+++ b/mcp_server/config/milestone_config.py
@@ -1,0 +1,90 @@
+"""Milestone configuration model (Issue #149).
+
+Purpose: Config-driven milestone validation — permissive when list empty.
+Source: .st3/milestones.yaml
+Pattern: Singleton with ClassVar (matches GitConfig pattern)
+"""
+
+from pathlib import Path
+from typing import ClassVar, Optional
+
+import yaml
+from pydantic import BaseModel
+
+
+class MilestoneEntry(BaseModel):
+    """Single milestone entry from milestones.yaml."""
+
+    number: int
+    title: str
+    state: str = "open"
+
+
+class MilestoneConfig(BaseModel):
+    """Milestone validation configuration.
+
+    Validates milestone titles against known milestones.
+    Permissive (always passes) when milestones list is empty — this is
+    intentional: the file starts empty and is populated manually.
+    Loaded from .st3/milestones.yaml. Singleton per process.
+    """
+
+    singleton_instance: ClassVar[Optional["MilestoneConfig"]] = None
+
+    version: str
+    milestones: list[MilestoneEntry] = []
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def validate_milestone(self, title: str) -> bool:
+        """Return True if title is a known milestone, or if list is empty (permissive).
+
+        Args:
+            title: Milestone title to check.
+
+        Returns:
+            True when list is empty (permissive) or title matches a known milestone.
+        """
+        if not self.milestones:
+            return True
+        return any(m.title == title for m in self.milestones)
+
+    # ------------------------------------------------------------------
+    # Singleton factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_file(cls, path: str = ".st3/milestones.yaml") -> "MilestoneConfig":
+        """Load config from YAML file (singleton pattern).
+
+        Args:
+            path: Path to milestones.yaml file.
+
+        Returns:
+            MilestoneConfig singleton instance.
+
+        Raises:
+            FileNotFoundError: If milestones.yaml doesn't exist.
+        """
+        if cls.singleton_instance is not None:
+            return cls.singleton_instance
+
+        config_path = Path(path)
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Milestone config not found: {path}. "
+                f"Create .st3/milestones.yaml (empty list is valid)."
+            )
+
+        with open(config_path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+
+        cls.singleton_instance = cls(**data)
+        return cls.singleton_instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset singleton (for testing only)."""
+        cls.singleton_instance = None

--- a/mcp_server/config/scope_config.py
+++ b/mcp_server/config/scope_config.py
@@ -1,0 +1,79 @@
+"""Scope configuration model (Issue #149).
+
+Purpose: Config-driven scope validation — flat list of valid scope names.
+Source: .st3/scopes.yaml
+Pattern: Singleton with ClassVar (matches GitConfig pattern)
+"""
+
+from pathlib import Path
+from typing import ClassVar, Optional
+
+import yaml
+from pydantic import BaseModel
+
+
+class ScopeConfig(BaseModel):
+    """Scope conventions configuration.
+
+    Holds the list of valid scope names. Labels are derived by convention
+    as 'scope:{name}' — no explicit label field is needed here.
+    Loaded from .st3/scopes.yaml. Singleton per process.
+    """
+
+    singleton_instance: ClassVar[Optional["ScopeConfig"]] = None
+
+    version: str
+    scopes: list[str]
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def has_scope(self, name: str) -> bool:
+        """Return True if name is a valid scope (case-sensitive).
+
+        Args:
+            name: Scope name to validate.
+
+        Returns:
+            True if name is in the scopes list.
+        """
+        return name in self.scopes
+
+    # ------------------------------------------------------------------
+    # Singleton factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_file(cls, path: str = ".st3/scopes.yaml") -> "ScopeConfig":
+        """Load config from YAML file (singleton pattern).
+
+        Args:
+            path: Path to scopes.yaml file.
+
+        Returns:
+            ScopeConfig singleton instance.
+
+        Raises:
+            FileNotFoundError: If scopes.yaml doesn't exist.
+            ValueError: If YAML is invalid or validation fails.
+        """
+        if cls.singleton_instance is not None:
+            return cls.singleton_instance
+
+        config_path = Path(path)
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Scope config not found: {path}. Create .st3/scopes.yaml with valid scope names."
+            )
+
+        with open(config_path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+
+        cls.singleton_instance = cls(**data)
+        return cls.singleton_instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset singleton (for testing only)."""
+        cls.singleton_instance = None

--- a/mcp_server/config/workflow_config.py
+++ b/mcp_server/config/workflow_config.py
@@ -1,0 +1,97 @@
+"""Workflow configuration model (Issue #149).
+
+Purpose: Load workflows.yaml to resolve first workflow phase for phase:* label assembly.
+Source: .st3/workflows.yaml
+Pattern: Singleton with ClassVar (matches GitConfig pattern)
+"""
+
+from pathlib import Path
+from typing import ClassVar, Optional
+
+import yaml
+from pydantic import BaseModel
+
+
+class WorkflowEntry(BaseModel):
+    """Single workflow definition from workflows.yaml."""
+
+    name: str
+    description: str = ""
+    default_execution_mode: str = "interactive"
+    phases: list[str]
+
+    def first_phase(self) -> str:
+        """Return the first phase of this workflow.
+
+        Raises:
+            ValueError: If the workflow has no phases.
+        """
+        if not self.phases:
+            raise ValueError(f"Workflow '{self.name}' has no phases defined.")
+        return self.phases[0]
+
+
+class WorkflowConfig(BaseModel):
+    """Workflow configuration loaded from workflows.yaml.
+
+    Used to resolve the first phase of a workflow for `phase:*` label assembly.
+    Singleton per process.
+    """
+
+    singleton_instance: ClassVar[Optional["WorkflowConfig"]] = None
+
+    version: str
+    phase_source: str = ""
+    workflows: dict[str, WorkflowEntry]
+
+    def get_first_phase(self, workflow_name: str) -> str:
+        """Return the first phase for the given workflow name.
+
+        Args:
+            workflow_name: Workflow name (e.g. "feature", "hotfix").
+
+        Returns:
+            First phase string (e.g. "research", "tdd").
+
+        Raises:
+            ValueError: If the workflow is not defined in workflows.yaml.
+        """
+        entry = self.workflows.get(workflow_name)
+        if entry is None:
+            valid = sorted(self.workflows)
+            raise ValueError(f"Unknown workflow: '{workflow_name}'. Valid workflows: {valid}")
+        return entry.first_phase()
+
+    def has_workflow(self, workflow_name: str) -> bool:
+        """Return True if a workflow with the given name is defined."""
+        return workflow_name in self.workflows
+
+    @classmethod
+    def from_file(cls, path: str = ".st3/workflows.yaml") -> "WorkflowConfig":
+        """Load config from YAML file (singleton pattern).
+
+        Args:
+            path: Path to workflows.yaml file.
+
+        Returns:
+            WorkflowConfig singleton instance.
+        """
+        if cls.singleton_instance is not None:
+            return cls.singleton_instance
+
+        resolved = Path(path)
+        raw = yaml.safe_load(resolved.read_text(encoding="utf-8"))
+
+        # workflows.yaml stores entries as dicts — normalise each into WorkflowEntry
+        workflows_raw: dict = raw.get("workflows", {})
+        workflows = {k: WorkflowEntry(**v) for k, v in workflows_raw.items()}
+
+        instance = cls.model_validate(
+            {
+                "version": raw.get("version", "1.0"),
+                "phase_source": raw.get("phase_source", ""),
+                "workflows": workflows,
+            }
+        )
+        cls.singleton_instance = instance
+        return instance

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,4 +1,5 @@
 """MCP Server Entrypoint."""
+
 import asyncio
 import sys
 import time
@@ -160,8 +161,7 @@ class MCPServer:
             # Scaffold tools (unified artifact scaffolding)
             ScaffoldArtifactTool(
                 manager=ArtifactManager(
-                    workspace_root=workspace_root,
-                    template_registry=self.template_registry
+                    workspace_root=workspace_root, template_registry=self.template_registry
                 )
             ),
             # Discovery tools
@@ -173,36 +173,40 @@ class MCPServer:
         github_token = settings.github.token
         if github_token:
             self.resources.append(GitHubIssuesResource())
-            self.tools.extend([
-                # GitHub Issue tools
-                CreateIssueTool(),
-                ListIssuesTool(),
-                GetIssueTool(),
-                CloseIssueTool(),
-                UpdateIssueTool(),
-                # PR and Label tools (require token at init time)
-                CreatePRTool(),
-                ListPRsTool(),
-                MergePRTool(),
-                AddLabelsTool(),
-                ListLabelsTool(),
-                CreateLabelTool(),
-                DeleteLabelTool(),
-                RemoveLabelsTool(),
-                ListMilestonesTool(),
-                CreateMilestoneTool(),
-                CloseMilestoneTool(),
-            ])
+            self.tools.extend(
+                [
+                    # GitHub Issue tools
+                    CreateIssueTool(),
+                    ListIssuesTool(),
+                    GetIssueTool(),
+                    CloseIssueTool(),
+                    UpdateIssueTool(),
+                    # PR and Label tools (require token at init time)
+                    CreatePRTool(),
+                    ListPRsTool(),
+                    MergePRTool(),
+                    AddLabelsTool(),
+                    ListLabelsTool(),
+                    CreateLabelTool(),
+                    DeleteLabelTool(),
+                    RemoveLabelsTool(),
+                    ListMilestonesTool(),
+                    CreateMilestoneTool(),
+                    CloseMilestoneTool(),
+                ]
+            )
             logger.info("GitHub integration enabled")
         else:
             # Register issue tools without token so schemas are available; execution will error.
-            self.tools.extend([
-                CreateIssueTool(),
-                ListIssuesTool(),
-                GetIssueTool(),
-                CloseIssueTool(),
-                UpdateIssueTool(),
-            ])
+            self.tools.extend(
+                [
+                    CreateIssueTool(),
+                    ListIssuesTool(),
+                    GetIssueTool(),
+                    CloseIssueTool(),
+                    UpdateIssueTool(),
+                ]
+            )
             logger.info(
                 "GitHub token not configured - GitHub issue tools available but will "
                 "return error on use. Set GITHUB_TOKEN to enable full functionality."
@@ -211,11 +215,7 @@ class MCPServer:
         self.setup_handlers()
 
     def _validate_tool_arguments(
-        self,
-        tool: BaseTool,
-        arguments: dict[str, Any] | None,
-        call_id: str,
-        name: str
+        self, tool: BaseTool, arguments: dict[str, Any] | None, call_id: str, name: str
     ) -> BaseModel | dict[str, Any] | list[TextContent | ImageContent | EmbeddedResource]:
         """Validate tool arguments against args_model.
 
@@ -230,38 +230,41 @@ class MCPServer:
         model_cls = cast(type[BaseModel], tool.args_model)
         logger.debug(
             "Validating tool arguments",
-            extra={"props": {
-                "call_id": call_id,
-                "tool_name": name,
-                "model": model_cls.__name__,
-            }}
+            extra={
+                "props": {
+                    "call_id": call_id,
+                    "tool_name": name,
+                    "model": model_cls.__name__,
+                }
+            },
         )
         try:
             model_validated = model_cls(**(arguments or {}))
             logger.debug(
                 "Arguments validated successfully",
-                extra={"props": {
-                    "call_id": call_id,
-                    "tool_name": name,
-                }}
+                extra={
+                    "props": {
+                        "call_id": call_id,
+                        "tool_name": name,
+                    }
+                },
             )
             return model_validated
         except ValidationError as validation_error:
             logger.warning(
                 "Argument validation failed: %s",
                 validation_error,
-                extra={"props": {
-                    "call_id": call_id,
-                    "tool_name": name,
-                    "model": model_cls.__name__,
-                    "arguments": arguments,
-                }}
+                extra={
+                    "props": {
+                        "call_id": call_id,
+                        "tool_name": name,
+                        "model": model_cls.__name__,
+                        "arguments": arguments,
+                    }
+                },
             )
             error_details = str(validation_error)
-            return [TextContent(
-                type="text",
-                text=f"Invalid input for {name}: {error_details}"
-            )]
+            return [TextContent(type="text", text=f"Invalid input for {name}: {error_details}")]
 
     @staticmethod
     def _augment_text_with_error_metadata(text: str, result: ToolResult) -> str:
@@ -278,8 +281,7 @@ class MCPServer:
         return text
 
     def _convert_tool_result_to_content(
-        self,
-        result: ToolResult
+        self, result: ToolResult
     ) -> list[TextContent | ImageContent | EmbeddedResource]:
         """Convert ToolResult to MCP content list."""
         response_content: list[TextContent | ImageContent | EmbeddedResource] = []
@@ -290,16 +292,13 @@ class MCPServer:
                 text = self._augment_text_with_error_metadata(text, result)
                 response_content.append(TextContent(type="text", text=text))
             elif content.get("type") == "image":
-                response_content.append(ImageContent(
-                    type="image",
-                    data=content["data"],
-                    mimeType=content["mimeType"]
-                ))
+                response_content.append(
+                    ImageContent(type="image", data=content["data"], mimeType=content["mimeType"])
+                )
             elif content.get("type") == "resource":
-                response_content.append(EmbeddedResource(
-                    type="resource",
-                    resource=content["resource"]
-                ))
+                response_content.append(
+                    EmbeddedResource(type="resource", resource=content["resource"])
+                )
 
         return response_content
 
@@ -313,7 +312,7 @@ class MCPServer:
                     uri=AnyUrl(r.uri_pattern),
                     name=r.uri_pattern.rsplit("/", maxsplit=1)[-1],
                     description=r.description,
-                    mimeType=r.mime_type
+                    mimeType=r.mime_type,
                 )
                 for r in self.resources
             ]
@@ -328,18 +327,13 @@ class MCPServer:
         @self.server.list_tools()  # type: ignore[no-untyped-call, untyped-decorator]
         async def handle_list_tools() -> list[Tool]:
             return [
-                Tool(
-                    name=t.name,
-                    description=t.description,
-                    inputSchema=t.input_schema
-                )
+                Tool(name=t.name, description=t.description, inputSchema=t.input_schema)
                 for t in self.tools
             ]
 
         @self.server.call_tool()  # type: ignore[untyped-decorator]
         async def handle_call_tool(
-            name: str,
-            arguments: dict[str, Any] | None
+            name: str, arguments: dict[str, Any] | None
         ) -> list[TextContent | ImageContent | EmbeddedResource]:
             call_id = uuid.uuid4().hex
             start_time = time.perf_counter()
@@ -347,20 +341,20 @@ class MCPServer:
 
             logger.debug(
                 "Tool call received",
-                extra={"props": {
-                    "call_id": call_id,
-                    "tool_name": name,
-                    "argument_keys": argument_keys,
-                }}
+                extra={
+                    "props": {
+                        "call_id": call_id,
+                        "tool_name": name,
+                        "argument_keys": argument_keys,
+                    }
+                },
             )
 
             for tool in self.tools:
                 if tool.name == name:
                     try:
                         # Validate arguments
-                        validated = self._validate_tool_arguments(
-                            tool, arguments, call_id, name
-                        )
+                        validated = self._validate_tool_arguments(tool, arguments, call_id, name)
                         # Early return if validation failed
                         if isinstance(validated, list):
                             return validated
@@ -375,22 +369,26 @@ class MCPServer:
 
                         logger.debug(
                             "Tool call completed",
-                            extra={"props": {
-                                "call_id": call_id,
-                                "tool_name": name,
-                                "duration_ms": duration_ms,
-                            }}
+                            extra={
+                                "props": {
+                                    "call_id": call_id,
+                                    "tool_name": name,
+                                    "duration_ms": duration_ms,
+                                }
+                            },
                         )
                         return response_content
                     except asyncio.CancelledError:
                         duration_ms = (time.perf_counter() - start_time) * 1000.0
                         logger.info(
                             "Tool call cancelled",
-                            extra={"props": {
-                                "call_id": call_id,
-                                "tool_name": name,
-                                "duration_ms": duration_ms,
-                            }}
+                            extra={
+                                "props": {
+                                    "call_id": call_id,
+                                    "tool_name": name,
+                                    "duration_ms": duration_ms,
+                                }
+                            },
                         )
                         raise
                     except (KeyError, AttributeError, TypeError) as e:
@@ -400,17 +398,18 @@ class MCPServer:
                             "Response processing failed: %s",
                             e,
                             exc_info=True,
-                            extra={"props": {
-                                "call_id": call_id,
-                                "tool_name": name,
-                                "duration_ms": duration_ms,
-                                "error_type": type(e).__name__,
-                            }}
+                            extra={
+                                "props": {
+                                    "call_id": call_id,
+                                    "tool_name": name,
+                                    "duration_ms": duration_ms,
+                                    "error_type": type(e).__name__,
+                                }
+                            },
                         )
-                        return [TextContent(
-                            type="text",
-                            text=f"Error processing tool response: {e!s}"
-                        )]
+                        return [
+                            TextContent(type="text", text=f"Error processing tool response: {e!s}")
+                        ]
             raise ValueError(f"Tool not found: {name}")
 
     async def run(self) -> None:
@@ -420,10 +419,7 @@ class MCPServer:
         # Validate label configuration at startup
         validate_label_config_on_startup()
 
-        logger.info(
-            "Starting MCP server: %s",
-            server_name
-        )
+        logger.info("Starting MCP server: %s", server_name)
         lifecycle_logger.info("MCP server running")
 
         # Force LF only on Windows to prevent "invalid trailing data"
@@ -433,9 +429,7 @@ class MCPServer:
         try:
             async with stdio_server(stdout=stdout) as (read_stream, write_stream):
                 await self.server.run(
-                    read_stream,
-                    write_stream,
-                    self.server.create_initialization_options()
+                    read_stream, write_stream, self.server.create_initialization_options()
                 )
         except KeyboardInterrupt:
             lifecycle_logger.info("MCP server interrupted by user")
@@ -444,10 +438,7 @@ class MCPServer:
                 "MCP server crashed: %s",
                 e,
                 exc_info=True,
-                extra={"props": {
-                    "error_type": type(e).__name__,
-                    "error_message": str(e)
-                }}
+                extra={"props": {"error_type": type(e).__name__, "error_message": str(e)}},
             )
             # Re-raise to ensure proper exit code
             raise

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -372,6 +372,7 @@ class MCPServer:
                         response_content = self._convert_tool_result_to_content(result)
 
                         duration_ms = (time.perf_counter() - start_time) * 1000.0
+
                         logger.debug(
                             "Tool call completed",
                             extra={"props": {

--- a/mcp_server/tools/issue_tools.py
+++ b/mcp_server/tools/issue_tools.py
@@ -214,11 +214,24 @@ class CreateIssueTool(BaseTool):
     def input_schema(self) -> dict[str, Any]:
         return super().input_schema
 
-    def _render_body(self, body: IssueBody) -> str:
-        """Render an IssueBody to markdown via issue.md.jinja2."""
+    def _render_body(self, body: IssueBody, title: str = "") -> str:
+        """Render an IssueBody to markdown via issue.md.jinja2.
+
+        Args:
+            body: Structured issue body fields.
+            title: Issue title rendered as H1 heading.
+
+        Returns:
+            Markdown string with SCAFFOLD metadata as invisible HTML comments.
+        """
         return self._renderer.render(
             "concrete/issue.md.jinja2",
-            title="",
+            format="markdown",
+            title=title,
+            output_path="",
+            artifact_type="",
+            version_hash="",
+            timestamp="",
             problem=body.problem,
             expected=body.expected,
             actual=body.actual,
@@ -264,7 +277,7 @@ class CreateIssueTool(BaseTool):
     async def execute(self, params: CreateIssueInput) -> ToolResult:
         try:
             title_safe = normalize_unicode(params.title)
-            body_safe = normalize_unicode(self._render_body(params.body))
+            body_safe = normalize_unicode(self._render_body(params.body, title=params.title))
             labels = self._assemble_labels(params)
 
             issue = self.manager.create_issue(

--- a/mcp_server/tools/issue_tools.py
+++ b/mcp_server/tools/issue_tools.py
@@ -3,6 +3,7 @@
 import unicodedata
 from typing import Any, Literal
 
+import jinja2
 from pydantic import BaseModel, Field, field_validator
 
 from mcp_server.config.contributor_config import ContributorConfig
@@ -274,6 +275,11 @@ class CreateIssueTool(BaseTool):
                 assignees=params.assignees,
             )
             return ToolResult.text(f"Created issue #{issue['number']}: {issue['title']}")
+        except jinja2.TemplateError as e:
+            return ToolResult.error(
+                f"Body rendering failed: {e}. "
+                "Check that issue.md.jinja2 exists in the templates directory."
+            )
         except ExecutionError as e:
             return ToolResult.error(str(e))
 

--- a/mcp_server/tools/issue_tools.py
+++ b/mcp_server/tools/issue_tools.py
@@ -1,5 +1,6 @@
 """Issue management tools."""
 
+import json
 import unicodedata
 from typing import Any, Literal
 
@@ -118,8 +119,6 @@ class CreateIssueInput(BaseModel):
         'is not of type object'.
         """
         if isinstance(v, str):
-            import json
-
             try:
                 parsed = json.loads(v)
             except json.JSONDecodeError as e:

--- a/mcp_server/tools/issue_tools.py
+++ b/mcp_server/tools/issue_tools.py
@@ -280,6 +280,8 @@ class CreateIssueTool(BaseTool):
                 f"Body rendering failed: {e}. "
                 "Check that issue.md.jinja2 exists in the templates directory."
             )
+        except ValueError as e:
+            return ToolResult.error(f"Label assembly failed: {e}.")
         except ExecutionError as e:
             return ToolResult.error(str(e))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,45 @@
 @dependencies: pytest
 @responsibilities:
   - Import shared fixtures for pytest discovery
+  - Reset config singletons between tests to prevent cross-test contamination
 """
+
+import pytest
 
 # Import fixtures from fixture modules
 pytest_plugins = [
     "tests.fixtures.artifact_test_harness",
     "tests.fixtures.workflow_fixtures",
 ]
+
+
+@pytest.fixture(autouse=True)
+def reset_config_singletons() -> object:
+    """Reset all config singletons before/after each test.
+
+    Prevents cross-test contamination when config tests load custom YAML paths
+    and set the module-level singleton, which would otherwise be reused by
+    subsequent tests that call ``from_file()`` without arguments.
+
+    Covers both the *singleton_instance* pattern (IssueConfig, ScopeConfig,
+    WorkflowConfig, MilestoneConfig, ContributorConfig) and the *_instance*
+    pattern used by LabelConfig.
+    """
+    from mcp_server.config.issue_config import IssueConfig
+    from mcp_server.config.scope_config import ScopeConfig
+    from mcp_server.config.workflow_config import WorkflowConfig
+    from mcp_server.config.milestone_config import MilestoneConfig
+    from mcp_server.config.contributor_config import ContributorConfig
+    from mcp_server.config.label_config import LabelConfig
+
+    def _reset_all() -> None:
+        IssueConfig.singleton_instance = None
+        ScopeConfig.singleton_instance = None
+        WorkflowConfig.singleton_instance = None
+        MilestoneConfig.singleton_instance = None
+        ContributorConfig.singleton_instance = None
+        LabelConfig.reset()
+
+    _reset_all()
+    yield
+    _reset_all()

--- a/tests/integration/test_create_issue_e2e.py
+++ b/tests/integration/test_create_issue_e2e.py
@@ -1,0 +1,157 @@
+"""
+@module: tests.integration.test_create_issue_e2e
+@layer: Test Infrastructure
+@dependencies: mcp_server.tools.issue_tools, mcp_server.managers.github_manager
+@responsibilities:
+  - Real-world smoke tests for CreateIssueTool against live GitHub API
+  - Validates label assembly, milestone forwarding, and input validation end-to-end
+  - Marked @pytest.mark.integration — excluded from standard CI
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.tools.issue_tools import CreateIssueInput, CreateIssueTool, IssueBody
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MINIMAL_BODY = IssueBody(problem="[e2e smoke] Integration test — safe to close automatically.")
+
+
+def make_input(**overrides: object) -> CreateIssueInput:
+    """Return a minimal valid CreateIssueInput, overridable per test."""
+    defaults: dict[str, object] = {
+        "issue_type": "feature",
+        "title": "[e2e smoke] create_issue integration test",
+        "priority": "low",
+        "scope": "tooling",
+        "body": MINIMAL_BODY,
+    }
+    defaults.update(overrides)
+    return CreateIssueInput(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Minimal input — issue created, labels correct
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_minimal_input_creates_issue_with_correct_labels() -> None:
+    """Create an issue with only required fields; verify label set on GitHub."""
+    tool = CreateIssueTool()
+    params = make_input()
+
+    result = await tool.execute(params)
+
+    assert not result.is_error, f"Expected success, got error: {result.content}"
+    assert "Created issue #" in result.content[0]["text"]
+
+    # Parse the issue number from the result message
+    text: str = result.content[0]["text"]
+    issue_number = int(text.split("#")[1].split(":")[0].strip())
+
+    # Fetch the created issue and verify labels
+    from mcp_server.managers.github_manager import GitHubManager
+
+    manager = GitHubManager()
+    issue = manager.get_issue(issue_number)
+    label_names = {lbl.name for lbl in issue.labels}
+
+    assert "type:feature" in label_names, f"Missing type:feature in {label_names}"
+    assert "scope:tooling" in label_names, f"Missing scope:tooling in {label_names}"
+    assert "priority:low" in label_names, f"Missing priority:low in {label_names}"
+    # feature workflow first phase = research
+    assert "phase:research" in label_names, f"Missing phase:research in {label_names}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: All options — parent, is_epic, all labels applied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_options_creates_issue_with_full_label_set() -> None:
+    """Create an epic issue with parent; verify type:epic + parent:N labels."""
+    tool = CreateIssueTool()
+    params = make_input(
+        title="[e2e smoke] create_issue full-options test",
+        issue_type="feature",
+        is_epic=True,
+        parent_issue=149,
+        priority="medium",
+        scope="mcp-server",
+        body=IssueBody(
+            problem="[e2e smoke] Full-options test — safe to close.",
+            expected="Issue created with complete label set.",
+        ),
+    )
+
+    result = await tool.execute(params)
+
+    assert not result.is_error, f"Expected success, got error: {result.content}"
+
+    text: str = result.content[0]["text"]
+    issue_number = int(text.split("#")[1].split(":")[0].strip())
+
+    from mcp_server.managers.github_manager import GitHubManager
+
+    manager = GitHubManager()
+    issue = manager.get_issue(issue_number)
+    label_names = {lbl.name for lbl in issue.labels}
+
+    assert "type:epic" in label_names, f"Missing type:epic in {label_names}"
+    assert "parent:149" in label_names, f"Missing parent:149 in {label_names}"
+    assert "scope:mcp-server" in label_names, f"Missing scope:mcp-server in {label_names}"
+    assert "priority:medium" in label_names, f"Missing priority:medium in {label_names}"
+    assert "phase:research" in label_names, f"Missing phase:research in {label_names}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Invalid input — tool refuses before GitHub API call
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_issue_type_is_refused_before_api_call() -> None:
+    """Unknown issue_type must be rejected by Pydantic validation, no GitHub call."""
+    with pytest.raises(Exception):  # noqa: B017
+        make_input(issue_type="invalid_type")
+
+
+def test_invalid_scope_is_refused_before_api_call() -> None:
+    """Unknown scope must be rejected by Pydantic validation, no GitHub call."""
+    with pytest.raises(Exception):  # noqa: B017
+        make_input(scope="nonexistent-scope")
+
+
+def test_invalid_priority_is_refused_before_api_call() -> None:
+    """Unknown priority must be rejected by Pydantic validation, no GitHub call."""
+    with pytest.raises(Exception):  # noqa: B017
+        make_input(priority="ultra-critical")
+
+
+def test_title_too_long_is_refused_before_api_call() -> None:
+    """Title exceeding git.yaml max length must be rejected before GitHub call."""
+    with pytest.raises(Exception):  # noqa: B017
+        make_input(title="X" * 200)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Milestone validation — permissive when milestones.yaml is empty
+# ---------------------------------------------------------------------------
+
+
+def test_milestone_accepted_when_milestones_yaml_is_empty() -> None:
+    """Milestone validation is permissive when milestones.yaml has no entries.
+
+    This is documented in planning.md (Risk #2): milestones.yaml starts empty
+    and validation is a no-op until populated.
+    """
+    # Should NOT raise — empty milestones list means any value is accepted
+    params = make_input(milestone="any-future-milestone")
+    assert params.milestone == "any-future-milestone"

--- a/tests/unit/config/test_contributor_config.py
+++ b/tests/unit/config/test_contributor_config.py
@@ -1,0 +1,130 @@
+"""Unit tests for ContributorConfig singleton (Issue #149, Cycle 1).
+
+@layer: tests
+@dependencies: mcp_server.config.contributor_config
+@responsibilities: Verify ContributorConfig loads contributors.yaml (including empty list),
+                   validate_assignee() permissive when list empty, singleton behaviour.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcp_server.config.contributor_config import ContributorConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_EMPTY_CONTRIBUTORS_YAML = {"version": "1.0", "contributors": []}
+
+_POPULATED_CONTRIBUTORS_YAML = {
+    "version": "1.0",
+    "contributors": [
+        {"login": "alice", "name": "Alice Doe"},
+        {"login": "bob"},
+    ],
+}
+
+
+@pytest.fixture(name="empty_contributors_path")
+def _empty_contributors_path() -> Path:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    ) as fh:
+        yaml.dump(_EMPTY_CONTRIBUTORS_YAML, fh, allow_unicode=True)
+        return Path(fh.name)
+
+
+@pytest.fixture(name="populated_contributors_path")
+def _populated_contributors_path() -> Path:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    ) as fh:
+        yaml.dump(_POPULATED_CONTRIBUTORS_YAML, fh, allow_unicode=True)
+        return Path(fh.name)
+
+
+@pytest.fixture(name="empty_contributor_config")
+def _empty_contributor_config(empty_contributors_path: Path) -> ContributorConfig:
+    ContributorConfig.reset_instance()
+    cfg = ContributorConfig.from_file(str(empty_contributors_path))
+    yield cfg
+    ContributorConfig.reset_instance()
+
+
+@pytest.fixture(name="populated_contributor_config")
+def _populated_contributor_config(populated_contributors_path: Path) -> ContributorConfig:
+    ContributorConfig.reset_instance()
+    cfg = ContributorConfig.from_file(str(populated_contributors_path))
+    yield cfg
+    ContributorConfig.reset_instance()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestContributorConfigFromFile:
+    """Loading and singleton behaviour."""
+
+    def test_from_file_loads_empty_list(
+        self, empty_contributor_config: ContributorConfig
+    ) -> None:
+        assert empty_contributor_config.contributors == []
+
+    def test_from_file_loads_populated_list(
+        self, populated_contributor_config: ContributorConfig
+    ) -> None:
+        logins = [c.login for c in populated_contributor_config.contributors]
+        assert "alice" in logins
+        assert "bob" in logins
+
+    def test_from_file_contributor_name_is_optional(
+        self, populated_contributor_config: ContributorConfig
+    ) -> None:
+        """name field is optional — bob has no name."""
+        bob = next(
+            c for c in populated_contributor_config.contributors if c.login == "bob"
+        )
+        assert bob.name is None
+
+    def test_from_file_raises_on_missing_file(self) -> None:
+        ContributorConfig.reset_instance()
+        with pytest.raises(FileNotFoundError, match="Contributor config not found"):
+            ContributorConfig.from_file(".st3/nonexistent_contributors.yaml")
+
+    def test_singleton_returns_same_instance(self, empty_contributors_path: Path) -> None:
+        ContributorConfig.reset_instance()
+        cfg1 = ContributorConfig.from_file(str(empty_contributors_path))
+        cfg2 = ContributorConfig.from_file(str(empty_contributors_path))
+        assert cfg1 is cfg2
+
+
+class TestContributorConfigValidateAssignee:
+    """validate_assignee() permissive when list empty, strict when populated."""
+
+    def test_validate_assignee_always_true_when_list_empty(
+        self, empty_contributor_config: ContributorConfig
+    ) -> None:
+        """Permissive: any login passes when contributors list is empty."""
+        assert empty_contributor_config.validate_assignee("anyone") is True
+        assert empty_contributor_config.validate_assignee("unknown-user") is True
+
+    def test_validate_assignee_true_for_known_login(
+        self, populated_contributor_config: ContributorConfig
+    ) -> None:
+        assert populated_contributor_config.validate_assignee("alice") is True
+
+    def test_validate_assignee_false_for_unknown_login(
+        self, populated_contributor_config: ContributorConfig
+    ) -> None:
+        assert populated_contributor_config.validate_assignee("charlie") is False
+
+    def test_validate_assignee_is_case_sensitive(
+        self, populated_contributor_config: ContributorConfig
+    ) -> None:
+        assert populated_contributor_config.validate_assignee("Alice") is False

--- a/tests/unit/config/test_contributor_config.py
+++ b/tests/unit/config/test_contributor_config.py
@@ -7,6 +7,7 @@
 """
 
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -48,7 +49,9 @@ def _populated_contributors_path() -> Path:
 
 
 @pytest.fixture(name="empty_contributor_config")
-def _empty_contributor_config(empty_contributors_path: Path) -> ContributorConfig:
+def _empty_contributor_config(
+    empty_contributors_path: Path,
+) -> Generator[ContributorConfig, None, None]:
     ContributorConfig.reset_instance()
     cfg = ContributorConfig.from_file(str(empty_contributors_path))
     yield cfg
@@ -56,7 +59,9 @@ def _empty_contributor_config(empty_contributors_path: Path) -> ContributorConfi
 
 
 @pytest.fixture(name="populated_contributor_config")
-def _populated_contributor_config(populated_contributors_path: Path) -> ContributorConfig:
+def _populated_contributor_config(
+    populated_contributors_path: Path,
+) -> Generator[ContributorConfig, None, None]:
     ContributorConfig.reset_instance()
     cfg = ContributorConfig.from_file(str(populated_contributors_path))
     yield cfg
@@ -71,9 +76,7 @@ def _populated_contributor_config(populated_contributors_path: Path) -> Contribu
 class TestContributorConfigFromFile:
     """Loading and singleton behaviour."""
 
-    def test_from_file_loads_empty_list(
-        self, empty_contributor_config: ContributorConfig
-    ) -> None:
+    def test_from_file_loads_empty_list(self, empty_contributor_config: ContributorConfig) -> None:
         assert empty_contributor_config.contributors == []
 
     def test_from_file_loads_populated_list(
@@ -87,9 +90,7 @@ class TestContributorConfigFromFile:
         self, populated_contributor_config: ContributorConfig
     ) -> None:
         """name field is optional — bob has no name."""
-        bob = next(
-            c for c in populated_contributor_config.contributors if c.login == "bob"
-        )
+        bob = next(c for c in populated_contributor_config.contributors if c.login == "bob")
         assert bob.name is None
 
     def test_from_file_raises_on_missing_file(self) -> None:

--- a/tests/unit/config/test_issue_config.py
+++ b/tests/unit/config/test_issue_config.py
@@ -7,6 +7,7 @@
 """
 
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -46,7 +47,7 @@ def _issues_yaml_path() -> Path:
 
 
 @pytest.fixture(name="issue_config")
-def _issue_config(issues_yaml_path: Path) -> IssueConfig:
+def _issue_config(issues_yaml_path: Path) -> Generator[IssueConfig, None, None]:
     """Return a fresh IssueConfig loaded from temporary yaml."""
     IssueConfig.reset_instance()
     cfg = IssueConfig.from_file(str(issues_yaml_path))
@@ -93,9 +94,7 @@ class TestIssueConfigGetWorkflow:
     def test_get_workflow_hotfix(self, issue_config: IssueConfig) -> None:
         assert issue_config.get_workflow("hotfix") == "hotfix"
 
-    def test_get_workflow_chore_maps_to_feature_workflow(
-        self, issue_config: IssueConfig
-    ) -> None:
+    def test_get_workflow_chore_maps_to_feature_workflow(self, issue_config: IssueConfig) -> None:
         assert issue_config.get_workflow("chore") == "feature"
 
     def test_get_workflow_raises_on_unknown_type(self, issue_config: IssueConfig) -> None:

--- a/tests/unit/config/test_issue_config.py
+++ b/tests/unit/config/test_issue_config.py
@@ -1,0 +1,127 @@
+"""Unit tests for IssueConfig singleton (Issue #149, Cycle 1).
+
+@layer: tests
+@dependencies: mcp_server.config.issue_config
+@responsibilities: Verify IssueConfig loads issues.yaml, get_workflow, get_label (incl. hotfix
+                   → type:bug mapping), singleton behaviour, optional_label_inputs.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcp_server.config.issue_config import IssueConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_MINIMAL_ISSUES_YAML = {
+    "version": "1.0",
+    "issue_types": [
+        {"name": "feature", "workflow": "feature", "label": "type:feature"},
+        {"name": "bug", "workflow": "bug", "label": "type:bug"},
+        {"name": "hotfix", "workflow": "hotfix", "label": "type:bug"},
+        {"name": "chore", "workflow": "feature", "label": "type:chore"},
+        {"name": "epic", "workflow": "epic", "label": "type:epic"},
+    ],
+    "required_label_categories": ["type", "priority", "scope"],
+    "optional_label_inputs": {
+        "is_epic": {"type": "bool", "label": "type:epic", "behavior": "Overrides type:*"},
+        "parent_issue": {"type": "int", "label_pattern": "parent:{value}"},
+    },
+}
+
+
+@pytest.fixture(name="issues_yaml_path")
+def _issues_yaml_path() -> Path:
+    """Write a temporary issues.yaml and return its Path."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    ) as fh:
+        yaml.dump(_MINIMAL_ISSUES_YAML, fh, allow_unicode=True)
+        return Path(fh.name)
+
+
+@pytest.fixture(name="issue_config")
+def _issue_config(issues_yaml_path: Path) -> IssueConfig:
+    """Return a fresh IssueConfig loaded from temporary yaml."""
+    IssueConfig.reset_instance()
+    cfg = IssueConfig.from_file(str(issues_yaml_path))
+    yield cfg
+    IssueConfig.reset_instance()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIssueConfigFromFile:
+    """Loading and singleton behaviour."""
+
+    def test_from_file_loads_issue_types(self, issue_config: IssueConfig) -> None:
+        names = [entry.name for entry in issue_config.issue_types]
+        assert "feature" in names
+        assert "hotfix" in names
+        assert "chore" in names
+
+    def test_from_file_raises_on_missing_file(self) -> None:
+        IssueConfig.reset_instance()
+        with pytest.raises(FileNotFoundError, match="Issue config not found"):
+            IssueConfig.from_file(".st3/nonexistent_issues.yaml")
+
+    def test_singleton_returns_same_instance(self, issues_yaml_path: Path) -> None:
+        IssueConfig.reset_instance()
+        cfg1 = IssueConfig.from_file(str(issues_yaml_path))
+        cfg2 = IssueConfig.from_file(str(issues_yaml_path))
+        assert cfg1 is cfg2
+
+    def test_loads_optional_label_inputs(self, issue_config: IssueConfig) -> None:
+        assert "is_epic" in issue_config.optional_label_inputs
+        assert "parent_issue" in issue_config.optional_label_inputs
+
+
+class TestIssueConfigGetWorkflow:
+    """get_workflow() correctness."""
+
+    def test_get_workflow_feature(self, issue_config: IssueConfig) -> None:
+        assert issue_config.get_workflow("feature") == "feature"
+
+    def test_get_workflow_hotfix(self, issue_config: IssueConfig) -> None:
+        assert issue_config.get_workflow("hotfix") == "hotfix"
+
+    def test_get_workflow_chore_maps_to_feature_workflow(
+        self, issue_config: IssueConfig
+    ) -> None:
+        assert issue_config.get_workflow("chore") == "feature"
+
+    def test_get_workflow_raises_on_unknown_type(self, issue_config: IssueConfig) -> None:
+        with pytest.raises(ValueError, match="Unknown issue type"):
+            issue_config.get_workflow("unknown_type")
+
+
+class TestIssueConfigGetLabel:
+    """get_label() correctness, including hotfix → type:bug non-obvious mapping."""
+
+    def test_get_label_feature(self, issue_config: IssueConfig) -> None:
+        assert issue_config.get_label("feature") == "type:feature"
+
+    def test_get_label_bug(self, issue_config: IssueConfig) -> None:
+        assert issue_config.get_label("bug") == "type:bug"
+
+    def test_get_label_hotfix_returns_type_bug(self, issue_config: IssueConfig) -> None:
+        """hotfix must map to type:bug, not type:hotfix."""
+        assert issue_config.get_label("hotfix") == "type:bug"
+
+    def test_get_label_chore(self, issue_config: IssueConfig) -> None:
+        assert issue_config.get_label("chore") == "type:chore"
+
+    def test_get_label_epic(self, issue_config: IssueConfig) -> None:
+        assert issue_config.get_label("epic") == "type:epic"
+
+    def test_get_label_raises_on_unknown_type(self, issue_config: IssueConfig) -> None:
+        with pytest.raises(ValueError, match="Unknown issue type"):
+            issue_config.get_label("nonexistent")

--- a/tests/unit/config/test_labels_yaml_conventions.py
+++ b/tests/unit/config/test_labels_yaml_conventions.py
@@ -95,6 +95,13 @@ class TestParentLabelPattern:
 # ---------------------------------------------------------------------------
 
 
+class TestDroppedLabels:
+    def test_type_enhancement_removed(self, labels_data: dict) -> None:
+        """type:enhancement was dropped per research — replaced by type:feature."""
+        names = [lbl["name"] for lbl in labels_data["labels"]]
+        assert "type:enhancement" not in names
+
+
 class TestTypeChoreLabel:
     def test_type_chore_label_exists(self, labels_data: dict) -> None:
         names = [lbl["name"] for lbl in labels_data["labels"]]

--- a/tests/unit/config/test_labels_yaml_conventions.py
+++ b/tests/unit/config/test_labels_yaml_conventions.py
@@ -1,0 +1,111 @@
+"""
+tests/unit/config/test_labels_yaml_conventions.py
+==================================================
+Cycle 2 — Verify .st3/labels.yaml conventions:
+
+- No status:* labels should exist (removed in cycle 2)
+- Parent label pattern must be "^parent:\\d+$" (not "^parent:issue-\\d+$")
+- type:chore label must exist
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+LABELS_PATH = Path(".st3/labels.yaml")
+
+
+@pytest.fixture(name="labels_data")
+def _labels_data() -> dict:  # type: ignore[return]
+    with LABELS_PATH.open() as fh:
+        return yaml.safe_load(fh)
+
+
+# ---------------------------------------------------------------------------
+# TestNoStatusLabels
+# ---------------------------------------------------------------------------
+
+
+class TestNoStatusLabels:
+    def test_no_status_blocked_label(self, labels_data: dict) -> None:
+        names = [lbl["name"] for lbl in labels_data["labels"]]
+        assert "status:blocked" not in names
+
+    def test_no_status_in_progress_label(self, labels_data: dict) -> None:
+        names = [lbl["name"] for lbl in labels_data["labels"]]
+        assert "status:in-progress" not in names
+
+    def test_no_status_needs_info_label(self, labels_data: dict) -> None:
+        names = [lbl["name"] for lbl in labels_data["labels"]]
+        assert "status:needs-info" not in names
+
+    def test_no_status_ready_label(self, labels_data: dict) -> None:
+        names = [lbl["name"] for lbl in labels_data["labels"]]
+        assert "status:ready" not in names
+
+    def test_no_status_prefix_labels_at_all(self, labels_data: dict) -> None:
+        names = [lbl["name"] for lbl in labels_data["labels"]]
+        status_labels = [n for n in names if n.startswith("status:")]
+        assert status_labels == [], f"Unexpected status labels: {status_labels}"
+
+
+# ---------------------------------------------------------------------------
+# TestParentLabelPattern
+# ---------------------------------------------------------------------------
+
+
+class TestParentLabelPattern:
+    def test_parent_pattern_exists(self, labels_data: dict) -> None:
+        patterns = [p["pattern"] for p in labels_data.get("label_patterns", [])]
+        parent_patterns = [p for p in patterns if "parent" in p]
+        assert len(parent_patterns) == 1, "Expected exactly one parent pattern"
+
+    def test_parent_pattern_is_numeric_only(self, labels_data: dict) -> None:
+        patterns = {p["pattern"] for p in labels_data.get("label_patterns", [])}
+        assert r"^parent:\d+$" in patterns, (
+            f"Expected '^parent:\\d+$' but got: {patterns}"
+        )
+
+    def test_old_parent_pattern_is_gone(self, labels_data: dict) -> None:
+        patterns = {p["pattern"] for p in labels_data.get("label_patterns", [])}
+        assert r"^parent:issue-\d+$" not in patterns
+
+    def test_parent_pattern_matches_numeric(self, labels_data: dict) -> None:
+        patterns = [p["pattern"] for p in labels_data.get("label_patterns", [])]
+        parent_pattern = next(p for p in patterns if "parent" in p)
+        assert re.fullmatch(parent_pattern, "parent:91") is not None
+
+    def test_parent_pattern_rejects_old_format(self, labels_data: dict) -> None:
+        patterns = [p["pattern"] for p in labels_data.get("label_patterns", [])]
+        parent_pattern = next(p for p in patterns if "parent" in p)
+        assert re.fullmatch(parent_pattern, "parent:issue-18") is None
+
+    def test_parent_pattern_example_updated(self, labels_data: dict) -> None:
+        parent_entry = next(
+            p for p in labels_data.get("label_patterns", []) if "parent" in p["pattern"]
+        )
+        example = parent_entry.get("example", "")
+        assert re.fullmatch(parent_entry["pattern"], example) is not None, (
+            f"Pattern example '{example}' does not match pattern '{parent_entry['pattern']}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestTypeChoreLabel
+# ---------------------------------------------------------------------------
+
+
+class TestTypeChoreLabel:
+    def test_type_chore_label_exists(self, labels_data: dict) -> None:
+        names = [lbl["name"] for lbl in labels_data["labels"]]
+        assert "type:chore" in names
+
+    def test_type_chore_has_color(self, labels_data: dict) -> None:
+        chore = next(lbl for lbl in labels_data["labels"] if lbl["name"] == "type:chore")
+        assert chore.get("color"), "type:chore must have a color"
+
+    def test_type_chore_has_description(self, labels_data: dict) -> None:
+        chore = next(lbl for lbl in labels_data["labels"] if lbl["name"] == "type:chore")
+        assert chore.get("description"), "type:chore must have a description"

--- a/tests/unit/config/test_labels_yaml_conventions.py
+++ b/tests/unit/config/test_labels_yaml_conventions.py
@@ -64,9 +64,7 @@ class TestParentLabelPattern:
 
     def test_parent_pattern_is_numeric_only(self, labels_data: dict) -> None:
         patterns = {p["pattern"] for p in labels_data.get("label_patterns", [])}
-        assert r"^parent:\d+$" in patterns, (
-            f"Expected '^parent:\\d+$' but got: {patterns}"
-        )
+        assert r"^parent:\d+$" in patterns, f"Expected '^parent:\\d+$' but got: {patterns}"
 
     def test_old_parent_pattern_is_gone(self, labels_data: dict) -> None:
         patterns = {p["pattern"] for p in labels_data.get("label_patterns", [])}

--- a/tests/unit/config/test_milestone_config.py
+++ b/tests/unit/config/test_milestone_config.py
@@ -7,6 +7,7 @@
 """
 
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -48,7 +49,7 @@ def _populated_milestones_path() -> Path:
 
 
 @pytest.fixture(name="empty_milestone_config")
-def _empty_milestone_config(empty_milestones_path: Path) -> MilestoneConfig:
+def _empty_milestone_config(empty_milestones_path: Path) -> Generator[MilestoneConfig, None, None]:
     MilestoneConfig.reset_instance()
     cfg = MilestoneConfig.from_file(str(empty_milestones_path))
     yield cfg
@@ -56,7 +57,9 @@ def _empty_milestone_config(empty_milestones_path: Path) -> MilestoneConfig:
 
 
 @pytest.fixture(name="populated_milestone_config")
-def _populated_milestone_config(populated_milestones_path: Path) -> MilestoneConfig:
+def _populated_milestone_config(
+    populated_milestones_path: Path,
+) -> Generator[MilestoneConfig, None, None]:
     MilestoneConfig.reset_instance()
     cfg = MilestoneConfig.from_file(str(populated_milestones_path))
     yield cfg

--- a/tests/unit/config/test_milestone_config.py
+++ b/tests/unit/config/test_milestone_config.py
@@ -1,0 +1,114 @@
+"""Unit tests for MilestoneConfig singleton (Issue #149, Cycle 1).
+
+@layer: tests
+@dependencies: mcp_server.config.milestone_config
+@responsibilities: Verify MilestoneConfig loads milestones.yaml (including empty list),
+                   validate_milestone() permissive when list empty, singleton behaviour.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcp_server.config.milestone_config import MilestoneConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_EMPTY_MILESTONES_YAML = {"version": "1.0", "milestones": []}
+
+_POPULATED_MILESTONES_YAML = {
+    "version": "1.0",
+    "milestones": [
+        {"number": 1, "title": "v1.0", "state": "open"},
+        {"number": 2, "title": "v2.0", "state": "closed"},
+    ],
+}
+
+
+@pytest.fixture(name="empty_milestones_path")
+def _empty_milestones_path() -> Path:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    ) as fh:
+        yaml.dump(_EMPTY_MILESTONES_YAML, fh, allow_unicode=True)
+        return Path(fh.name)
+
+
+@pytest.fixture(name="populated_milestones_path")
+def _populated_milestones_path() -> Path:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    ) as fh:
+        yaml.dump(_POPULATED_MILESTONES_YAML, fh, allow_unicode=True)
+        return Path(fh.name)
+
+
+@pytest.fixture(name="empty_milestone_config")
+def _empty_milestone_config(empty_milestones_path: Path) -> MilestoneConfig:
+    MilestoneConfig.reset_instance()
+    cfg = MilestoneConfig.from_file(str(empty_milestones_path))
+    yield cfg
+    MilestoneConfig.reset_instance()
+
+
+@pytest.fixture(name="populated_milestone_config")
+def _populated_milestone_config(populated_milestones_path: Path) -> MilestoneConfig:
+    MilestoneConfig.reset_instance()
+    cfg = MilestoneConfig.from_file(str(populated_milestones_path))
+    yield cfg
+    MilestoneConfig.reset_instance()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMilestoneConfigFromFile:
+    """Loading and singleton behaviour."""
+
+    def test_from_file_loads_empty_list(self, empty_milestone_config: MilestoneConfig) -> None:
+        assert empty_milestone_config.milestones == []
+
+    def test_from_file_loads_populated_list(
+        self, populated_milestone_config: MilestoneConfig
+    ) -> None:
+        titles = [m.title for m in populated_milestone_config.milestones]
+        assert "v1.0" in titles
+        assert "v2.0" in titles
+
+    def test_from_file_raises_on_missing_file(self) -> None:
+        MilestoneConfig.reset_instance()
+        with pytest.raises(FileNotFoundError, match="Milestone config not found"):
+            MilestoneConfig.from_file(".st3/nonexistent_milestones.yaml")
+
+    def test_singleton_returns_same_instance(self, empty_milestones_path: Path) -> None:
+        MilestoneConfig.reset_instance()
+        cfg1 = MilestoneConfig.from_file(str(empty_milestones_path))
+        cfg2 = MilestoneConfig.from_file(str(empty_milestones_path))
+        assert cfg1 is cfg2
+
+
+class TestMilestoneConfigValidateMilestone:
+    """validate_milestone() permissive when list empty, strict when populated."""
+
+    def test_validate_milestone_always_true_when_list_empty(
+        self, empty_milestone_config: MilestoneConfig
+    ) -> None:
+        """Permissive: any title passes when milestones list is empty."""
+        assert empty_milestone_config.validate_milestone("v99.0") is True
+        assert empty_milestone_config.validate_milestone("anything") is True
+
+    def test_validate_milestone_true_for_known_title(
+        self, populated_milestone_config: MilestoneConfig
+    ) -> None:
+        assert populated_milestone_config.validate_milestone("v1.0") is True
+
+    def test_validate_milestone_false_for_unknown_title(
+        self, populated_milestone_config: MilestoneConfig
+    ) -> None:
+        assert populated_milestone_config.validate_milestone("v99.0") is False

--- a/tests/unit/config/test_scope_config.py
+++ b/tests/unit/config/test_scope_config.py
@@ -7,6 +7,7 @@
 """
 
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -34,7 +35,7 @@ def _scopes_yaml_path() -> Path:
 
 
 @pytest.fixture(name="scope_config")
-def _scope_config(scopes_yaml_path: Path) -> ScopeConfig:
+def _scope_config(scopes_yaml_path: Path) -> Generator[ScopeConfig, None, None]:
     ScopeConfig.reset_instance()
     cfg = ScopeConfig.from_file(str(scopes_yaml_path))
     yield cfg
@@ -72,14 +73,10 @@ class TestScopeConfigHasScope:
     def test_has_scope_returns_true_for_known_scope(self, scope_config: ScopeConfig) -> None:
         assert scope_config.has_scope("tooling") is True
 
-    def test_has_scope_returns_true_for_hyphenated_scope(
-        self, scope_config: ScopeConfig
-    ) -> None:
+    def test_has_scope_returns_true_for_hyphenated_scope(self, scope_config: ScopeConfig) -> None:
         assert scope_config.has_scope("mcp-server") is True
 
-    def test_has_scope_returns_false_for_unknown_scope(
-        self, scope_config: ScopeConfig
-    ) -> None:
+    def test_has_scope_returns_false_for_unknown_scope(self, scope_config: ScopeConfig) -> None:
         assert scope_config.has_scope("unknown-scope") is False
 
     def test_has_scope_is_case_sensitive(self, scope_config: ScopeConfig) -> None:

--- a/tests/unit/config/test_scope_config.py
+++ b/tests/unit/config/test_scope_config.py
@@ -1,0 +1,87 @@
+"""Unit tests for ScopeConfig singleton (Issue #149, Cycle 1).
+
+@layer: tests
+@dependencies: mcp_server.config.scope_config
+@responsibilities: Verify ScopeConfig loads scopes.yaml (flat list), has_scope(),
+                   singleton behaviour, case-sensitivity.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcp_server.config.scope_config import ScopeConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_MINIMAL_SCOPES_YAML = {
+    "version": "1.0",
+    "scopes": ["architecture", "mcp-server", "platform", "tooling", "workflow", "documentation"],
+}
+
+
+@pytest.fixture(name="scopes_yaml_path")
+def _scopes_yaml_path() -> Path:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    ) as fh:
+        yaml.dump(_MINIMAL_SCOPES_YAML, fh, allow_unicode=True)
+        return Path(fh.name)
+
+
+@pytest.fixture(name="scope_config")
+def _scope_config(scopes_yaml_path: Path) -> ScopeConfig:
+    ScopeConfig.reset_instance()
+    cfg = ScopeConfig.from_file(str(scopes_yaml_path))
+    yield cfg
+    ScopeConfig.reset_instance()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestScopeConfigFromFile:
+    """Loading and singleton behaviour."""
+
+    def test_from_file_loads_scopes(self, scope_config: ScopeConfig) -> None:
+        assert "tooling" in scope_config.scopes
+        assert "architecture" in scope_config.scopes
+        assert "documentation" in scope_config.scopes
+
+    def test_from_file_raises_on_missing_file(self) -> None:
+        ScopeConfig.reset_instance()
+        with pytest.raises(FileNotFoundError, match="Scope config not found"):
+            ScopeConfig.from_file(".st3/nonexistent_scopes.yaml")
+
+    def test_singleton_returns_same_instance(self, scopes_yaml_path: Path) -> None:
+        ScopeConfig.reset_instance()
+        cfg1 = ScopeConfig.from_file(str(scopes_yaml_path))
+        cfg2 = ScopeConfig.from_file(str(scopes_yaml_path))
+        assert cfg1 is cfg2
+
+
+class TestScopeConfigHasScope:
+    """has_scope() correctness and edge cases."""
+
+    def test_has_scope_returns_true_for_known_scope(self, scope_config: ScopeConfig) -> None:
+        assert scope_config.has_scope("tooling") is True
+
+    def test_has_scope_returns_true_for_hyphenated_scope(
+        self, scope_config: ScopeConfig
+    ) -> None:
+        assert scope_config.has_scope("mcp-server") is True
+
+    def test_has_scope_returns_false_for_unknown_scope(
+        self, scope_config: ScopeConfig
+    ) -> None:
+        assert scope_config.has_scope("unknown-scope") is False
+
+    def test_has_scope_is_case_sensitive(self, scope_config: ScopeConfig) -> None:
+        assert scope_config.has_scope("Tooling") is False
+        assert scope_config.has_scope("ARCHITECTURE") is False

--- a/tests/unit/mcp_server/integration/test_github.py
+++ b/tests/unit/mcp_server/integration/test_github.py
@@ -1,19 +1,21 @@
 """Tests for GitHub integration."""
+
 import asyncio
 from unittest.mock import Mock
 
 import pytest
 
 from mcp_server.managers.github_manager import GitHubManager
-from mcp_server.tools.issue_tools import CreateIssueInput, CreateIssueTool
+from mcp_server.tools.issue_tools import CreateIssueInput, CreateIssueTool, IssueBody
 
 
 @pytest.fixture
-def mock_adapter():
+def mock_adapter() -> Mock:
     """Create a mock GitHub adapter for testing."""
     return Mock()
 
-def test_manager_get_issues(mock_adapter) -> None:
+
+def test_manager_get_issues(mock_adapter: Mock) -> None:
     """Test GitHubManager returns correctly formatted issue data."""
     # Setup mock
     mock_issue = Mock()
@@ -33,7 +35,8 @@ def test_manager_get_issues(mock_adapter) -> None:
     assert data["open_count"] == 1
     assert data["issues"][0]["title"] == "Test Issue"
 
-def test_create_issue_tool(mock_adapter) -> None:
+
+def test_create_issue_tool(mock_adapter: Mock) -> None:
     """Test CreateIssueTool creates issue and returns correct response."""
     # Setup mock
     mock_issue = Mock()
@@ -45,13 +48,13 @@ def test_create_issue_tool(mock_adapter) -> None:
     manager = GitHubManager(adapter=mock_adapter)
     tool = CreateIssueTool(manager=manager)
 
-    result = asyncio.run(tool.execute(CreateIssueInput(title="New Issue", body="Body")))
+    params = CreateIssueInput(
+        issue_type="feature",
+        title="New Issue",
+        priority="medium",
+        scope="mcp-server",
+        body=IssueBody(problem="Some problem description"),
+    )
+    result = asyncio.run(tool.execute(params))
 
     assert "Created issue #42" in result.content[0]["text"]
-    mock_adapter.create_issue.assert_called_with(
-        title="New Issue",
-        body="Body",
-        labels=None,
-        milestone_number=None,
-        assignees=None
-    )

--- a/tests/unit/tools/test_create_issue_errors.py
+++ b/tests/unit/tools/test_create_issue_errors.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import jinja2
 import pytest
 
+from mcp_server.core.exceptions import ExecutionError
 from mcp_server.tools.issue_tools import CreateIssueInput, CreateIssueTool, IssueBody
 
 # ---------------------------------------------------------------------------
@@ -51,8 +52,6 @@ class TestExecutionErrorHandling:
     @pytest.mark.asyncio
     async def test_execution_error_returns_tool_result_error(self) -> None:
         """ExecutionError from GitHubManager must produce ToolResult.error()."""
-        from mcp_server.core.exceptions import ExecutionError
-
         mock_manager = MagicMock()
         mock_manager.create_issue.side_effect = ExecutionError("GitHub API rate limit exceeded")
         tool = CreateIssueTool(manager=mock_manager)
@@ -63,8 +62,6 @@ class TestExecutionErrorHandling:
 
     @pytest.mark.asyncio
     async def test_execution_error_message_is_included(self) -> None:
-        from mcp_server.core.exceptions import ExecutionError
-
         mock_manager = MagicMock()
         mock_manager.create_issue.side_effect = ExecutionError("GitHub API rate limit exceeded")
         tool = CreateIssueTool(manager=mock_manager)
@@ -77,8 +74,6 @@ class TestExecutionErrorHandling:
     @pytest.mark.asyncio
     async def test_execution_error_does_not_raise(self) -> None:
         """execute() must not raise — it must return ToolResult.error()."""
-        from mcp_server.core.exceptions import ExecutionError
-
         mock_manager = MagicMock()
         mock_manager.create_issue.side_effect = ExecutionError("Network error")
         tool = CreateIssueTool(manager=mock_manager)
@@ -189,8 +184,6 @@ class TestNoExceptionLeaks:
     @pytest.mark.asyncio
     async def test_execution_error_does_not_propagate(self) -> None:
         """No known error type should propagate out of execute()."""
-        from mcp_server.core.exceptions import ExecutionError
-
         mock_manager = MagicMock()
         mock_manager.create_issue.side_effect = ExecutionError("fail")
         tool = CreateIssueTool(manager=mock_manager)
@@ -203,9 +196,7 @@ class TestNoExceptionLeaks:
     @pytest.mark.asyncio
     async def test_template_error_does_not_propagate(self) -> None:
         tool = make_tool()
-        with patch.object(
-            tool, "_render_body", side_effect=jinja2.TemplateError("fail")
-        ):
+        with patch.object(tool, "_render_body", side_effect=jinja2.TemplateError("fail")):
             try:
                 await tool.execute(VALID_PARAMS)
             except Exception as exc:  # noqa: BLE001

--- a/tests/unit/tools/test_create_issue_errors.py
+++ b/tests/unit/tools/test_create_issue_errors.py
@@ -1,0 +1,212 @@
+"""
+tests/unit/tools/test_create_issue_errors.py
+=============================================
+Cycle 6 — Error handling in CreateIssueTool.execute().
+
+Tests that all expected failure modes produce ToolResult.error() with actionable
+messages instead of leaking raw exceptions to the caller.
+
+Failure modes covered:
+  1. ExecutionError from GitHubManager  → ToolResult.error
+  2. JinjaRenderer TemplateError        → ToolResult.error
+  3. ValueError from _assemble_labels  → ToolResult.error
+  4. ToolResult.is_error is True in all failure cases
+"""
+
+from unittest.mock import MagicMock, patch
+
+import jinja2
+import pytest
+
+from mcp_server.tools.issue_tools import CreateIssueInput, CreateIssueTool, IssueBody
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+BODY = IssueBody(problem="Test error scenarios")
+
+VALID_PARAMS = CreateIssueInput(
+    issue_type="feature",
+    title="Error test issue",
+    priority="medium",
+    scope="mcp-server",
+    body=BODY,
+)
+
+
+def make_tool(manager: MagicMock | None = None) -> CreateIssueTool:
+    """Return a CreateIssueTool with a mock manager."""
+    mgr = manager or MagicMock()
+    mgr.create_issue.return_value = {"number": 1, "title": "T", "url": ""}
+    return CreateIssueTool(manager=mgr)
+
+
+# ---------------------------------------------------------------------------
+# TestExecutionErrorHandling
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionErrorHandling:
+    @pytest.mark.asyncio
+    async def test_execution_error_returns_tool_result_error(self) -> None:
+        """ExecutionError from GitHubManager must produce ToolResult.error()."""
+        from mcp_server.core.exceptions import ExecutionError
+
+        mock_manager = MagicMock()
+        mock_manager.create_issue.side_effect = ExecutionError("GitHub API rate limit exceeded")
+        tool = CreateIssueTool(manager=mock_manager)
+
+        result = await tool.execute(VALID_PARAMS)
+
+        assert result.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_execution_error_message_is_included(self) -> None:
+        from mcp_server.core.exceptions import ExecutionError
+
+        mock_manager = MagicMock()
+        mock_manager.create_issue.side_effect = ExecutionError("GitHub API rate limit exceeded")
+        tool = CreateIssueTool(manager=mock_manager)
+
+        result = await tool.execute(VALID_PARAMS)
+
+        result_text = result.content[0]["text"]
+        assert "rate limit" in result_text or "GitHub" in result_text
+
+    @pytest.mark.asyncio
+    async def test_execution_error_does_not_raise(self) -> None:
+        """execute() must not raise — it must return ToolResult.error()."""
+        from mcp_server.core.exceptions import ExecutionError
+
+        mock_manager = MagicMock()
+        mock_manager.create_issue.side_effect = ExecutionError("Network error")
+        tool = CreateIssueTool(manager=mock_manager)
+
+        # Must not raise
+        result = await tool.execute(VALID_PARAMS)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# TestRenderingErrorHandling
+# ---------------------------------------------------------------------------
+
+
+class TestRenderingErrorHandling:
+    @pytest.mark.asyncio
+    async def test_template_error_returns_tool_result_error(self) -> None:
+        """jinja2.TemplateError from _render_body must produce ToolResult.error()."""
+        tool = make_tool()
+        with patch.object(
+            tool,
+            "_render_body",
+            side_effect=jinja2.TemplateError("Template not found"),
+        ):
+            result = await tool.execute(VALID_PARAMS)
+
+        assert result.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_template_error_does_not_raise(self) -> None:
+        tool = make_tool()
+        with patch.object(
+            tool,
+            "_render_body",
+            side_effect=jinja2.TemplateError("Bad template"),
+        ):
+            result = await tool.execute(VALID_PARAMS)
+
+        assert result is not None
+        assert result.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_template_not_found_error_is_handled(self) -> None:
+        """jinja2.TemplateNotFound (subclass of TemplateError) is also caught."""
+        tool = make_tool()
+        with patch.object(
+            tool,
+            "_render_body",
+            side_effect=jinja2.TemplateNotFound("issue.md.jinja2"),
+        ):
+            result = await tool.execute(VALID_PARAMS)
+
+        assert result.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_template_error_message_is_actionable(self) -> None:
+        """TemplateError message must hint at the template path — not just 'Unexpected error'."""
+        tool = make_tool()
+        with patch.object(
+            tool,
+            "_render_body",
+            side_effect=jinja2.TemplateError("template missing"),
+        ):
+            result = await tool.execute(VALID_PARAMS)
+
+        result_text = result.content[0]["text"]
+        assert "rendering" in result_text or "template" in result_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestAssembleLabelErrorHandling
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleLabelErrorHandling:
+    @pytest.mark.asyncio
+    async def test_value_error_from_label_assembly_returns_tool_result_error(self) -> None:
+        """ValueError from _assemble_labels must produce ToolResult.error() not raise."""
+        tool = make_tool()
+        with patch.object(
+            tool,
+            "_assemble_labels",
+            side_effect=ValueError("Unknown workflow: 'invalid'"),
+        ):
+            result = await tool.execute(VALID_PARAMS)
+
+        assert result.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_value_error_does_not_raise(self) -> None:
+        tool = make_tool()
+        with patch.object(
+            tool,
+            "_assemble_labels",
+            side_effect=ValueError("Unknown workflow"),
+        ):
+            result = await tool.execute(VALID_PARAMS)
+
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# TestNoExceptionLeaks
+# ---------------------------------------------------------------------------
+
+
+class TestNoExceptionLeaks:
+    @pytest.mark.asyncio
+    async def test_execution_error_does_not_propagate(self) -> None:
+        """No known error type should propagate out of execute()."""
+        from mcp_server.core.exceptions import ExecutionError
+
+        mock_manager = MagicMock()
+        mock_manager.create_issue.side_effect = ExecutionError("fail")
+        tool = CreateIssueTool(manager=mock_manager)
+
+        try:
+            await tool.execute(VALID_PARAMS)
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"execute() raised unexpectedly: {exc!r}")
+
+    @pytest.mark.asyncio
+    async def test_template_error_does_not_propagate(self) -> None:
+        tool = make_tool()
+        with patch.object(
+            tool, "_render_body", side_effect=jinja2.TemplateError("fail")
+        ):
+            try:
+                await tool.execute(VALID_PARAMS)
+            except Exception as exc:  # noqa: BLE001
+                pytest.fail(f"execute() raised unexpectedly: {exc!r}")

--- a/tests/unit/tools/test_create_issue_input.py
+++ b/tests/unit/tools/test_create_issue_input.py
@@ -1,0 +1,224 @@
+"""
+tests/unit/tools/test_create_issue_input.py
+============================================
+Cycle 4 — CreateIssueInput schema refactor.
+
+Tests:
+- All required fields (issue_type, title, priority, scope, body)
+- Validators: issue_type against IssueConfig, title max length, priority, scope
+- Optional fields: is_epic, parent_issue, milestone, assignees
+- Breaking change: body must be IssueBody, not str
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_server.tools.issue_tools import CreateIssueInput, IssueBody
+
+# ---------------------------------------------------------------------------
+# Helper: minimal valid input
+# ---------------------------------------------------------------------------
+
+VALID_BODY = IssueBody(problem="The tool crashes on startup.")
+
+VALID_MINIMAL: dict = {
+    "issue_type": "feature",
+    "title": "Add structured issue creation",
+    "priority": "medium",
+    "scope": "mcp-server",
+    "body": VALID_BODY,
+}
+
+
+# ---------------------------------------------------------------------------
+# TestCreateIssueInputRequired
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIssueInputRequired:
+    def test_all_required_fields_accepted(self) -> None:
+        inp = CreateIssueInput(**VALID_MINIMAL)
+        assert inp.issue_type == "feature"
+        assert inp.title == "Add structured issue creation"
+        assert inp.priority == "medium"
+        assert inp.scope == "mcp-server"
+        assert inp.body == VALID_BODY
+
+    def test_missing_issue_type_raises(self) -> None:
+        data = {k: v for k, v in VALID_MINIMAL.items() if k != "issue_type"}
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**data)
+
+    def test_missing_title_raises(self) -> None:
+        data = {k: v for k, v in VALID_MINIMAL.items() if k != "title"}
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**data)
+
+    def test_missing_priority_raises(self) -> None:
+        data = {k: v for k, v in VALID_MINIMAL.items() if k != "priority"}
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**data)
+
+    def test_missing_scope_raises(self) -> None:
+        data = {k: v for k, v in VALID_MINIMAL.items() if k != "scope"}
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**data)
+
+    def test_missing_body_raises(self) -> None:
+        data = {k: v for k, v in VALID_MINIMAL.items() if k != "body"}
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**data)
+
+
+# ---------------------------------------------------------------------------
+# TestIssueTypeValidation
+# ---------------------------------------------------------------------------
+
+
+class TestIssueTypeValidation:
+    def test_valid_issue_type_feature(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "issue_type": "feature"})
+        assert inp.issue_type == "feature"
+
+    def test_valid_issue_type_bug(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "issue_type": "bug"})
+        assert inp.issue_type == "bug"
+
+    def test_valid_issue_type_hotfix(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "issue_type": "hotfix"})
+        assert inp.issue_type == "hotfix"
+
+    def test_valid_issue_type_chore(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "issue_type": "chore"})
+        assert inp.issue_type == "chore"
+
+    def test_unknown_issue_type_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            CreateIssueInput(**{**VALID_MINIMAL, "issue_type": "nonsense"})
+        assert "nonsense" in str(exc_info.value)
+
+    def test_unknown_issue_type_error_hints_valid_values(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            CreateIssueInput(**{**VALID_MINIMAL, "issue_type": "invalid_type"})
+        error_str = str(exc_info.value)
+        # Error message should reference at least one valid type
+        assert "feature" in error_str or "Valid" in error_str or "valid" in error_str
+
+
+# ---------------------------------------------------------------------------
+# TestTitleValidation
+# ---------------------------------------------------------------------------
+
+
+class TestTitleValidation:
+    def test_title_within_72_chars_accepted(self) -> None:
+        title = "A" * 72
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "title": title})
+        assert len(inp.title) == 72
+
+    def test_title_exceeding_72_chars_raises(self) -> None:
+        title = "A" * 73
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**{**VALID_MINIMAL, "title": title})
+
+    def test_short_title_accepted(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "title": "Fix bug"})
+        assert inp.title == "Fix bug"
+
+
+# ---------------------------------------------------------------------------
+# TestPriorityValidation
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityValidation:
+    @pytest.mark.parametrize("priority", ["critical", "high", "medium", "low", "triage"])
+    def test_valid_priority_accepted(self, priority: str) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "priority": priority})
+        assert inp.priority == priority
+
+    def test_unknown_priority_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**{**VALID_MINIMAL, "priority": "urgent"})
+
+
+# ---------------------------------------------------------------------------
+# TestScopeValidation
+# ---------------------------------------------------------------------------
+
+
+class TestScopeValidation:
+    @pytest.mark.parametrize(
+        "scope",
+        ["architecture", "mcp-server", "platform", "tooling", "workflow", "documentation"],
+    )
+    def test_valid_scope_accepted(self, scope: str) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "scope": scope})
+        assert inp.scope == scope
+
+    def test_unknown_scope_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**{**VALID_MINIMAL, "scope": "backend"})
+
+
+# ---------------------------------------------------------------------------
+# TestBodyTypeValidation
+# ---------------------------------------------------------------------------
+
+
+class TestBodyTypeValidation:
+    def test_body_must_be_issue_body_instance(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**{**VALID_MINIMAL, "body": "plain string body"})  # type: ignore[arg-type]
+
+    def test_body_as_issue_body_accepted(self) -> None:
+        body = IssueBody(problem="Correct type")
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "body": body})
+        assert inp.body.problem == "Correct type"
+
+
+# ---------------------------------------------------------------------------
+# TestOptionalFields
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalFields:
+    def test_is_epic_defaults_to_false(self) -> None:
+        inp = CreateIssueInput(**VALID_MINIMAL)
+        assert inp.is_epic is False
+
+    def test_is_epic_true_accepted(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "is_epic": True})
+        assert inp.is_epic is True
+
+    def test_parent_issue_defaults_to_none(self) -> None:
+        inp = CreateIssueInput(**VALID_MINIMAL)
+        assert inp.parent_issue is None
+
+    def test_parent_issue_positive_int_accepted(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "parent_issue": 91})
+        assert inp.parent_issue == 91
+
+    def test_parent_issue_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**{**VALID_MINIMAL, "parent_issue": 0})
+
+    def test_parent_issue_negative_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateIssueInput(**{**VALID_MINIMAL, "parent_issue": -1})
+
+    def test_milestone_defaults_to_none(self) -> None:
+        inp = CreateIssueInput(**VALID_MINIMAL)
+        assert inp.milestone is None
+
+    def test_milestone_string_title_accepted(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "milestone": "v2.0"})
+        assert inp.milestone == "v2.0"
+
+    def test_assignees_defaults_to_none(self) -> None:
+        inp = CreateIssueInput(**VALID_MINIMAL)
+        assert inp.assignees is None
+
+    def test_assignees_list_accepted(self) -> None:
+        inp = CreateIssueInput(**{**VALID_MINIMAL, "assignees": ["alice", "bob"]})
+        assert inp.assignees == ["alice", "bob"]

--- a/tests/unit/tools/test_create_issue_input.py
+++ b/tests/unit/tools/test_create_issue_input.py
@@ -10,6 +10,8 @@ Tests:
 - Breaking change: body must be IssueBody, not str
 """
 
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -247,7 +249,6 @@ class TestBodyJsonStringCoercion:
 
     def test_body_json_string_minimal_is_coerced(self) -> None:
         """A JSON string with only `problem` is parsed into IssueBody."""
-        import json
         body_str = json.dumps({"problem": "Widget crashes on startup."})
         inp = CreateIssueInput(**{**VALID_MINIMAL, "body": body_str})
         assert isinstance(inp.body, IssueBody)
@@ -255,7 +256,6 @@ class TestBodyJsonStringCoercion:
 
     def test_body_json_string_full_is_coerced(self) -> None:
         """A JSON string with all optional fields is fully parsed."""
-        import json
         body_str = json.dumps({
             "problem": "Login fails.",
             "expected": "Redirect to dashboard.",
@@ -271,7 +271,6 @@ class TestBodyJsonStringCoercion:
 
     def test_body_json_string_missing_problem_raises(self) -> None:
         """A JSON string without `problem` raises ValidationError."""
-        import json
         body_str = json.dumps({"expected": "Something"})
         with pytest.raises(ValidationError):
             CreateIssueInput(**{**VALID_MINIMAL, "body": body_str})

--- a/tests/unit/tools/test_create_issue_input.py
+++ b/tests/unit/tools/test_create_issue_input.py
@@ -141,6 +141,14 @@ class TestPriorityValidation:
         with pytest.raises(ValidationError):
             CreateIssueInput(**{**VALID_MINIMAL, "priority": "urgent"})
 
+    def test_unknown_priority_error_references_valid_values(self) -> None:
+        """Validator must report config-sourced values, not a hardcoded constant."""
+        with pytest.raises(ValidationError) as exc_info:
+            CreateIssueInput(**{**VALID_MINIMAL, "priority": "urgent"})
+        error_str = str(exc_info.value)
+        # At least one of the config-driven priorities must appear in the error
+        assert any(p in error_str for p in ["critical", "high", "medium", "low", "triage"])
+
 
 # ---------------------------------------------------------------------------
 # TestScopeValidation

--- a/tests/unit/tools/test_create_issue_label_assembly.py
+++ b/tests/unit/tools/test_create_issue_label_assembly.py
@@ -1,0 +1,252 @@
+"""
+tests/unit/tools/test_create_issue_label_assembly.py
+======================================================
+Cycle 5 — Label assembly in CreateIssueTool.
+
+Tests for the private `_assemble_labels()` method and for `execute()` forwarding
+the assembled label list to GitHubManager (no free-form labels, no `labels=None`).
+
+Assembly rules (in order):
+  type_label     = "type:epic"                   if is_epic
+                 = IssueConfig.get_label(issue_type)   otherwise
+  scope_label    = "scope:{scope}"
+  priority_label = "priority:{priority}"
+  phase_label    = "phase:{first_phase}"          from workflows.yaml via issue_type → workflow
+  parent_label   = "parent:{n}"                  if parent_issue is not None
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_server.tools.issue_tools import CreateIssueInput, CreateIssueTool, IssueBody
+
+# ---------------------------------------------------------------------------
+# Shared minimal input factory
+# ---------------------------------------------------------------------------
+
+BODY = IssueBody(problem="Test problem")
+
+
+def make_params(**overrides) -> CreateIssueInput:  # type: ignore[no-untyped-def]
+    """Return a minimal valid CreateIssueInput with optional overrides."""
+    base = {
+        "issue_type": "feature",
+        "title": "Test issue",
+        "priority": "medium",
+        "scope": "mcp-server",
+        "body": BODY,
+    }
+    base.update(overrides)
+    return CreateIssueInput(**base)
+
+
+# ---------------------------------------------------------------------------
+# TestTypeLabelAssembly
+# ---------------------------------------------------------------------------
+
+
+class TestTypeLabelAssembly:
+    def test_feature_produces_type_feature(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="feature"))
+        assert "type:feature" in labels
+
+    def test_bug_produces_type_bug(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="bug"))
+        assert "type:bug" in labels
+
+    def test_hotfix_produces_type_bug_not_type_hotfix(self) -> None:
+        """hotfix maps to type:bug via IssueConfig.get_label(), not type:hotfix."""
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="hotfix"))
+        assert "type:bug" in labels
+        assert "type:hotfix" not in labels
+
+    def test_is_epic_overrides_type_to_type_epic(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="feature", is_epic=True))
+        assert "type:epic" in labels
+        assert "type:feature" not in labels
+
+    def test_is_epic_overrides_any_issue_type(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="bug", is_epic=True))
+        assert "type:epic" in labels
+        assert "type:bug" not in labels
+
+    def test_no_duplicate_type_labels(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="feature"))
+        type_labels = [l for l in labels if l.startswith("type:")]
+        assert len(type_labels) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestScopeLabelAssembly
+# ---------------------------------------------------------------------------
+
+
+class TestScopeLabelAssembly:
+    def test_scope_mcp_server_produces_scope_mcp_server(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(scope="mcp-server"))
+        assert "scope:mcp-server" in labels
+
+    def test_scope_tooling_produces_scope_tooling(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(scope="tooling"))
+        assert "scope:tooling" in labels
+
+    def test_scope_platform_produces_scope_platform(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(scope="platform"))
+        assert "scope:platform" in labels
+
+
+# ---------------------------------------------------------------------------
+# TestPriorityLabelAssembly
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityLabelAssembly:
+    def test_priority_medium_produces_priority_medium(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(priority="medium"))
+        assert "priority:medium" in labels
+
+    def test_priority_high_produces_priority_high(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(priority="high"))
+        assert "priority:high" in labels
+
+    def test_priority_critical_produces_priority_critical(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(priority="critical"))
+        assert "priority:critical" in labels
+
+
+# ---------------------------------------------------------------------------
+# TestPhaseLabelAssembly
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseLabelAssembly:
+    def test_feature_workflow_first_phase_is_research(self) -> None:
+        """feature → workflow:feature → first phase = research."""
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="feature"))
+        assert "phase:research" in labels
+
+    def test_hotfix_workflow_first_phase_is_tdd(self) -> None:
+        """hotfix → workflow:hotfix → first phase = tdd."""
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="hotfix"))
+        assert "phase:tdd" in labels
+
+    def test_docs_workflow_first_phase_is_planning(self) -> None:
+        """docs → workflow:docs → first phase = planning."""
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="docs"))
+        assert "phase:planning" in labels
+
+    def test_bug_workflow_first_phase_is_research(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="bug"))
+        assert "phase:research" in labels
+
+    def test_no_duplicate_phase_labels(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(issue_type="feature"))
+        phase_labels = [l for l in labels if l.startswith("phase:")]
+        assert len(phase_labels) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestParentLabelAssembly
+# ---------------------------------------------------------------------------
+
+
+class TestParentLabelAssembly:
+    def test_parent_issue_produces_parent_n_label(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(parent_issue=91))
+        assert "parent:91" in labels
+
+    def test_parent_issue_none_produces_no_parent_label(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(parent_issue=None))
+        assert not any(l.startswith("parent:") for l in labels)
+
+    def test_parent_issue_different_value(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(parent_issue=149))
+        assert "parent:149" in labels
+
+
+# ---------------------------------------------------------------------------
+# TestFullLabelSet
+# ---------------------------------------------------------------------------
+
+
+class TestFullLabelSet:
+    def test_minimal_input_produces_four_labels(self) -> None:
+        """Minimal input → type + scope + priority + phase (no parent)."""
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params())
+        assert len(labels) == 4
+
+    def test_with_parent_issue_produces_five_labels(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(make_params(parent_issue=10))
+        assert len(labels) == 5
+
+    def test_full_label_set_no_duplicates(self) -> None:
+        tool = CreateIssueTool(manager=MagicMock())
+        labels = tool._assemble_labels(
+            make_params(issue_type="bug", priority="high", scope="platform", parent_issue=55)
+        )
+        assert len(labels) == len(set(labels))
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteForwardsAssembledLabels
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteForwardsAssembledLabels:
+    @pytest.mark.asyncio
+    async def test_execute_passes_assembled_labels_to_manager(self) -> None:
+        """execute() must pass the assembled label list — not None — to create_issue."""
+        mock_manager = MagicMock()
+        mock_manager.create_issue.return_value = {
+            "number": 1,
+            "title": "Test",
+            "url": "http://x",
+        }
+        tool = CreateIssueTool(manager=mock_manager)
+
+        params = make_params(issue_type="feature", scope="mcp-server", priority="medium")
+        await tool.execute(params)
+
+        call_kwargs = mock_manager.create_issue.call_args.kwargs
+        labels = call_kwargs["labels"]
+        assert labels is not None
+        assert isinstance(labels, list)
+        assert len(labels) > 0
+
+    @pytest.mark.asyncio
+    async def test_execute_labels_include_type_scope_priority_phase(self) -> None:
+        mock_manager = MagicMock()
+        mock_manager.create_issue.return_value = {"number": 2, "title": "T", "url": ""}
+        tool = CreateIssueTool(manager=mock_manager)
+
+        params = make_params(issue_type="feature", scope="tooling", priority="high")
+        await tool.execute(params)
+
+        labels = mock_manager.create_issue.call_args.kwargs["labels"]
+        assert "type:feature" in labels
+        assert "scope:tooling" in labels
+        assert "priority:high" in labels
+        assert "phase:research" in labels

--- a/tests/unit/tools/test_create_issue_label_assembly.py
+++ b/tests/unit/tools/test_create_issue_label_assembly.py
@@ -28,7 +28,7 @@ from mcp_server.tools.issue_tools import CreateIssueInput, CreateIssueTool, Issu
 BODY = IssueBody(problem="Test problem")
 
 
-def make_params(**overrides) -> CreateIssueInput:  # type: ignore[no-untyped-def]
+def make_params(**overrides: object) -> CreateIssueInput:
     """Return a minimal valid CreateIssueInput with optional overrides."""
     base = {
         "issue_type": "feature",
@@ -79,7 +79,7 @@ class TestTypeLabelAssembly:
     def test_no_duplicate_type_labels(self) -> None:
         tool = CreateIssueTool(manager=MagicMock())
         labels = tool._assemble_labels(make_params(issue_type="feature"))
-        type_labels = [l for l in labels if l.startswith("type:")]
+        type_labels = [lbl for lbl in labels if lbl.startswith("type:")]
         assert len(type_labels) == 1
 
 
@@ -159,7 +159,7 @@ class TestPhaseLabelAssembly:
     def test_no_duplicate_phase_labels(self) -> None:
         tool = CreateIssueTool(manager=MagicMock())
         labels = tool._assemble_labels(make_params(issue_type="feature"))
-        phase_labels = [l for l in labels if l.startswith("phase:")]
+        phase_labels = [lbl for lbl in labels if lbl.startswith("phase:")]
         assert len(phase_labels) == 1
 
 
@@ -177,7 +177,7 @@ class TestParentLabelAssembly:
     def test_parent_issue_none_produces_no_parent_label(self) -> None:
         tool = CreateIssueTool(manager=MagicMock())
         labels = tool._assemble_labels(make_params(parent_issue=None))
-        assert not any(l.startswith("parent:") for l in labels)
+        assert not any(lbl.startswith("parent:") for lbl in labels)
 
     def test_parent_issue_different_value(self) -> None:
         tool = CreateIssueTool(manager=MagicMock())

--- a/tests/unit/tools/test_create_issue_schema.py
+++ b/tests/unit/tools/test_create_issue_schema.py
@@ -1,0 +1,60 @@
+"""C9 RED: input_schema for CreateIssueTool must not contain $ref or $defs.
+
+VS Code / Copilot Chat does not resolve JSON Schema $ref references when
+constructing MCP tool call arguments. If the schema contains
+  body: {"$ref": "#/$defs/IssueBody"}
+Claude cannot build the nested object and returns "no response".
+
+Fix: override input_schema in CreateIssueTool to inline all $ref references
+so that the schema is fully self-contained (no $defs, no $ref).
+"""
+
+import json
+
+import pytest
+
+from mcp_server.tools.issue_tools import CreateIssueTool
+
+
+class TestCreateIssueInputSchemaNoRefs:
+    """CreateIssueTool.input_schema must be fully inlined — no $ref / $defs."""
+
+    @pytest.fixture
+    def schema(self) -> dict:  # type: ignore[type-arg]
+        tool = CreateIssueTool.__new__(CreateIssueTool)
+        return tool.input_schema
+
+    def test_schema_has_no_defs_key(self, schema: dict) -> None:  # type: ignore[type-arg]
+        """$defs key must be absent from the top-level schema."""
+        assert "$defs" not in schema, (
+            "input_schema must not contain $defs — use inlined properties instead"
+        )
+
+    def test_schema_body_has_no_ref(self, schema: dict) -> None:  # type: ignore[type-arg]
+        """body property must not be a $ref — it must be inlined."""
+        body_prop = schema.get("properties", {}).get("body", {})
+        assert "$ref" not in body_prop, (
+            "body property must not use $ref — inline IssueBody properties directly"
+        )
+
+    def test_schema_body_is_object_type(self, schema: dict) -> None:  # type: ignore[type-arg]
+        """body property must declare type: object."""
+        body_prop = schema.get("properties", {}).get("body", {})
+        assert body_prop.get("type") == "object", (
+            "body property must have type: object after $ref resolution"
+        )
+
+    def test_schema_body_has_problem_property(self, schema: dict) -> None:  # type: ignore[type-arg]
+        """body.properties.problem must exist after inlining."""
+        body_prop = schema.get("properties", {}).get("body", {})
+        body_properties = body_prop.get("properties", {})
+        assert "problem" in body_properties, (
+            "body.properties.problem must exist after $ref is resolved"
+        )
+
+    def test_schema_has_no_ref_anywhere(self, schema: dict) -> None:  # type: ignore[type-arg]
+        """No $ref should appear anywhere in the serialized schema."""
+        serialized = json.dumps(schema)
+        assert '"$ref"' not in serialized, (
+            "input_schema must not contain any $ref references — all must be inlined"
+        )

--- a/tests/unit/tools/test_issue_body.py
+++ b/tests/unit/tools/test_issue_body.py
@@ -125,3 +125,41 @@ class TestRenderBody:
         result = tool._render_body(body)
         assert isinstance(result, str)
         assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# TestRenderBodyTitleAndFormat  (Cycle 7 RED — bug fixes for issue #157)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderBodyTitleAndFormat:
+    """_render_body() must forward title as H1 and hide the SCAFFOLD header."""
+
+    def test_render_body_title_appears_as_h1(self, tool: CreateIssueTool) -> None:
+        """Title arg must be rendered as `# <title>` in the output."""
+        body = IssueBody(problem="Widget explodes on startup")
+        result = tool._render_body(body, title="Widget Login Bug")
+        assert "# Widget Login Bug" in result
+
+    def test_render_body_scaffold_not_visible_as_plain_text(self, tool: CreateIssueTool) -> None:
+        """SCAFFOLD metadata must NOT appear as visible plain text (must be HTML comment)."""
+        body = IssueBody(problem="p")
+        result = tool._render_body(body, title="Test")
+        # Plain-text form from non-markdown rendering — must not be present
+        assert "# template=" not in result
+        assert "# version=" not in result
+
+    def test_render_body_scaffold_is_html_comment(self, tool: CreateIssueTool) -> None:
+        """SCAFFOLD metadata must be rendered as an HTML comment (invisible on GitHub)."""
+        body = IssueBody(problem="p")
+        result = tool._render_body(body, title="Test")
+        assert "<!-- template=" in result
+
+    def test_render_body_different_titles_produce_different_h1(self, tool: CreateIssueTool) -> None:
+        """Different titles produce different H1 headings."""
+        body = IssueBody(problem="p")
+        result_a = tool._render_body(body, title="Alpha")
+        result_b = tool._render_body(body, title="Beta")
+        assert "# Alpha" in result_a
+        assert "# Beta" in result_b
+        assert "# Alpha" not in result_b

--- a/tests/unit/tools/test_issue_body.py
+++ b/tests/unit/tools/test_issue_body.py
@@ -83,9 +83,7 @@ class TestRenderBody:
         assert "## Problem" in result
         assert "Widget explodes on startup" in result
 
-    def test_render_minimal_body_excludes_optional_sections(
-        self, tool: CreateIssueTool
-    ) -> None:
+    def test_render_minimal_body_excludes_optional_sections(self, tool: CreateIssueTool) -> None:
         body = IssueBody(problem="minimal")
         result = tool._render_body(body)
         assert "## Expected Behavior" not in result

--- a/tests/unit/tools/test_issue_body.py
+++ b/tests/unit/tools/test_issue_body.py
@@ -1,0 +1,129 @@
+"""
+tests/unit/tools/test_issue_body.py
+====================================
+Cycle 3 — IssueBody Pydantic model and _render_body() helper.
+
+Tests:
+- IssueBody field requirements and defaults
+- Rendering via CreateIssueTool._render_body() with issue.md.jinja2
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_server.config.template_config import get_template_root
+from mcp_server.scaffolding.renderer import JinjaRenderer
+from mcp_server.tools.issue_tools import CreateIssueTool, IssueBody
+
+
+@pytest.fixture(name="renderer")
+def _renderer() -> JinjaRenderer:
+    return JinjaRenderer(template_dir=get_template_root())
+
+
+@pytest.fixture(name="tool")
+def _tool(renderer: JinjaRenderer) -> CreateIssueTool:
+    tool = CreateIssueTool.__new__(CreateIssueTool)
+    tool._renderer = renderer  # inject without GitHubManager
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# TestIssueBodyModel
+# ---------------------------------------------------------------------------
+
+
+class TestIssueBodyModel:
+    def test_problem_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            IssueBody()  # type: ignore[call-arg]
+
+    def test_problem_is_accepted(self) -> None:
+        body = IssueBody(problem="Some problem")
+        assert body.problem == "Some problem"
+
+    def test_all_optional_fields_default_to_none(self) -> None:
+        body = IssueBody(problem="p")
+        assert body.expected is None
+        assert body.actual is None
+        assert body.context is None
+        assert body.steps_to_reproduce is None
+        assert body.related_docs is None
+
+    def test_related_docs_accepts_list_of_strings(self) -> None:
+        body = IssueBody(problem="p", related_docs=["docs/a.md", "docs/b.md"])
+        assert body.related_docs == ["docs/a.md", "docs/b.md"]
+
+    def test_related_docs_rejects_plain_string(self) -> None:
+        with pytest.raises(ValidationError):
+            IssueBody(problem="p", related_docs="docs/a.md")  # type: ignore[arg-type]
+
+    def test_full_body_accepted(self) -> None:
+        body = IssueBody(
+            problem="p",
+            expected="e",
+            actual="a",
+            context="c",
+            steps_to_reproduce="1. step",
+            related_docs=["docs/planning.md"],
+        )
+        assert body.expected == "e"
+        assert body.steps_to_reproduce == "1. step"
+
+
+# ---------------------------------------------------------------------------
+# TestRenderBody
+# ---------------------------------------------------------------------------
+
+
+class TestRenderBody:
+    def test_render_produces_problem_section(self, tool: CreateIssueTool) -> None:
+        body = IssueBody(problem="Widget explodes on startup")
+        result = tool._render_body(body)
+        assert "## Problem" in result
+        assert "Widget explodes on startup" in result
+
+    def test_render_minimal_body_excludes_optional_sections(
+        self, tool: CreateIssueTool
+    ) -> None:
+        body = IssueBody(problem="minimal")
+        result = tool._render_body(body)
+        assert "## Expected Behavior" not in result
+        assert "## Actual Behavior" not in result
+        assert "## Context" not in result
+
+    def test_render_includes_expected_section(self, tool: CreateIssueTool) -> None:
+        body = IssueBody(problem="p", expected="Should work")
+        result = tool._render_body(body)
+        assert "## Expected Behavior" in result
+        assert "Should work" in result
+
+    def test_render_includes_actual_section(self, tool: CreateIssueTool) -> None:
+        body = IssueBody(problem="p", actual="Does not work")
+        result = tool._render_body(body)
+        assert "## Actual Behavior" in result
+        assert "Does not work" in result
+
+    def test_render_includes_context_section(self, tool: CreateIssueTool) -> None:
+        body = IssueBody(problem="p", context="Only on Windows")
+        result = tool._render_body(body)
+        assert "## Context" in result
+        assert "Only on Windows" in result
+
+    def test_render_includes_steps_to_reproduce(self, tool: CreateIssueTool) -> None:
+        body = IssueBody(problem="p", steps_to_reproduce="1. Open app\n2. Click crash")
+        result = tool._render_body(body)
+        assert "## Steps to Reproduce" in result
+        assert "1. Open app" in result
+
+    def test_render_includes_related_docs_section(self, tool: CreateIssueTool) -> None:
+        body = IssueBody(problem="p", related_docs=["docs/planning.md", "docs/design.md"])
+        result = tool._render_body(body)
+        assert "planning.md" in result
+        assert "design.md" in result
+
+    def test_render_returns_string(self, tool: CreateIssueTool) -> None:
+        body = IssueBody(problem="p")
+        result = tool._render_body(body)
+        assert isinstance(result, str)
+        assert len(result) > 0

--- a/tests/unit/tools/test_issue_tools.py
+++ b/tests/unit/tools/test_issue_tools.py
@@ -1,4 +1,5 @@
 """Unit tests for issue_tools.py."""
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,6 +11,7 @@ from mcp_server.tools.issue_tools import (
     CreateIssueTool,
     GetIssueInput,
     GetIssueTool,
+    IssueBody,
     ListIssuesInput,
     ListIssuesTool,
     UpdateIssueInput,
@@ -18,24 +20,31 @@ from mcp_server.tools.issue_tools import (
 
 
 @pytest.fixture
-def mock_github_manager():
+def mock_github_manager() -> MagicMock:
     return MagicMock()
 
+
 @pytest.mark.asyncio
-async def test_create_issue_tool(mock_github_manager):
+async def test_create_issue_tool(mock_github_manager: MagicMock) -> None:
     tool = CreateIssueTool(manager=mock_github_manager)
-    # Return a dict to match GitHubManager.create_issue behavior
     issue_mock = {"number": 123, "url": "http://github.com/issues/123", "title": "New Issue"}
     mock_github_manager.create_issue.return_value = issue_mock
 
-    params = CreateIssueInput(title="New Issue", body="Description")
+    params = CreateIssueInput(
+        issue_type="feature",
+        title="New Issue",
+        priority="medium",
+        scope="mcp-server",
+        body=IssueBody(problem="Some problem description"),
+    )
     result = await tool.execute(params)
 
     mock_github_manager.create_issue.assert_called_once()
     assert "Created issue #123" in result.content[0]["text"]
 
+
 @pytest.mark.asyncio
-async def test_update_issue_tool(mock_github_manager):
+async def test_update_issue_tool(mock_github_manager: MagicMock) -> None:
     tool = UpdateIssueTool(manager=mock_github_manager)
     mock_github_manager.update_issue.return_value = MagicMock(number=123)
 
@@ -43,17 +52,23 @@ async def test_update_issue_tool(mock_github_manager):
     result = await tool.execute(params)
 
     mock_github_manager.update_issue.assert_called_with(
-        issue_number=123, title="Updated Title", body=None, state=None,
-        labels=None, assignees=None, milestone=None
+        issue_number=123,
+        title="Updated Title",
+        body=None,
+        state=None,
+        labels=None,
+        assignees=None,
+        milestone=None,
     )
     assert "Updated issue #123" in result.content[0]["text"]
 
+
 @pytest.mark.asyncio
-async def test_list_issues_tool(mock_github_manager):
+async def test_list_issues_tool(mock_github_manager: MagicMock) -> None:
     tool = ListIssuesTool(manager=mock_github_manager)
     mock_github_manager.list_issues.return_value = [
         MagicMock(number=1, title="Issue 1", state="open", labels=[MagicMock(name="bug")]),
-        MagicMock(number=2, title="Issue 2", state="closed", labels=[])
+        MagicMock(number=2, title="Issue 2", state="closed", labels=[]),
     ]
 
     params = ListIssuesInput(state="open", labels=["bug"])
@@ -63,8 +78,9 @@ async def test_list_issues_tool(mock_github_manager):
     mock_github_manager.list_issues.assert_called_with(state="open", labels=["bug"])
     assert "#1 Issue 1" in result.content[0]["text"]
 
+
 @pytest.mark.asyncio
-async def test_get_issue_tool(mock_github_manager):
+async def test_get_issue_tool(mock_github_manager: MagicMock) -> None:
     tool = GetIssueTool(manager=mock_github_manager)
 
     issue_mock = MagicMock(
@@ -76,7 +92,7 @@ async def test_get_issue_tool(mock_github_manager):
         created_at=MagicMock(isoformat=lambda: "2023-01-01"),
         assignees=[],
         labels=[],
-        milestone=None
+        milestone=None,
     )
     mock_github_manager.get_issue.return_value = issue_mock
 
@@ -86,8 +102,9 @@ async def test_get_issue_tool(mock_github_manager):
     assert "#1: Bug" in result.content[0]["text"]
     assert "Fix it" in result.content[0]["text"]
 
+
 @pytest.mark.asyncio
-async def test_close_issue_tool(mock_github_manager):
+async def test_close_issue_tool(mock_github_manager: MagicMock) -> None:
     tool = CloseIssueTool(manager=mock_github_manager)
     mock_github_manager.close_issue.return_value = MagicMock(number=5)
 


### PR DESCRIPTION
## Summary

Redesign de `create_issue` MCP tool met een gestructureerd `IssueBody` object, config-driven label assembly en Pydantic input validatie — vervangt het fragiele Jinja2-template veld contract door een expliciete, statisch-getypte API.

Closes #149

---

## Wat is veranderd

### Nieuwe productie code
| File | Doel |
|---|---|
| `mcp_server/config/issue_config.py` | `IssueConfig` — issue type → workflow + `type:*` label |
| `mcp_server/config/scope_config.py` | `ScopeConfig` — laadt `.st3/scopes.yaml`, valideert scope inputs |
| `mcp_server/config/workflow_config.py` | `WorkflowConfig` — laadt `.st3/workflows.yaml`, first-phase lookup |
| `mcp_server/config/milestone_config.py` | `MilestoneConfig` — valideert milestone titles t.o.v. `.st3/milestones.yaml` |
| `mcp_server/config/contributor_config.py` | `ContributorConfig` — valideert assignee GitHub logins |
| `mcp_server/tools/issue_tools.py` | `CreateIssueInput` (Pydantic), `IssueBody`, `_assemble_labels()`, `execute()` |
| `mcp_server/server.py` | Nieuwe config modules geregistreerd + ruff format fixes |

### Config bestanden
- `.st3/issues.yaml` — issue type → workflow + label
- `.st3/scopes.yaml` — geldige scope namen
- `.st3/milestones.yaml` — milestone title registry
- `.st3/contributors.yaml` — geldige GitHub logins
- `.st3/labels.yaml` — `parent:\d+` pattern toegevoegd, status:* labels verwijderd

### Tests (TDD cycles C7/C8/C9)
- `tests/unit/tools/test_create_issue_input.py` — Pydantic validators (33 cases)
- `tests/unit/tools/test_create_issue_label_assembly.py` — `_assemble_labels()` (30 cases)
- `tests/unit/tools/test_create_issue_errors.py` — error path validation
- `tests/unit/tools/test_create_issue_schema.py` — JSON schema structuur
- `tests/unit/tools/test_issue_body.py` — `IssueBody` model
- `tests/unit/config/test_{issue,scope,milestone,contributor}_config.py` — singleton + YAML loading
- `tests/unit/config/test_labels_yaml_conventions.py` — `.st3/labels.yaml` contracts
- `tests/integration/test_create_issue_e2e.py` — end-to-end met GitHub stub

### Test infrastructure fix
Autouse fixture toegevoegd in `tests/conftest.py` die alle config singletons reset (`IssueConfig`, `ScopeConfig`, `WorkflowConfig`, `MilestoneConfig`, `ContributorConfig`, `LabelConfig`) voor/na elke test — voorkomt cross-test singleton contaminatie in de volledige suite.

### Documentatie
- `agent.md` §2.1 — tools table bijgewerkt met `create_issue` signatuur
- `docs/reference/mcp/MCP_TOOLS.md` — issue lifecycle sectie
- `docs/reference/mcp/mcp_vision_reference.md` — config-driven architectuur notities
- `.st3/labels.yaml` CHANGELOG entry

---

## Quality Gates

| Gate | Resultaat |
|---|---|
| ruff format | ✅ |
| ruff check | ✅ |
| pyright | ✅ |
| mypy | ✅ |
| pytest (volledige suite) | ✅ 1978 passed, 9 skipped, 0 failures |

---

## Follow-up

Issue #187 — decouple `create_issue` van het Jinja2 template veld contract (body rendering path).