### PR TITLE
feat(#146): TDD Cycle Tracking & Validation — integration branch → main

### DIFF
--- a/.st3/projects.json
+++ b/.st3/projects.json
@@ -470,7 +470,7 @@
       "planning",
       "design",
       "tdd",
-      "integration",
+      "validation",
       "documentation"
     ],
     "skip_reason": null,
@@ -485,11 +485,360 @@
       "research",
       "planning",
       "tdd",
-      "integration",
+      "validation",
       "documentation"
     ],
     "skip_reason": null,
     "parent_branch": null,
     "created_at": "2026-02-14T20:53:55.634622+00:00"
+  },
+  "146": {
+    "issue_title": "TDD Cycle Tracking &amp; Validation (Planning Outcome \u2192 State Machine)",
+    "workflow_name": "feature",
+    "execution_mode": "interactive",
+    "required_phases": [
+      "research",
+      "planning",
+      "design",
+      "tdd",
+      "validation",
+      "documentation"
+    ],
+    "skip_reason": null,
+    "parent_branch": null,
+    "created_at": "2026-02-17T08:37:24.636799+00:00"
+  },
+  "229": {
+    "issue_title": "Phase deliverables enforcement: exit gate (hard) + entry warning (soft)",
+    "workflow_name": "feature",
+    "execution_mode": "interactive",
+    "required_phases": [
+      "research",
+      "planning",
+      "design",
+      "tdd",
+      "validation",
+      "documentation"
+    ],
+    "skip_reason": null,
+    "parent_branch": "feature/146-tdd-cycle-tracking",
+    "created_at": "2026-02-19T09:50:48.221403+00:00",
+    "planning_deliverables": {
+      "tdd_cycles": {
+        "total": 10,
+        "cycles": [
+          {
+            "cycle_number": 1,
+            "deliverables": [
+              {
+                "id": "D1.1",
+                "description": "workphases.yaml: exit_requires + entry_expects fields on planning phase",
+                "validates": {
+                  "type": "key_path",
+                  "file": ".st3/workphases.yaml",
+                  "path": "phases.planning.exit_requires"
+                }
+              },
+              {
+                "id": "D1.2",
+                "description": "DeliverableChecker implementation",
+                "validates": {
+                  "type": "file_exists",
+                  "file": "mcp_server/managers/deliverable_checker.py"
+                }
+              },
+              {
+                "id": "D1.3",
+                "description": "DeliverableChecker unit tests",
+                "validates": {
+                  "type": "file_exists",
+                  "file": "tests/unit/mcp_server/managers/test_deliverable_checker.py"
+                }
+              }
+            ],
+            "exit_criteria": "All 8 unit tests pass (schema backward compat + checker)"
+          },
+          {
+            "cycle_number": 2,
+            "deliverables": [
+              {
+                "id": "D2.1",
+                "description": "PhaseStateEngine: on_exit_planning_phase wired to WorkphasesConfig + DeliverableChecker (Option B)",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "on_exit_planning_phase"
+                }
+              },
+              {
+                "id": "D2.2",
+                "description": "PhaseStateEngine: on_enter_tdd_phase no longer validates planning_deliverables independently",
+                "validates": {
+                  "type": "absent_text",
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "planning_deliverables"
+                }
+              },
+              {
+                "id": "D2.3",
+                "description": "DeliverableChecker: file_glob type added (GAP-05) \u2014 pattern-based file existence check",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/deliverable_checker.py",
+                  "text": "file_glob"
+                }
+              },
+              {
+                "id": "D2.4",
+                "description": "git_add_or_commit validates workflow_phase + cycle_number against state.json (GAP-07) \u2014 blocks on phase mismatch",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/tools/git_tools.py",
+                  "text": "phase_mismatch"
+                }
+              }
+            ],
+            "exit_criteria": "All 9 tests pass; planning exit gate wired to WorkphasesConfig+DeliverableChecker; file_glob type available"
+          },
+          {
+            "cycle_number": 3,
+            "deliverables": [
+              {
+                "id": "D3.1",
+                "description": "force_transition logs warning listing skipped gates",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "skipped_gates"
+                }
+              },
+              {
+                "id": "D3.2",
+                "description": "force_cycle_transition warns about unvalidated deliverables in skipped cycles (GAP-08)",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/tools/transition_tools.py",
+                  "text": "Unvalidated cycle deliverables"
+                }
+              }
+            ],
+            "exit_criteria": "All 5 tests pass; forced phase transition warns skipped gates; forced cycle transition warns unvalidated skipped cycle deliverables"
+          },
+          {
+            "cycle_number": 4,
+            "deliverables": [
+              {
+                "id": "D4.1",
+                "description": "SavePlanningDeliverablesTool defined in project_tools.py",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/tools/project_tools.py",
+                  "text": "SavePlanningDeliverablesTool"
+                }
+              },
+              {
+                "id": "D4.2",
+                "description": "SavePlanningDeliverablesTool registered in server.py",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/server.py",
+                  "text": "SavePlanningDeliverablesTool"
+                }
+              },
+              {
+                "id": "D4.3",
+                "description": "Layer 2 schema validation: validates entry type + required fields checked before persisting (GAP-06)",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/tools/project_tools.py",
+                  "text": "validate_spec"
+                }
+              }
+            ],
+            "exit_criteria": "All 6 tests pass; tool callable via MCP; rejects invalid validates.type with helpful error listing available types and required fields"
+          },
+          {
+            "cycle_number": 5,
+            "deliverables": [
+              {
+                "id": "D5.1",
+                "description": "UpdatePlanningDeliverablesTool defined in project_tools.py with merge-strategy",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/tools/project_tools.py",
+                  "text": "UpdatePlanningDeliverablesTool"
+                }
+              },
+              {
+                "id": "D5.2",
+                "description": "ProjectManager.update_planning_deliverables() merge logic implemented",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/project_manager.py",
+                  "text": "update_planning_deliverables"
+                }
+              },
+              {
+                "id": "D5.3",
+                "description": "UpdatePlanningDeliverablesTool registered in server.py",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/server.py",
+                  "text": "UpdatePlanningDeliverablesTool"
+                }
+              }
+            ],
+            "exit_criteria": "All 5 tests pass; new cycles append, existing deliverables merge by id; call before initial save raises clear error"
+          },
+          {
+            "cycle_number": 6,
+            "deliverables": [
+              {
+                "id": "D6.1",
+                "description": "PhaseStateEngine reads type:file_glob from exit_requires and checks filesystem",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "file_glob"
+                }
+              },
+              {
+                "id": "D6.2",
+                "description": "workphases.yaml research phase configured with file_glob exit gate",
+                "validates": {
+                  "type": "key_path",
+                  "file": ".st3/workphases.yaml",
+                  "path": "phases.research.exit_requires"
+                }
+              }
+            ],
+            "exit_criteria": "All 5 tests pass; research phase blocks transition without *research*.md; {issue_number} interpolated correctly"
+          },
+          {
+            "cycle_number": 7,
+            "deliverables": [
+              {
+                "id": "D7.1",
+                "description": "save_planning_deliverables accepts per-phase keys (design, validation, documentation) alongside tdd_cycles",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/project_manager.py",
+                  "text": "phase_deliverables"
+                }
+              },
+              {
+                "id": "D7.2",
+                "description": "PhaseStateEngine exit gate checks planning_deliverables.<phase>.deliverables when present",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "phase_deliverables"
+                }
+              }
+            ],
+            "exit_criteria": "All 5 tests pass; per-phase deliverable gates optional; hotfix workflow unaffected"
+          },
+          {
+            "cycle_number": 8,
+            "deliverables": [
+              {
+                "id": "D8.1",
+                "description": "update_planning_deliverables merges design/validation/documentation keys analoog aan tdd_cycles",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/project_manager.py",
+                  "text": "incoming_phase"
+                }
+              },
+              {
+                "id": "D8.2",
+                "description": "Per-fase merge by id: bestaande entry met matching id updated, nieuwe id toegevoegd",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/project_manager.py",
+                  "text": "_known_phase_keys"
+                }
+              },
+              {
+                "id": "D8.3",
+                "description": "exit_criteria op bestaande cycle wordt overschreven bij update",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/project_manager.py",
+                  "text": "exit_criteria"
+                }
+              }
+            ],
+            "exit_criteria": "All 6 tests pass; update met design key updated projects.json; update tdd_cycles backward compat"
+          },
+          {
+            "cycle_number": 9,
+            "deliverables": [
+              {
+                "id": "D9.1",
+                "description": "PhaseStateEngine.on_exit_validation_phase() geimplementeerd analoog aan on_exit_design_phase",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "on_exit_validation_phase"
+                }
+              },
+              {
+                "id": "D9.2",
+                "description": "PhaseStateEngine.on_exit_documentation_phase() geimplementeerd analoog aan on_exit_design_phase",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "on_exit_documentation_phase"
+                }
+              },
+              {
+                "id": "D9.3",
+                "description": "transition() wired: on_exit_validation_phase en on_exit_documentation_phase aangeroepen bij juiste from_phase",
+                "validates": {
+                  "type": "contains_text",
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "on_exit_documentation_phase"
+                }
+              }
+            ],
+            "exit_criteria": "All 6 tests pass; validation->documentation blokkeert op falende spec; gate optioneel; GAP-14 specs gecorrigeerd"
+          },
+          {
+            "cycle_number": 10,
+            "deliverables": [
+              {
+                "description": "force_phase_transition response emits blocking gates before \u2705 success line",
+                "id": "D10.1",
+                "validates": {
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "ACTION REQUIRED",
+                  "type": "contains_text"
+                }
+              },
+              {
+                "description": "force_cycle_transition response emits blocking deliverables before \u2705 success line",
+                "id": "D10.2",
+                "validates": {
+                  "file": "mcp_server/tools/transition_tools.py",
+                  "text": "ACTION REQUIRED",
+                  "type": "contains_text"
+                }
+              },
+              {
+                "description": "Skipped gates classified as would_block vs would_pass before emitting response",
+                "id": "D10.3",
+                "validates": {
+                  "file": "mcp_server/managers/phase_state_engine.py",
+                  "text": "would_block",
+                  "type": "contains_text"
+                }
+              }
+            ],
+            "exit_criteria": "All 5 tests pass; blocking gates appear before \u2705; passing gates appear after or omitted; transition behaviour unchanged"
+          }
+        ]
+      }
+    }
   }
 }

--- a/.st3/workflows.yaml
+++ b/.st3/workflows.yaml
@@ -10,49 +10,49 @@ workflows:
   # Feature Development (full workflow)
   feature:
     name: feature
-    description: "Full development workflow with all phases (research → design → TDD → integration → docs)"
+    description: "Full development workflow with all phases (research → design → TDD → validation → docs)"
     default_execution_mode: interactive
     phases:
       - research
       - planning
       - design
       - tdd
-      - integration
+      - validation
       - documentation
 
   # Bug Fix (with lightweight design phase for uniformity)
   bug:
     name: bug
-    description: "Bug fix workflow (research → planning → design → TDD → integration → docs)"
+    description: "Bug fix workflow (research → planning → design → TDD → validation → docs)"
     default_execution_mode: interactive
     phases:
       - research
       - planning
       - design
       - tdd
-      - integration
+      - validation
       - documentation
 
   # Hotfix (minimal workflow)
   hotfix:
     name: hotfix
-    description: "Emergency fix workflow (TDD → integration → docs only)"
+    description: "Emergency fix workflow (TDD → validation → docs only)"
     default_execution_mode: autonomous
     phases:
       - tdd
-      - integration
+      - validation
       - documentation
 
   # Refactor (no design phase by default)
   refactor:
     name: refactor
-    description: "Code refactoring workflow (research → planning → TDD → integration → docs)"
+    description: "Code refactoring workflow (research → planning → TDD → validation → docs)"
     default_execution_mode: interactive
     phases:
       - research
       - planning
       - tdd
-      - integration
+      - validation
       - documentation
 
   # Documentation (minimal workflow)
@@ -75,4 +75,3 @@ workflows:
       - design
       - coordination
       - documentation
-

--- a/.st3/workphases.yaml
+++ b/.st3/workphases.yaml
@@ -12,6 +12,10 @@ phases:
     description: "Problem analysis, requirements gathering, technical exploration"
     commit_type_hint: "docs"
     subphases: []  # No subphases for research
+    exit_requires:
+      - type: file_glob
+        file: "docs/development/issue{issue_number}/*research*.md"
+        description: "Research document aanwezig (Issue #229 C6)"
 
   planning:
     display_name: "Planning"
@@ -22,6 +26,9 @@ phases:
       - "c2"  # Cycle 2
       - "c3"  # Cycle 3
       - "c4"  # Cycle 4
+    exit_requires:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown with validates specs (Issue #229)"
 
   design:
     display_name: "Design"
@@ -40,9 +47,12 @@ phases:
       - "red"          # Write failing test
       - "green"        # Implement minimum code to pass
       - "refactor"     # Clean up code
+    entry_expects:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown expected from planning phase (Issue #229)"
 
-  integration:
-    display_name: "Integration"
+  validation:
+    display_name: "Validation"
     description: "End-to-end testing, acceptance testing, system integration"
     commit_type_hint: "test"
     subphases:

--- a/docs/development/issue146/design.md
+++ b/docs/development/issue146/design.md
@@ -1,0 +1,909 @@
+<!-- docs/development/issue146/design.md -->
+<!-- template=design version=5827e841 created=2026-02-17T11:00:00Z updated= -->
+# Issue #146 TDD Cycle Tracking & Validation - Design
+
+**Status:** DRAFT  
+**Version:** 1.0  
+**Last Updated:** 2026-02-17
+
+---
+
+## Scope
+
+**In Scope:**
+Tool signatures, class diagrams, sequence diagrams, module organization, validation patterns, phase rename (manual recovery)
+
+**Out of Scope:**
+Implementation code, test cases, performance optimization
+
+---
+
+## 1. Context & Requirements
+
+### 1.1. Problem Statement
+
+TDD cycle tracking missing: no planning deliverables storage, no cycle state in state.json, no validation of cycle_number parameter, no discovery tools visibility, confusing 'integration' phase terminology
+
+### 1.2. Requirements
+
+**Functional:**
+- [ ] Store planning_deliverables in projects.json
+- [ ] Track current_tdd_cycle in state.json
+- [ ] Validate cycle_number for all TDD commits
+- [ ] Transition tools: transition_cycle, force_cycle_transition
+- [ ] Discovery tools show cycle info during TDD
+- [ ] Rename integration phase to validation
+
+**Non-Functional:**
+- [ ] Mirror PhaseStateEngine transition patterns
+- [ ] Graceful degradation for discovery tools
+- [ ] Strict validation for TDD workflow
+- [ ] Audit trail for forced transitions
+- [ ] Manual recovery errors for "integration" → "validation" rename
+
+### 1.3. Constraints
+
+None
+---
+
+## 2. Design Options
+
+### 2.1. Option A: Extend PhaseStateEngine (CHOSEN)
+
+**Approach:** Add cycle tracking fields to existing PhaseStateEngine, create new MCP tools
+
+**Pros:**
+- ✅ Consistent with existing architecture patterns
+- ✅ Reuses transition validation logic
+- ✅ Minimal new abstractions (DRY principle)
+- ✅ state.json already managed by PhaseStateEngine
+
+**Cons:**
+- ❌ PhaseStateEngine grows in responsibility (but still cohesive)
+
+### 2.2. Option B: Separate CycleManager
+
+**Approach:** Create new CycleManager class parallel to PhaseStateEngine
+
+**Pros:**
+- ✅ Single Responsibility (cycle management separate from phase management)
+
+**Cons:**
+- ❌ Duplicates transition logic (force transitions, validation, audit trail)
+- ❌ Two state managers writing to state.json (coordination complexity)
+- ❌ Inconsistent with existing patterns
+
+### 2.3. Option C: Hybrid (CycleState + PhaseStateEngine coordination)
+
+**Approach:** CycleState handles cycle-specific logic, PhaseStateEngine orchestrates
+
+**Pros:**
+- ✅ Clean separation of concerns
+
+**Cons:**
+- ❌ Over-engineering for current scope
+- ❌ Complex coordination between two managers
+- ❌ Not following YAGNI principle
+
+---
+
+## 3. Chosen Design
+
+**Decision:** Option A - Extend PhaseStateEngine with cycle tracking, create 3 new MCP tools (finalize_planning_deliverables, transition_cycle, force_cycle_transition), enhance 2 discovery tools, rename integration→validation phase
+
+**Rationale:** Mirrors existing PhaseStateEngine patterns for consistency, strict validation enforces quality, conditional visibility reduces noise, integration→validation improves clarity
+
+**Key Decisions from Planning:**
+1. **PhaseStateEngine owns cycle state** (not separate manager)
+2. **ProjectManager stores planning_deliverables** (projects.json)
+3. **Conditional visibility** in get_work_context (TDD phase only)
+4. **Forward-only transitions** with force override (human approval required)
+5. **Entry-time validation** blocking (preventive not reactive)
+6. **Integration→Validation rename** for all workflows
+
+---
+
+## 4. Architecture Overview
+
+### 4.1. Component Diagram
+
+```mermaid
+graph TB
+    subgraph "MCP Tools Layer"
+        T1[finalize_planning_deliverables]
+        T2[transition_cycle]
+        T3[force_cycle_transition]
+        T4[get_work_context]
+        T5[get_project_plan]
+        T6[transition_phase]
+    end
+    
+    subgraph "Manager Layer"
+        PSE[PhaseStateEngine]
+        PM[ProjectManager]
+        GM[GitManager]
+    end
+    
+    subgraph "Storage Layer"
+        PJ[projects.json]
+        SJ[state.json]
+        WY[workflows.yaml]
+    end
+    
+    T1 --> PM
+    T2 --> PSE
+    T3 --> PSE
+    T4 --> PSE
+    T4 --> PM
+    T5 --> PM
+    T6 --> PSE
+    
+    PSE --> SJ
+    PM --> PJ
+    PM --> WY
+    GM --> PSE
+    
+    style T1 fill:#e1f5fe
+    style T2 fill:#e1f5fe
+    style T3 fill:#e1f5fe
+    style PSE fill:#fff3e0
+    style PM fill:#fff3e0
+```
+
+### 4.2. Module Organization
+
+```
+mcp_server/
+├── tools/
+│   ├── planning_tools.py          # NEW: finalize_planning_deliverables
+│   ├── transition_tools.py        # NEW: transition_cycle, force_cycle_transition
+│   ├── discovery_tools.py         # ENHANCE: get_work_context
+│   └── project_tools.py           # ENHANCE: get_project_plan
+│
+├── managers/
+│   ├── phase_state_engine.py     # ENHANCE: cycle state management
+│   ├── project_manager.py        # ENHANCE: planning_deliverables schema
+│   └── git_manager.py             # ENHANCE: cycle_number validation
+│
+└── validators/
+    ├── cycle_validator.py         # NEW: cycle number validation
+    └── planning_validator.py      # NEW: planning deliverables validation
+```
+
+---
+
+## 5. Tool Contracts
+
+### 5.1. finalize_planning_deliverables
+
+**Purpose:** Store planning outcomes in projects.json at end of planning phase
+
+**Signature:**
+```python
+def finalize_planning_deliverables(
+    issue_number: int,
+    tdd_cycles: dict,
+    validation_plan: dict | None = None,
+    documentation_plan: dict | None = None
+) -> FinalizationResult:
+    """
+    Finalize planning deliverables and store in projects.json.
+    
+    Args:
+        issue_number: Issue number for the project
+        tdd_cycles: TDD cycle definitions with deliverables and exit criteria
+        validation_plan: Validation phase objectives and exit criteria
+        documentation_plan: Documentation requirements and exit criteria
+    
+    Returns:
+        FinalizationResult with success status and validation errors
+    
+    Raises:
+        ValidationError: If planning_deliverables already exist or schema invalid
+    """
+```
+
+**Input Schema:**
+```json
+{
+  "tdd_cycles": {
+    "total": 4,
+    "phase_exit_criteria": "All cycles complete, quality gates green",
+    "cycles": [
+      {
+        "cycle_number": 1,
+        "name": "Schema & Storage",
+        "deliverables": ["ProjectManager schema", "PhaseStateEngine fields"],
+        "exit_criteria": "Schema validated, tests pass"
+      }
+    ]
+  },
+  "validation_plan": {
+    "objectives": ["Smoke tests", "Performance"],
+    "exit_criteria": "All smoke tests green"
+  },
+  "documentation_plan": {
+    "sections": ["API Docs", "Architecture Update"],
+    "exit_criteria": "Docs reviewed and merged"
+  }
+}
+```
+
+**Validation Rules:**
+- `tdd_cycles.total` must equal `len(tdd_cycles.cycles)`
+- Each cycle must have unique sequential number (1-based)
+- `deliverables` array must not be empty
+- `exit_criteria` string must not be empty
+- Planning deliverables must not already exist in projects.json
+
+**Error Scenarios:**
+1. Planning deliverables already finalized → `"Planning already finalized for issue #146"`
+2. Invalid schema → `"Validation error: total (5) != cycle count (4)"`
+3. Missing required fields → `"Cycle 2: exit_criteria missing"`
+
+---
+
+### 5.2. transition_cycle
+
+**Purpose:** Transition to next TDD cycle (forward-only, sequential preferred)
+
+**Signature:**
+```python
+def transition_cycle(
+    to_cycle: int,
+    issue_number: int | None = None  # Auto-detect from current branch
+) -> TransitionResult:
+    """
+    Transition to next TDD cycle with exit criteria validation.
+    
+    Args:
+        to_cycle: Target cycle number (must be > current_cycle)
+        issue_number: Optional issue number (auto-detected if omitted)
+    
+    Returns:
+        TransitionResult with success status and transition details
+    
+    Raises:
+        ValidationError: If not in TDD phase, backwards transition, or exit criteria not met
+    """
+```
+
+**Validation Logic:**
+```python
+# 1. Check current phase
+if current_phase != "tdd":
+    raise ValidationError("Not in TDD phase")
+
+# 2. Check planning deliverables exist
+if "planning_deliverables" not in project:
+    raise ValidationError("Planning deliverables not found")
+
+# 3. Check forward-only
+if to_cycle <= current_tdd_cycle:
+    raise ValidationError("Backwards transition not allowed. Use force_cycle_transition.")
+
+# 4. Check previous cycle exit criteria (if sequential)
+if to_cycle == current_tdd_cycle + 1:
+    validate_exit_criteria(current_tdd_cycle)
+else:
+    raise ValidationError("Non-sequential transition. Use force_cycle_transition.")
+
+# 5. Update state
+state["current_tdd_cycle"] = to_cycle
+append_to_history(to_cycle, forced=False)
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "from_cycle": 1,
+  "to_cycle": 2,
+  "timestamp": "2026-02-17T11:15:00Z",
+  "message": "✅ Transitioned to TDD Cycle 2/4: Validation Logic"
+}
+```
+
+---
+
+### 5.3. force_cycle_transition
+
+**Purpose:** Force cycle transition (skip cycles or ignore exit criteria)
+
+**Signature:**
+```python
+def force_cycle_transition(
+    to_cycle: int,
+    skip_reason: str,
+    human_approval: str,
+    issue_number: int | None = None
+) -> TransitionResult:
+    """
+    Force cycle transition with audit trail.
+    
+    Args:
+        to_cycle: Target cycle number
+        skip_reason: Justification for forced transition
+        human_approval: Human approval statement (e.g., "User: John approved 2026-02-17")
+        issue_number: Optional issue number (auto-detected if omitted)
+    
+    Returns:
+        TransitionResult with success status and audit details
+    
+    Raises:
+        ValidationError: If skip_reason or human_approval empty
+    """
+```
+
+**Audit Trail:**
+```json
+{
+  "cycle_number": 4,
+  "name": "Transition Tools",
+  "entered": "2026-02-17T11:20:00Z",
+  "forced": true,
+  "skip_reason": "Cycles 2-3 covered by epic parent tests",
+  "human_approval": "User: John approved 2026-02-17",
+  "skipped_cycles": [2, 3]
+}
+```
+
+---
+
+### 5.4. get_work_context Enhancement
+
+**Changes:**
+- Add `tdd_cycle_info` section (conditional on TDD phase)
+- Graceful degradation if planning_deliverables missing
+
+**New Output (during TDD phase):**
+```json
+{
+  "branch": "feature/146-tdd-cycle-tracking",
+  "workflow_phase": "tdd",
+  "sub_phase": "green",
+  "tdd_cycle_info": {
+    "current": 2,
+    "total": 4,
+    "name": "Validation Logic",
+    "deliverables": [
+      "Cycle number validation",
+      "Planning deliverables checks",
+      "Error messages"
+    ],
+    "exit_criteria": "All validation scenarios covered",
+    "status": "in_progress"
+  },
+  "recent_commits": [...],
+  "active_issue": {...}
+}
+```
+
+**Outside TDD Phase:**
+```json
+{
+  "workflow_phase": "design"
+  // NO tdd_cycle_info (conditional visibility)
+}
+```
+
+---
+
+### 5.5. get_project_plan Enhancement
+
+**Changes:**
+- Add `planning_deliverables` section (complete structure)
+
+**New Output:**
+```json
+{
+  "issue_number": 146,
+  "workflow_name": "feature",
+  "required_phases": ["research", "planning", "design", "tdd", "validation", "documentation"],
+  "current_phase": "tdd",
+  "planning_deliverables": {
+    "tdd_cycles": {
+      "total": 4,
+      "phase_exit_criteria": "All cycles complete, quality gates green",
+      "cycles": [...]
+    },
+    "validation_plan": {...},
+    "documentation_plan": {...}
+  }
+}
+```
+
+---
+
+## 6. PhaseStateEngine Extensions
+
+### 6.1. New State Fields
+
+**state.json additions:**
+```json
+{
+  "current_tdd_cycle": 2,           // Active cycle (null if not in TDD)
+  "last_tdd_cycle": 2,              // Historical (persists after TDD exit)
+  "tdd_cycle_history": [
+    {
+      "cycle_number": 1,
+      "name": "Schema & Storage",
+      "entered": "2026-02-15T10:00:00Z",
+      "completed": "2026-02-16T14:30:00Z",
+      "forced": false
+    },
+    {
+      "cycle_number": 2,
+      "name": "Validation Logic",
+      "entered": "2026-02-16T14:35:00Z",
+      "completed": null,
+      "forced": false
+    }
+  ]
+}
+```
+
+### 6.2. Phase Entry/Exit Hooks
+
+**Design Decision: Auto-Initialize Cycle 1 on TDD Entry**
+
+**Rationale:**
+- ✅ Single-action entry: `transition_phase("tdd")` both validates and initializes
+- ✅ Preventive validation: Blocks entry if planning deliverables missing (Q4 decision)
+- ✅ Consistent state: TDD phase always has active cycle (never None during TDD)
+- ✅ Mirrors phase philosophy: PhaseStateEngine owns both phase AND cycle state
+- ✅ Reduces user error: No forgotten `transition_cycle(1)` call
+
+**Alternative Rejected:** Explicit two-step (`transition_phase` + `transition_cycle`) adds complexity and risk of inconsistent state.
+**on_enter_tdd_phase():**
+```python
+def on_enter_tdd_phase(issue_number: int):
+    """Validate planning deliverables, smart resume or auto-initialize."""
+    project = load_project(issue_number)
+    
+    # BLOCKING VALIDATION: Check planning_deliverables exist
+    if "planning_deliverables" not in project:
+        raise PhaseTransitionError(
+            "Cannot enter TDD phase without planning deliverables",
+            recovery=(
+                "MANUAL RECOVERY:\\n"
+                "1. Review planning.md - ensure all cycles defined\\n"
+                "2. Call finalize_planning_deliverables(...) to store schema\\n"
+                "3. Retry transition_phase(to_phase='tdd')\\n"
+            )
+        )
+    
+    # BLOCKING VALIDATION: Check tdd_cycles defined
+    tdd_cycles = project["planning_deliverables"].get("tdd_cycles", {})
+    total_planned_cycles = tdd_cycles.get("total", 0)
+    if total_planned_cycles == 0:
+        raise PhaseTransitionError(
+            "No TDD cycles defined in planning deliverables",
+            recovery="Update planning_deliverables with tdd_cycles"
+        )
+    
+    # SMART RESUME: Check if re-entering TDD phase
+    state = load_state()
+    last_tdd_cycle = state.get("last_tdd_cycle")
+    
+    if last_tdd_cycle:
+        # Re-entry scenario: check if work already complete
+        if last_tdd_cycle >= total_planned_cycles:
+            raise PhaseTransitionError(
+                f"TDD phase completed ({last_tdd_cycle}/{total_planned_cycles} cycles). Cannot re-enter.\\n"
+                f"\\n"
+                f"MANUAL RECOVERY:\\n"
+                f"1. Replan: force_phase_transition('planning') → update total_cycles (e.g., 4→6)\\n"
+                f"2. New issue: Create separate issue for new work (recommended)\\n"
+                f"\\n"
+                f"Why: All planned cycles completed. New work requires replanning or new issue."
+            )
+        
+        # Incomplete work: smart resume
+        state["current_tdd_cycle"] = last_tdd_cycle + 1
+        logger.info(f"TDD phase re-entered: resuming cycle {last_tdd_cycle + 1}/{total_planned_cycles}")
+    else:
+        # First entry: auto-initialize to cycle 1
+        state["current_tdd_cycle"] = 1
+        logger.info(f"TDD phase entered: auto-initialized to cycle 1/{total_planned_cycles}")
+    
+    # Initialize fresh history
+    state["tdd_cycle_history"] = []
+    save_state(state)
+```
+
+**on_exit_tdd_phase():**
+```python
+def on_exit_tdd_phase():
+    """Preserve cycle state, validate phase exit criteria."""
+    state = load_state()
+    
+    # Preserve last cycle for reference
+    state["last_tdd_cycle"] = state["current_tdd_cycle"]
+    state["current_tdd_cycle"] = None  # Clear active cycle
+    
+    # Validate ALL cycles completed (or force-skipped)
+    validate_phase_exit_criteria()
+    
+    save_state(state)
+```
+
+---
+## 7. Validation Logic
+
+### 7.1. Cycle Number Validation
+
+**Location:** `mcp_server/validators/cycle_validator.py`
+
+**Class Structure:**
+```python
+class CycleValidator:
+    def validate_cycle_number(
+        self,
+        cycle_number: int | None,
+        issue_number: int
+    ) -> ValidationResult:
+        """Validate cycle_number against planning deliverables."""
+        
+        # 1. Check required
+        if cycle_number is None:
+            return self._error("cycle_number required for all TDD commits")
+        
+        # 2. Load planning deliverables
+        project = self.project_manager.load_project(issue_number)
+        if "planning_deliverables" not in project:
+            return self._error("Cannot commit to TDD without planning deliverables")
+        
+        # 3. Check range
+        total_cycles = project["planning_deliverables"]["tdd_cycles"]["total"]
+        if cycle_number < 1 or cycle_number > total_cycles:
+            return self._error(
+                f"cycle_number {cycle_number} out of range (1-{total_cycles})"
+            )
+        
+        return ValidationResult(success=True)
+```
+
+### 7.2. Exit Criteria Validation
+
+**Class Structure:**
+```python
+class ExitCriteriaValidator:
+    def validate_cycle_exit_criteria(
+        self,
+        issue_number: int,
+        cycle_number: int
+    ) -> ValidationResult:
+        """Check if cycle exit criteria are met."""
+        
+        project = self.project_manager.load_project(issue_number)
+        cycle_data = self._get_cycle_data(project, cycle_number)
+        
+        # Check deliverables completed
+        for deliverable in cycle_data["deliverables"]:
+            if not self._is_deliverable_complete(deliverable):
+                return self._error(f"Deliverable incomplete: {deliverable}")
+        
+        # Check custom exit criteria
+        if not self._check_exit_criteria(cycle_data["exit_criteria"]):
+            return self._error(f"Exit criteria not met: {cycle_data['exit_criteria']}")
+        
+        return ValidationResult(success=True)
+```
+
+---
+
+## 8. Integration → Validation Phase Rename
+
+### 8.1. Affected Files
+
+**Configuration:**
+- `.st3/workflows.yaml` - all workflow definitions
+- `.st3/projects.json` - existing projects with "integration" phase
+
+**Code:**
+- `mcp_server/managers/phase_state_engine.py` - transition logic
+- `backend/core/scope_encoder.py` - scope generation (P_INTEGRATION → P_VALIDATION)
+
+**Documentation:**
+- All docs/ references to "integration" phase
+
+### 8.2. Migration Strategy
+
+**Approach:** Strict manual recovery (no automatic migration)
+
+**Phase 1: Update Workflows (Hard Breaking Change)**
+```yaml
+# workflows.yaml - direct update
+required_phases:
+  - research
+  - planning
+  - design
+  - tdd
+  - validation  # Renamed from "integration"
+  - documentation
+```
+
+**Phase 2: Update Scope Encoding**
+```python
+# backend/core/scope_encoder.py
+PHASE_SCOPE_MAP = {
+    "research": "P_RESEARCH",
+    "planning": "P_PLANNING",
+    "design": "P_DESIGN",
+    "tdd": "P_TDD",
+    "validation": "P_VALIDATION",  # Renamed from P_INTEGRATION
+    "documentation": "P_DOCUMENTATION"
+}
+```
+
+**Phase 3: Error Handling for Legacy Projects**
+```python
+# PhaseStateEngine validation
+def validate_phase_exists(phase: str, workflow_name: str) -> None:
+    """Strict validation - fails on unrecognized phase."""
+    valid_phases = get_workflow_phases(workflow_name)
+    
+    if phase not in valid_phases:
+        # Check if user is using old "integration" term
+        if phase == "integration":
+            raise PhaseValidationError(
+                f"Phase 'integration' renamed to 'validation' in Issue #146.\n"
+                f"\n"
+                f"MANUAL RECOVERY:\n"
+                f"1. Edit .st3/state.json: Change 'current_phase' from 'integration' to 'validation'\n"
+                f"2. Edit .st3/projects.json: Update issue entry's 'required_phases' array\n"
+                f"3. Use transition_phase(to_phase='validation') to continue\n"
+                f"\n"
+                f"See docs/development/issue146/design.md for details."
+            )
+        
+        raise PhaseValidationError(
+            f"Unknown phase '{phase}' for workflow '{workflow_name}'.\n"
+            f"Valid phases: {', '.join(valid_phases)}"
+        )
+```
+
+**Phase 4: Documentation Updates**
+- All docs/ references to "integration" phase updated to "validation"
+- Agent.md tool references updated
+- MCP reference docs updated
+
+### 8.3. Rollout Plan
+
+1. **TDD Cycle 1:** Update workflows.yaml (hard breaking change)
+2. **TDD Cycle 1:** Update scope encoding (P_INTEGRATION → P_VALIDATION)
+3. **TDD Cycle 2:** Add strict validation with actionable error messages
+4. **TDD Cycle 3:** Update all documentation (docs/, agent.md, references)
+5. **Manual Migration:** Users update existing projects.json entries manually
+
+**Migration Impact:**
+- ❌ NO automatic migration code
+- ❌ NO backward-compatible aliases
+- ✅ STRICT validation fails on "integration"
+- ✅ ACTIONABLE error messages with recovery steps
+- ✅ MANUAL fix: Edit .st3/state.json and .st3/projects.json
+
+---
+
+## 9. Sequence Diagrams
+
+### 9.1. Planning Finalization Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Tool as finalize_planning_deliverables
+    participant PM as ProjectManager
+    participant PJ as projects.json
+    
+    Agent->>Tool: finalize_planning_deliverables(issue=146, tdd_cycles={...})
+    Tool->>PM: validate_planning_deliverables(...)
+    PM->>PM: Check schema (total == cycle count, etc.)
+    alt Schema valid
+        PM->>PJ: Update projects.json[146].planning_deliverables
+        PJ-->>PM: Success
+        PM-->>Tool: ValidationResult(success=True)
+        Tool-->>Agent: ✅ Planning finalized
+    else Schema invalid
+        PM-->>Tool: ValidationError("total mismatch")
+        Tool-->>Agent: ❌ Error message
+    end
+```
+
+### 9.2. Cycle Transition Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Tool as transition_cycle
+    participant PSE as PhaseStateEngine
+    participant Val as CycleValidator
+    participant SJ as state.json
+    
+    Agent->>Tool: transition_cycle(to_cycle=2)
+    Tool->>PSE: get_current_phase()
+    PSE-->>Tool: "tdd"
+    Tool->>PSE: get_current_cycle()
+    PSE-->>Tool: 1
+    Tool->>Val: validate_exit_criteria(cycle=1)
+    alt Exit criteria met
+        Val-->>Tool: ValidationResult(success=True)
+        Tool->>PSE: update_cycle_state(to_cycle=2)
+        PSE->>SJ: Write current_tdd_cycle=2
+        PSE->>SJ: Append to tdd_cycle_history
+        SJ-->>PSE: Success
+        PSE-->>Tool: TransitionResult(success=True)
+        Tool-->>Agent: ✅ Transitioned to Cycle 2/4
+    else Exit criteria not met
+        Val-->>Tool: ValidationError("Deliverable incomplete")
+        Tool-->>Agent: ❌ Use force_cycle_transition
+    end
+```
+
+### 9.3. State Machine Extension
+
+```mermaid
+stateDiagram-v2
+    [*] --> Research
+    Research --> Planning: transition_phase
+    Planning --> Design: transition_phase
+    Design --> TDD: transition_phase (validate planning_deliverables)
+    
+    state TDD {
+        [*] --> Cycle1
+        Cycle1 --> Cycle2: transition_cycle (validate exit)
+        Cycle2 --> Cycle3: transition_cycle
+        Cycle3 --> Cycle4: transition_cycle
+        Cycle4 --> [*]
+        
+        note right of Cycle1: Forward-only transitions
+        note right of Cycle2: force_cycle_transition for skip
+    }
+    
+    TDD --> Validation: transition_phase (validate phase_exit_criteria)
+    Validation --> Documentation: transition_phase
+    Documentation --> [*]
+    
+    note right of Validation: Renamed from "Integration"
+```
+
+---
+
+## 10. Class Relationships
+
+```mermaid
+classDiagram
+    class PhaseStateEngine {
+        +current_phase: str
+        +current_tdd_cycle: int|None
+        +last_tdd_cycle: int|None
+        +tdd_cycle_history: list
+        +transition_phase(to_phase)
+        +transition_cycle(to_cycle)
+        +force_cycle_transition(to_cycle, reason, approval)
+        +on_enter_tdd_phase()
+        +on_exit_tdd_phase()
+    }
+    
+    class ProjectManager {
+        +projects: dict
+        +load_project(issue_number)
+        +save_project(issue_number, project)
+        +finalize_planning_deliverables(issue, tdd_cycles, ...)
+        +get_planning_deliverables(issue_number)
+    }
+    
+    class CycleValidator {
+        +validate_cycle_number(cycle_number, issue_number)
+        +validate_exit_criteria(issue_number, cycle_number)
+    }
+    
+    class PlanningValidator {
+        +validate_planning_deliverables(deliverables)
+        +validate_tdd_cycles_schema(tdd_cycles)
+    }
+    
+    class GitManager {
+        +commit_with_scope(message, phase, sub_phase, cycle_number)
+        +validate_commit_requirements()
+    }
+    
+    PhaseStateEngine --> CycleValidator: uses
+    PhaseStateEngine --> ProjectManager: uses
+    ProjectManager --> PlanningValidator: uses
+    GitManager --> CycleValidator: uses
+    GitManager --> PhaseStateEngine: uses
+```
+
+---
+
+## 11. Error Message Templates
+
+### 11.1. Missing Planning Deliverables
+```
+❌ ValidationError: Cannot enter TDD phase without planning deliverables
+
+Context:
+- Current phase: planning
+- Planning deliverables: NOT FOUND
+
+Recovery:
+Run finalize_planning_deliverables tool:
+  finalize_planning_deliverables(
+      issue_number=146,
+      tdd_cycles={...}
+  )
+```
+
+### 11.2. Missing Cycle Number
+```
+❌ ValidationError: cycle_number required for TDD commits
+
+Current: test(P_TDD_SP_RED): add test
+Required: test(P_TDD_SP_C2_RED): add test
+
+Recovery:
+Add cycle_number parameter:
+  git_add_or_commit(cycle_number=2, ...)
+```
+
+### 11.3. Invalid Cycle Number
+```
+❌ ValidationError: cycle_number out of range
+
+Attempted: 5
+Allowed: 1-4
+
+Recovery:
+1. Fix cycle_number: git commit --amend
+2. Update planning: finalize_planning_deliverables(...)
+```
+
+### 11.4. Exit Criteria Not Met
+```
+❌ ValidationError: Cycle 2 exit criteria not met
+
+Exit Criteria: "All validation scenarios covered"
+
+Incomplete:
+  ❌ Error message templates
+
+Recovery:
+1. Complete deliverables (recommended)
+2. Force transition: force_cycle_transition(to_cycle=3, skip_reason="...", human_approval="...")
+```
+
+---
+
+### 3.1. Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Extend PhaseStateEngine (not separate CycleManager) | Mirrors existing pattern, avoids StateManager duplication, maintains SRP |
+| Comprehensive planning_deliverables schema | Captures all TDD cycle definitions, exit criteria, validation plans (vs minimal cycle names) |
+| Forward-only cycle transitions | Prevents accidental regression, maintains clear progression (force override available) |
+| **Smart resume or auto-initialize on TDD entry** | **First entry: cycle 1. Re-entry (incomplete): last+1. Re-entry (complete): BLOCKED. Semantic boundary prevents needless work.** |
+| Conditional visibility (TDD phase only) | Reduces noise in get_work_context for non-TDD phases |
+| Entry-time blocking validation | Prevents invalid state before work starts (vs runtime detection) |
+| Both JSON + text formatting | Dual output for agents (structured) and developers (readable) |
+| Strict Integration→Validation rename | No aliases, manual recovery only - aligns with minimal backward-compat constraint |
+
+## Related Documentation
+- **[research.md][related-1]**
+- **[planning.md][related-2]**
+- **[../../reference/mcp/phase_state_engine.md][related-3]**
+
+<!-- Link definitions -->
+
+[related-1]: research.md
+[related-2]: planning.md
+[related-3]: ../../reference/mcp/phase_state_engine.md
+
+---
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-02-17 | Agent | Initial draft |

--- a/docs/development/issue146/planning.md
+++ b/docs/development/issue146/planning.md
@@ -1,0 +1,789 @@
+<!-- docs/development/issue146/planning.md -->
+<!-- template=planning version=130ac5ea created=2026-02-17T10:30:00Z updated= -->
+# Issue #146 TDD Cycle Tracking & Validation - Planning
+
+**Status:** DRAFT  
+**Version:** 1.0  
+**Last Updated:** 2026-02-17T10:30:00Z
+
+---
+
+## Purpose
+
+Define architecture decisions, component design, and implementation strategy for TDD cycle tracking system
+
+## Scope
+
+**In Scope:**
+Schema design, validation logic, state management, discovery tool enhancements, transition semantics, error handling
+
+**Out of Scope:**
+Implementation code, test writing, integration testing (TDD phase)
+
+## Prerequisites
+
+Read these first:
+1. Research questions answered (Q1-Q8)
+2. User decisions documented
+3. Section 5 alternatives evaluated
+---
+
+## Summary
+
+Planning document for TDD cycle tracking feature. Answers 8 research questions, defines comprehensive schema with cycle+phase exit criteria, strict validation strategy, persistent state matching PhaseStateEngine patterns, discovery tool enhancements with dual JSON/text output, and forward-only transitions with force override support.
+
+---
+
+## TDD Cycles
+
+### Cycle 1: Schema & Storage
+**Goal:** Define and implement planning deliverables and state management schemas
+
+**Deliverables:**
+- ProjectManager.planning_deliverables schema
+- PhaseStateEngine.tdd_cycle_* fields
+
+**Tests:**
+- Schema validation catches malformed planning_deliverables
+- State management correctly initializes/clears cycle fields
+
+**Exit Criteria:** Schema validated, tests pass
+
+---
+
+### Cycle 2: Validation Logic
+**Goal:** Implement cycle number validation and planning deliverables checks
+
+**Deliverables:**
+- Cycle number validation
+- Planning deliverables checks
+- Error messages
+
+**Tests:**
+- Missing cycle_number rejected
+- Out-of-range cycle_number rejected
+- Exit criteria validation works
+
+**Exit Criteria:** All validation scenarios covered
+
+---
+
+### Cycle 3: Discovery Tools
+**Goal:** Enhance get_work_context and get_project_plan with cycle info
+
+**Deliverables:**
+- get_work_context enhancement
+- get_project_plan enhancement
+- JSON+text formatting
+
+**Tests:**
+- Tools show cycle info when planning exists
+- Tools omit cycle info when planning missing
+- Dual-format output validated
+
+**Exit Criteria:** Tools return cycle info correctly
+
+---
+
+### Cycle 4: Transition Tools
+**Goal:** Implement transition_cycle and force_cycle_transition tools
+
+**Deliverables:**
+- transition_cycle tool
+- force_cycle_transition tool
+- Entry/exit hooks
+
+**Tests:**
+- Forward transitions work
+- Backward transitions blocked
+- Force transitions create audit trail
+
+**Exit Criteria:** All transition patterns working
+
+---
+
+## Architecture Decisions (Research Q&A)
+
+### Q1: Per-Cycle Deliverables Structure
+**Decision:** ✅ Full deliverables list (not just cycle names)
+
+**Rationale:**
+- Enables exit criteria validation per cycle
+- Supports TDD cycle planning workflow
+- Provides clear tracking of what needs to be built
+
+**Schema:**
+```json
+{
+  "cycle_number": 1,
+  "name": "Schema Design",
+  "deliverables": [
+    "ProjectManager.planning_deliverables schema",
+    "PhaseStateEngine.tdd_cycle_* fields"
+  ],
+  "exit_criteria": "All schema tests pass"
+}
+```
+
+---
+
+### Q2: Exit Criteria Levels
+**Decision:** ✅ Both cycle-level AND phase-level exit criteria
+
+**Clarification:** Phase-level exit criteria (not "project-level" - we're talking phase transitions).
+
+**Rationale:**
+- **Cycle-level:** Granular checkpoints prevent incomplete cycles
+- **Phase-level:** Overall TDD phase completion gatekeeping
+- **Transition blocking:** Force transitions required when criteria not met
+
+**Schema:**
+```json
+{
+  "planning_deliverables": {
+    "tdd_cycles": {
+      "total": 4,
+      "cycles": [
+        {
+          "cycle_number": 1,
+          "exit_criteria": "Schema validated, tests pass"  // Cycle-level
+        }
+      ],
+      "phase_exit_criteria": "All 4 cycles complete, quality gates green"  // Phase-level
+    }
+  }
+}
+```
+
+**Enforcement:**
+- `transition_cycle(to_cycle=2)` → validates cycle 1 exit criteria (blocking)
+- `transition_phase(to_phase="integration")` → validates TDD phase exit criteria (blocking)
+- Failures require force tool with reason + human_approval
+
+---
+
+### Q3: Cycle Number Requirement Scope
+**Decision:** ✅ ALL TDD commits require cycle_number
+
+**Rationale:**
+- All work during TDD happens within a cycle context (even if total_cycles=1)
+- Prevents ambiguity about which cycle work belongs to
+- Consistent with strict enforcement philosophy
+
+**Examples:**
+```python
+# Sub-phase commits (RED/GREEN/REFACTOR)
+git_add_or_commit(
+    workflow_phase="tdd",
+    sub_phase="red",
+    cycle_number=2,  # REQUIRED
+    message="add failing test"
+)
+
+# General TDD commits (docs, chores)
+git_add_or_commit(
+    workflow_phase="tdd",
+    cycle_number=2,  # ALSO REQUIRED
+    message="update cycle documentation"
+)
+```
+
+---
+
+### Q4: Planning Deliverables Enforcement Timing
+**Decision:** ✅ Block at phase/cycle entry (not at first commit)
+
+**Aangescherpt Model:** Planning deliverables lifecycle
+
+**Workflow:**
+```
+1. initialize_project(issue_number=146, workflow_name="feature")
+   → Creates projects.json entry with:
+      - workflow_name, required_phases from workflows.yaml
+      - expected_deliverables (templates):
+        * research: ["research.md"]
+        * planning: ["planning.md", "planning_deliverables"]
+   → NO actual planning outcomes yet (tdd_cycles, validation_plan)
+
+2. transition_phase(to_phase="planning")
+   → Check: research.md exists
+   
+3. [During planning phase: answer Q1-Q8, define TDD cycles]
+
+4. [End of planning: finalize planning deliverables]
+   → Update projects.json with actual planning outcomes:
+      - planning_deliverables.tdd_cycles (defined cycles)
+      - planning_deliverables.validation_plan
+      - planning_deliverables.documentation_plan
+   → Creates planning.md
+
+5. transition_phase(to_phase="design")
+   → Check: planning.md exists
+   
+6. transition_phase(to_phase="tdd")
+   → BLOCKS if planning_deliverables not in projects.json
+   → Error: "Cannot enter TDD phase without planning deliverables"
+   
+7. transition_cycle(to_cycle=2)
+   → BLOCKS if cycle 1 exit criteria not met
+   → Requires: force_cycle_transition with reason + approval
+```
+
+**Key Distinction:**
+- **initialize_project**: Sets expectations (template/schema requirements)
+- **Planning phase**: Defines actual deliverables (tdd_cycles content)
+- **TDD entry validation**: Checks planning outcomes exist (not just templates)
+
+**Entry Validation:**
+- TDD phase entry: Check planning_deliverables.tdd_cycles exists and total > 0
+- Cycle transition: Check previous cycle exit criteria met
+- Preventive (not reactive) - catch missing planning BEFORE work starts
+
+---
+
+### Q5: Cycle Info Visibility in Discovery Tools
+**Decision:** ✅ Conditional on TDD phase (matches research.md:314)
+
+**Clarification:** `get_work_context` is agent tool, not direct user output.
+
+**Behavior:**
+```json
+// During DESIGN phase (planning exists, but NOT in TDD)
+{
+  "workflow_phase": "design"
+  // NO tdd_cycle_info shown (not in TDD yet)
+}
+
+// During TDD phase (planning exists AND in TDD)
+{
+  "workflow_phase": "tdd",
+  "tdd_cycle_info": {
+    "current": 2,
+    "total": 4,
+    "name": "Validation Logic",
+    "status": "in_progress"
+  }
+}
+```
+
+**Rationale:**
+- Cycle info only relevant during TDD phase (when cycles are active)
+- Outside TDD: get_project_plan shows full planning_deliverables (if needed)
+- Consistent with research.md:314 conditional visibility decision
+- Reduces noise in get_work_context for non-TDD phases
+
+---
+
+### Q6: Output Formatting Strategy
+**Decision:** ✅ Both JSON (agents) + human-readable text (developers)
+
+**Implementation:**
+
+**A. get_work_context (frequent, agent-focused)**
+- Compact JSON for token efficiency:
+```json
+"tdd_cycle_info": {
+  "current": 2,
+  "total": 4,
+  "name": "Validation Logic",
+  "status": "in_progress"
+}
+```
+
+**B. Terminal output (transition confirmations, errors)**
+- Human-readable text:
+```
+✅ Transitioned to TDD Cycle 2/4: Validation Logic
+
+Deliverables:
+  - Cycle number validation
+  - Planning deliverables checks
+Exit criteria: All validation scenarios covered
+```
+
+---
+
+### Q7: Skip Cycle Transition Requirements
+**Decision:** ✅ Yes - skip_reason + human_approval required
+
+**Pattern:** Mirror `force_phase_transition` exactly
+
+**Implementation:**
+```python
+# Skip transition
+transition_cycle(to_cycle=3)  # 1→3 (skip cycle 2)
+→ ERROR: "Non-sequential cycle transition. Use force_cycle_transition."
+
+# Force transition
+force_cycle_transition(
+    to_cycle=3,
+    skip_reason="Cycle 2 covered by epic parent tests",
+    human_approval="User: John approved 2026-02-17"
+)
+→ ✅ Allowed (audit trail created)
+```
+
+---
+
+### Q8: Re-Entry Behavior After TDD Phase Exit
+**Decision:** ✅ Always possible with force_transition
+
+**Workflow:**
+```
+TDD (cycles 1-4) → Validation → [bug found]
+
+force_phase_transition(
+    to_phase="tdd",
+    skip_reason="Critical bug found during integration",
+    human_approval="User: John approved 2026-02-17"
+)
+→ ✅ Allowed
+
+# State after re-entry
+{
+  "current_tdd_cycle": 5,  // Smart resume: last_tdd_cycle + 1
+  "last_tdd_cycle": 4      // Historical record
+}
+
+# ⚠️ NOTE: This example would BLOCK with original 4 cycles (last=4, total=4)
+# User must first: force_phase_transition('planning') → update total_cycles=5+
+# OR: Create new issue for additional work
+# ✅ After replanning to total_cycles >= 5, re-entry succeeds with cycle 5
+```
+```
+
+---
+
+## Schema Design
+
+### Planning Deliverables Schema (projects.json)
+
+**Location:** `.st3/projects.json[<issue_number>]["planning_deliverables"]`
+
+**Structure:**
+```json
+{
+  "146": {
+    "issue_number": 146,
+    "workflow_name": "feature",
+    "planning_deliverables": {
+      "tdd_cycles": {
+        "total": 4,
+        "phase_exit_criteria": "All cycles complete, quality gates green",
+        "cycles": [
+          {
+            "cycle_number": 1,
+            "name": "Schema & Storage",
+            "deliverables": [
+              "ProjectManager.planning_deliverables schema",
+              "PhaseStateEngine.tdd_cycle_* fields"
+            ],
+            "exit_criteria": "Schema validated, tests pass",
+            "status": "completed"
+          }
+        ]
+      },
+      "validation_plan": {
+        "objectives": ["Smoke tests", "Performance"],
+        "exit_criteria": "All smoke tests green"
+      },
+      "documentation_plan": {
+        "sections": ["API Docs", "Architecture Update"],
+        "exit_criteria": "Docs reviewed and merged"
+      }
+    }
+  }
+}
+```
+
+**Validation Rules:**
+- `tdd_cycles.total` must match `len(tdd_cycles.cycles)`
+- Each cycle must have unique `cycle` number (1-based sequential)
+- `deliverables` array must not be empty
+- `exit_criteria` string must not be empty
+- `status`: "planned" | "in_progress" | "completed" | "skipped"
+
+---
+
+### State Management Schema (state.json)
+
+**Location:** `.st3/state.json`
+
+**New Fields:**
+```json
+{
+  "branch": "feature/146-tdd-cycle-tracking",
+  "current_phase": "tdd",
+  
+  "current_tdd_cycle": 2,           // Active cycle (null if not in TDD)
+  "last_tdd_cycle": 2,              // Historical (persists after TDD exit)
+  
+  "tdd_cycle_history": [
+    {
+      "cycle_number": 1,
+      "name": "Schema & Storage",
+      "entered": "2026-02-15T10:00:00Z",
+      "completed": "2026-02-16T14:30:00Z",
+      "forced": false
+    },
+    {
+      "cycle_number": 2,
+      "name": "Validation Logic",
+      "entered": "2026-02-16T14:35:00Z",
+      "completed": null,
+      "forced": false
+    }
+  ]
+}
+```
+
+**Lifecycle:**
+1. **TDD entry (first time):** `current_tdd_cycle` = 1 (auto-initialize)
+2. **TDD entry (re-entry, incomplete):** `current_tdd_cycle` = last_tdd_cycle + 1 (smart resume)
+3. **TDD entry (re-entry, complete):** BLOCKED - requires replanning or new issue
+4. **During TDD:** `current_tdd_cycle` = N (1-based)
+5. **TDD exit:** `current_tdd_cycle` = null, `last_tdd_cycle` = N (retained)
+
+## Validation Strategy
+
+### Planning Deliverables Validation
+
+**Trigger:** Phase transitions, cycle transitions
+
+**Logic:**
+```python
+def validate_planning_deliverables(issue_number: int):
+    project = load_project(issue_number)
+    
+    if "planning_deliverables" not in project:
+        raise ValidationError("Planning deliverables not found")
+    
+    cycles = project["planning_deliverables"]["tdd_cycles"]
+    
+    if cycles["total"] != len(cycles["cycles"]):
+        raise ValidationError(f"total mismatch: {cycles['total']} != {len(cycles['cycles'])}")
+    
+    for cycle_data in cycles["cycles"]:
+        if not cycle_data.get("deliverables"):
+            raise ValidationError(f"Cycle {cycle_data['cycle']}: deliverables missing")
+```
+
+---
+
+### Cycle Number Validation
+
+**Trigger:** `git_add_or_commit()` with `workflow_phase="tdd"`
+
+**Logic:**
+```python
+def validate_cycle_number(cycle_number: int | None, issue_number: int):
+    if cycle_number is None:
+        raise ValidationError("cycle_number required for all TDD commits")
+    
+    project = load_project(issue_number)
+    if "planning_deliverables" not in project:
+        raise ValidationError("Cannot commit to TDD without planning deliverables")
+    
+    total_cycles = project["planning_deliverables"]["tdd_cycles"]["total"]
+    
+    if cycle_number < 1 or cycle_number > total_cycles:
+        raise ValidationError(f"cycle_number {cycle_number} out of range (1-{total_cycles})")
+```
+
+---
+
+### Exit Criteria Validation
+
+**Trigger:** `transition_cycle()`, `transition_phase(from="tdd")`
+
+**Logic:**
+```python
+def validate_exit_criteria(issue_number: int, cycle_number: int):
+    project = load_project(issue_number)
+    cycle_data = get_cycle_data(project, cycle_number)
+    
+    # Check deliverables completed (implementation TBD in TDD phase)
+    for deliverable in cycle_data["deliverables"]:
+        if not is_deliverable_complete(deliverable):
+            raise ValidationError(f"Deliverable incomplete: {deliverable}")
+    
+    # Check exit criteria (implementation TBD in TDD phase)
+    if not check_exit_criteria(cycle_data["exit_criteria"]):
+        raise ValidationError(f"Exit criteria not met: {cycle_data['exit_criteria']}")
+```
+
+---
+
+## Discovery Tool Enhancements
+
+### get_work_context Enhancement
+
+**Changes:**
+- Add `tdd_cycle_info` section (conditional on TDD phase only)
+- Compact JSON format
+- Graceful degradation if planning_deliverables missing
+
+**Output (during TDD phase):**
+```json
+{
+  "workflow_phase": "tdd",
+  "tdd_cycle_info": {
+    "current": 2,
+    "total": 4,
+    "name": "Validation Logic",
+    "status": "in_progress",
+    "deliverables": ["Cycle validation", "Error messages"],
+    "exit_criteria": "All validation scenarios covered"
+  }
+}
+```
+
+---
+
+### get_project_plan Enhancement
+
+**Changes:**
+- Add `planning_deliverables` section (full structure)
+
+**Output:**
+```json
+{
+  "issue_number": 146,
+  "workflow_name": "feature",
+  "current_phase": "tdd",
+  "planning_deliverables": {
+    "tdd_cycles": {
+      "total": 4,
+      "phase_exit_criteria": "All cycles complete",
+      "cycles": [...]
+    }
+  }
+}
+```
+
+---
+
+## Transition Semantics
+
+### transition_cycle Tool
+
+**Signature:**
+```python
+def transition_cycle(
+    to_cycle: int,
+    issue_number: int | None = None
+) -> TransitionResult
+```
+
+**Validation:**
+1. Check current phase = "tdd"
+2. Check planning_deliverables exists
+3. Check `to_cycle > current_cycle` (forward-only)
+4. Check previous cycle exit criteria met
+5. Update state.json
+
+**Example:**
+```python
+transition_cycle(to_cycle=2)
+→ ✅ Success (forward, sequential)
+
+transition_cycle(to_cycle=4)
+→ ❌ ERROR: "Non-sequential. Use force_cycle_transition."
+```
+
+---
+
+### force_cycle_transition Tool
+
+**Signature:**
+```python
+def force_cycle_transition(
+    to_cycle: int,
+    skip_reason: str,
+    human_approval: str,
+    issue_number: int | None = None
+) -> TransitionResult
+```
+
+**Audit Trail:**
+```json
+{
+  "cycle_number": 4,
+  "entered": "2026-02-17T11:00:00Z",
+  "forced": true,
+  "skip_reason": "Cycles 2-3 covered by epic",
+  "human_approval": "User: John approved 2026-02-17",
+  "skipped_cycles": [2, 3]
+}
+```
+
+---
+
+### Phase Entry/Exit Hooks
+
+**TDD Phase Entry:**
+```python
+def on_enter_tdd_phase(issue_number: int):
+    """Smart resume or auto-initialize based on last_tdd_cycle."""
+    validate_planning_deliverables(issue_number)
+    
+    total_cycles = get_total_cycles(issue_number)
+    last_cycle = state.get("last_tdd_cycle")
+    
+    if last_cycle:
+        # Re-entry: check if complete
+        if last_cycle >= total_cycles:
+            raise PhaseTransitionError("TDD complete - requires replanning or new issue")
+        state["current_tdd_cycle"] = last_cycle + 1  # Smart resume
+    else:
+        state["current_tdd_cycle"] = 1  # First entry
+    
+    state["tdd_cycle_history"] = []
+```
+**TDD Phase Exit:**
+```python
+def on_exit_tdd_phase():
+    state["last_tdd_cycle"] = state["current_tdd_cycle"]
+    state["current_tdd_cycle"] = null
+    validate_phase_exit_criteria()
+```
+
+---
+
+## Error Handling Patterns
+
+### Missing Planning Deliverables
+
+**Trigger:** `transition_phase(to_phase="tdd")`
+
+**Error:**
+```
+❌ Cannot enter TDD phase without planning deliverables
+
+Context: Planning deliverables NOT FOUND in projects.json
+
+Recovery: Update projects.json with planning_deliverables
+```
+
+---
+
+### Missing Cycle Number
+
+**Trigger:** `git_add_or_commit(workflow_phase="tdd")` without cycle_number
+
+**Error:**
+```
+❌ cycle_number required for TDD commits
+
+Current: test(P_TDD_SP_RED): add test
+Required: test(P_TDD_SP_C2_RED): add test
+
+Recovery: Add cycle_number parameter
+```
+
+---
+
+### Invalid Cycle Number
+
+**Trigger:** cycle_number > total_cycles
+
+**Error:**
+```
+❌ cycle_number exceeds planned cycles
+
+Attempted: 5
+Allowed: 1-4
+
+Recovery:
+1. Fix commit message
+2. Update planning_deliverables.tdd_cycles.total
+```
+
+---
+
+### Exit Criteria Not Met
+
+**Trigger:** `transition_cycle()` when criteria incomplete
+
+**Error:**
+```
+❌ Cycle 2 exit criteria not met
+
+Exit Criteria: "All validation scenarios covered"
+
+Incomplete:
+  ❌ Error message templates
+
+Recovery:
+1. Complete deliverables (recommended)
+2. force_cycle_transition with reason + approval
+```
+
+---
+
+## Integration with Existing Systems
+
+### PhaseStateEngine
+- Mirror transition patterns (forward-only, force with approval)
+- Extend phase_history for tdd_cycle_history
+- Reuse validation logic
+
+### GitManager
+- Add cycle_number validation to commit workflow
+- Generate scope: `P_TDD_SP_C{N}_{SUBPHASE}`
+- Error messages integrated
+
+### Discovery Tools
+- Extend GetWorkContextTool with cycle info (conditional on TDD phase)
+- Extend GetProjectPlanTool with planning_deliverables
+- Graceful degradation when planning_deliverables missing (read-only tools only)
+
+---
+
+## Open Questions for Design Phase
+
+### 1. Planning Deliverables Finalization Tool
+**Context:** planning.md:214-218 describes workflow step "update projects.json with planning outcomes" and "creates planning.md", but no existing tool contract exists.
+
+**Design Tasks:**
+- Define tool signature (e.g., `finalize_planning_deliverables(issue_number, planning_deliverables)`)
+- Determine tool location (ProjectManager? Separate planning tools module?)
+- Schema validation for planning_deliverables input
+- Error handling when planning.md already exists or planning_deliverables already set
+- Integration with transition_phase validation (check planning complete before TDD entry)
+
+**Note:** This is NEW functionality - not extending existing tool.
+
+---
+
+### 2. Integration → Validation Phase Rename
+**Context:** Research.md:621-647 + original issue body #146 identified "integration" phase terminology as confusing. E2E tests are per TDD cycle (works well), but "integration" phase should be "validation" (real-life proven operation).
+
+**Design Tasks:**
+- Update workflows.yaml: Rename "integration" → "validation" in all workflows
+- Migration strategy for existing projects.json with "integration" phase
+- Update PhaseStateEngine transition logic (if hardcoded phase names exist)
+- Update GitManager scope encoding (P_INTEGRATION → P_VALIDATION)
+- Update all documentation references
+- Create migration script for existing projects
+
+**Note:** Part of Issue #146 scope - NOT separate issue.
+
+---
+- **[research.md][related-1]**
+- **[../issue144/planning.md][related-2]**
+- **[../../reference/mcp/phase_state_engine.md][related-3]**
+
+<!-- Link definitions -->
+
+[related-1]: research.md
+[related-2]: ../issue144/planning.md
+[related-3]: ../../reference/mcp/phase_state_engine.md
+
+---
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-02-17T10:30:00Z | Agent | Initial draft |

--- a/docs/development/issue146/research.md
+++ b/docs/development/issue146/research.md
@@ -1,403 +1,689 @@
 <!-- docs/development/issue146/research.md -->
-<!-- template=research version=8b7bb3ab created=2026-02-15T20:45:00Z updated= -->
-<!-- Demo: Auto-phase detection in integration fase -->
-# tdd-cycle-tracking
+<!-- template=research version=8b7bb3ab created=2026-02-17T09:00:00Z -->
+# Issue #146 TDD Cycle Tracking & Validation Research
 
-**Status:** DRAFT  
-**Version:** 1.2  
-**Last Updated:** 2026-02-15
+**Status:** IN PROGRESS  
+**Version:** 2.0  
+**Last Updated:** 2026-02-17
 
 ---
 
 ## Purpose
 
-Design TDD cycle tracking as state machine extension, aligned with planning phase outcomes and existing phase transition architecture
+Investigate TDD cycle tracking requirements for state machine extension, identifying gaps in current architecture and exploring solution options without making implementation decisions.
 
 ## Scope
 
 **In Scope:**
-Schema design (projects.json + state.json), tool contracts (finalize_planning, transition_cycle, force_cycle_transition), validation rules, scope format impact, breaking change strategy, error message templates
+- Current implementation analysis (cycle_number parameter, PhaseStateEngine patterns)
+- Gap identification (missing storage, validation, transitions, observability)
+- Alternative approaches discovery (schema options, validation strategies, breaking change approaches)
+- Discovery tools impact analysis (get_work_context, get_project_plan cycle visibility)
+- Backward compatibility constraints
 
 **Out of Scope:**
-Implementation details, test strategies, migration tooling, documentation updates (those are planning/design)
+- Architecture decisions (planning phase)
+- Implementation specifications (design phase)
+- Test strategy details (planning/design phase)
+- Migration tooling design (design phase)
 
 ## Prerequisites
 
 Read these first:
-1. Issue #138 complete (workflow-first architecture)
-2. projects.json schema understood
-3. state.json schema understood
-4. PhaseStateEngine patterns (transition/force_transition)
+1. [Issue #138 complete](../issue138/) - Workflow-first architecture with scope encoding
+2. [.st3/projects.json](.st3/projects.json) - Project metadata schema
+3. [.st3/state.json](.st3/state.json) - Live branch state schema  
+4. [mcp_server/managers/phase_state_engine.py](mcp_server/managers/phase_state_engine.py#L127-L250) - Transition/force_transition patterns
+5. [backend/core/scope_encoder.py](backend/core/scope_encoder.py#L57) - cycle_number parameter exists
 
 ---
 
 ## Problem Statement
 
-TDD cycle tracking is absent from workflow state machine. Planning phase outputs cycle breakdown (e.g., Issue #138 had 4 cycles), but no storage (projects.json), no live tracking (state.json), no validation (cycle_number unvalidated), no transition tools. This causes agent confusion and prevents deterministic progression.
+TDD cycle tracking is disconnected from workflow state machine. Planning phase can define cycle breakdown (e.g., Issue #138 documented 4 cycles), but:
+- No persistent storage in projects.json
+- No live tracking in state.json
+- No validation of cycle_number parameter against plan
+- No transition tools for cycle progression
+- No visibility in discovery tools (get_work_context, get_project_plan)
+
+**Impact:** Agents invent arbitrary cycle numbers (Issue #138: "cycle 3.1, 3.2, 3.6") without enforcement, causing workflow confusion and non-deterministic progression.
 
 ## Research Goals
 
-- Design projects.json tdd_cycles schema
-- Design state.json cycle tracking fields
-- Define tool contracts (finalize_planning, transition_cycle, force_cycle_transition)
-- Establish validation rules for cycle_number
-- Plan scope format breaking change strategy
-- Create error message templates
-
-## Related Documentation
-- **[mcp_server/managers/phase_state_engine.py:127-170 - transition/force_transition patterns][related-1]**
-- **[.st3/projects.json - Project metadata (needs tdd_cycles)][related-2]**
-- **[.st3/state.json - Live state (needs current_tdd_cycle)][related-3]**
-- **[backend/core/scope_encoder.py:57 - cycle_number parameter][related-4]**
-- **[mcp_server/tools/git_tools.py:145 - cycle_number in GitCommitInput][related-5]**
-
-<!-- Link definitions -->
-
-[related-1]: mcp_server/managers/phase_state_engine.py:127-170 - transition/force_transition patterns
-[related-2]: .st3/projects.json - Project metadata (needs tdd_cycles)
-[related-3]: .st3/state.json - Live state (needs current_tdd_cycle)
-[related-4]: backend/core/scope_encoder.py:57 - cycle_number parameter
-[related-5]: mcp_server/tools/git_tools.py:145 - cycle_number in GitCommitInput
+1. Map current implementation landscape (what EXISTS)
+2. Identify capability gaps (what's MISSING)
+3. Discover alternative solution approaches (OPTIONS, not decisions)
+4. Analyze discovery tools integration points
+5. Define backward compatibility constraints
 
 ---
 
-## Research Questions
+## 1. Current Implementation Analysis
 
-### Q1: Planning Phase Deliverables - Broader Scope
+### 1.1 Existing Components
 
-**Finding (User Feedback):** Planning fase levert niet alleen TDD cycle breakdown, maar ook:
-- **TDD Cycles:** Implementatie work packages met deliverables + exit criteria
-- **Integration Plan:** MAAR - E2E tests zitten al in TDD cycles! Wat is integration fase dan?
-- **Documentation Plan:** Artifacts + exit criteria voor documentation fase
+```mermaid
+graph LR
+    A[GitCommitInput] -->|cycle_number| B[ScopeEncoder]
+    B -->|P_TDD_SP_C1_RED| C[GitManager]
+    C --> D[Commit Message]
+    
+    E[PhaseStateEngine] -->|transition| F[state.json]
+    F -->|current_phase| G[Phase Tracking]
+    
+    H[projects.json] -->|required_phases| I[Workflow Validation]
+    
+    style B fill:#90EE90
+    style E fill:#90EE90
+    style H fill:#FFE4B5
+```
 
-**Current Problem:** Integration fase "wringt" - E2E testing gebeurt al per TDD cycle (werkt goed, geen context drift).
+**Found:**
+- ✅ `cycle_number` parameter accepted in `GitCommitInput` (line 145)
+- ✅ `ScopeEncoder.generate_scope()` formats cycle into scope: `P_TDD_SP_C{N}_{SUBPHASE}`
+- ✅ `PhaseStateEngine` has transition/force_transition pattern
+- ✅ Test coverage exists: `test_git_commit_tool_with_cycle_number`
 
-**Proposed Solution:**
-- **Hernoemvoorstel:** Integration → "Validation" / "Acceptance" / "Real-life Testing"
-- **Nieuwe definitie:** Niet E2E tests (al gedaan), maar:
-  - Deployment naar staging
-  - Smoke tests in productie-achtige omgeving
-  - Performance validation
-  - Real-world scenario's (proven operation)
-  - Regression checks tegen bestaande functionaliteit
+**Code Evidence:**
+```python
+# mcp_server/tools/git_tools.py:145
+cycle_number: int | None = Field(
+    default=None,
+    description="Cycle number (e.g., 1, 2, 3). Optional, used in multi-cycle TDD.",
+)
 
-**Schema Impact:**
-```json
-"planning_deliverables": {
-  "tdd_cycles": {
-    "total": 4,
-    "cycles": [
-      {
-        "cycle": 1,
-        "name": "Phase Resolution",
-        "deliverables": ["ScopeDecoder", "E2E test voor detection"],
-        "integration_tests": ["test_scope_detection_e2e.py"],  // ← E2E PER CYCLE
-        "exit_criteria": "Contract tests pass, E2E detection works"
-      }
-    ]
-  },
-  "validation_plan": {  // ← Hernoemd van "integration"
-    "objectives": [
-      "Deploy to staging environment",
-      "Smoke tests (happy path scenarios)",
-      "Performance baseline validation",
-      "Regression against Issue #117, #139"
-    ],
-    "exit_criteria": "All smoke tests green, no performance regressions"
-  },
-  "documentation_plan": {
-    "artifacts": [
-      "agent.md updates (Tool Priority Matrix)",
-      "Migration guide (breaking changes)",
-      "CHANGELOG entry"
-    ],
-    "exit_criteria": "All docs reviewed, agent.md tested"
+# backend/core/scope_encoder.py:144 - ACTUAL FORMAT
+if cycle_number is not None:
+    return f"P_{phase_upper}_SP_C{cycle_number}_{sub_phase_upper}"
+# Generates: P_TDD_SP_C1_RED (SP before cycle number)
+```
+
+### 1.2 Missing Components
+
+**Gap Analysis:**
+
+| Component | Status | Impact |
+|-----------|--------|--------|
+| Planning deliverables storage | ❌ Missing | No source of truth for cycle definitions |
+| Current cycle tracking in state.json | ❌ Missing | No live cycle state |
+| cycle_number validation | ❌ Missing | Arbitrary values accepted (999, -1, etc.) |
+| Cycle transition tools | ❌ Missing | No sequential progression enforcement |
+| Discovery tools cycle visibility | ❌ Missing | Agent blind to cycle context |
+
+**Evidence:**
+```python
+# backend/core/scope_encoder.py:147 - NO validation
+if cycle_number is not None:
+    return f"P_{phase_upper}_SP_C{cycle_number}_{sub_phase_upper}"
+    # ⚠️ Accepts cycle_number=999 without error
+
+# .st3/projects.json - NO cycle fields
+{
+  "146": {
+    "workflow_name": "feature",
+    "required_phases": [...],
+    // ⚠️ No tdd_cycles, no validation_plan, no documentation_plan
   }
+}
+
+# .st3/state.json - NO cycle tracking
+{
+  "current_phase": "tdd",
+  // ⚠️ No current_tdd_cycle, no tdd_cycle_transitions
 }
 ```
 
-**Decision:** Integration fase hernoemen naar **"validation"** (USER CONFIRMED)
-
-**Rationale:**
-- E2E tests per TDD cycle werken goed (geen context drift)
-- Separate "validation" fase voor real-life proven operation
-- Duidelijk onderscheid: TDD (unit+E2E per cycle) vs Validation (staging+smoke tests)
-- Consistent met industry terms (acceptance testing, validation testing)
-- Workflows.yaml impact: "integration" → "validation" in alle workflow definitions
-
 ---
 
-### Q2: Force Cycle Transition Scope (CORRECTIE)
+## 2. Gap Deep-Dive
 
-**Error in Initial Research:** Recovery option suggested `force_cycle_transition` for commits - FOUT!
+### 2.1 Validation Gap
 
-**Correct Semantics:**
-- `force_cycle_transition` = **STATE transition** (skip cycle 3, go to cycle 4)
-- Commit errors = manual fix (amend commit message)
-
-**Corrected Error Message:**
-```
-ValidationError: Commit scope missing cycle number
-
-Current scope: P_TDD_SP_RED
-Required scope: P_TDD_C{N}_SP_RED
-
-Context:
-- Current phase: tdd
-- Project has 4 planned cycles (1-4)
-- Current cycle: 3 (from state.json)
-
-Valid examples:
-- test(P_TDD_C3_SP_RED): add test for cycle 3
-- feat(P_TDD_C3_SP_GREEN): implement feature
-- refactor(P_TDD_C3_SP_REFACTOR): clean code
-
-Recovery options:
-1. Fix commit message: git commit --amend -m "test(P_TDD_C3_SP_RED): ..."
-2. Update state to match commit: transition_cycle(to_cycle=expected_cycle)
-3. Skip cycle (state only): force_cycle_transition(to_cycle=4, skip_reason="Cycle 3 not applicable")
-
-Note: force_cycle_transition updates STATE, NOT commits. For commit message issues, use option 1.
+**Current Behavior:**
+```python
+# All these SUCCEED without error:
+git_add_or_commit(cycle_number=999, ...)  # No project plan → no validation
+git_add_or_commit(cycle_number=-5, ...)   # Negative cycle accepted
+git_add_or_commit(cycle_number=None, ...) # Missing cycle for TDD sub-phase
 ```
 
-**Impact:** Validation must be clear that forced transitions bypass cycle progression, not commit format.
+**Questions Raised:**
+- Should cycle_number be REQUIRED for TDD sub-phases (red/green/refactor)?
+- Should cycle_number be FORBIDDEN for non-TDD phases?
+- What are recovery options when validation fails?
 
----
+### 2.2 Storage Gap
 
-### Q3: Schema Design - projects.json
+**Projects.json Missing Fields:**
 
-**Planning Outcome Storage:**
-
+Option 1: Flat structure
 ```json
 {
   "146": {
-    "issue_title": "TDD Cycle Tracking",
-    "workflow_name": "feature",
-    "required_phases": ["research", "planning", "design", "tdd", "validation", "documentation"],
-    
-    // NEW: Planning deliverables (output van planning fase)
-    "planning_deliverables": {
-      "tdd_cycles": {
-        "total": 3,
-        "cycles": [
-          {
-            "cycle": 1,
-            "name": "Schema Design",
-            "deliverables": ["projects.json schema", "state.json schema"],
-            "integration_tests": ["test_cycle_schema_validation.py"],
-            "exit_criteria": "Schema validated, tests pass"
-          },
-          {
-            "cycle": 2,
-            "name": "Tool Implementation",
-            "deliverables": ["finalize_planning tool", "transition_cycle tool"],
-            "integration_tests": ["test_cycle_transitions_e2e.py"],
-            "exit_criteria": "Tools functional, E2E test passes"
-          },
-          {
-            "cycle": 3,
-            "name": "Validation & Breaking Change",
-            "deliverables": ["cycle_number validation", "scope format enforcement"],
-            "integration_tests": ["test_scope_with_cycle_e2e.py"],
-            "exit_criteria": "Validation strict, error messages actionable"
-          }
-        ]
-      },
-      "validation_plan": {
-        "objectives": [
-          "Smoke test: Create project with cycles",
-          "Smoke test: Transition through cycles",
-          "Regression: Old projects without cycles still work",
-          "Performance: No slowdown in git operations"
-        ],
-        "exit_criteria": "All smoke tests green"
-      },
-      "documentation_plan": {
-        "artifacts": [
-          "agent.md: Phase 2.3 TDD Cycle examples",
-          "Migration guide: Breaking changes",
-          "CHANGELOG: v2.0.0 cycle tracking"
-        ],
-        "exit_criteria": "Docs reviewed + tested by user"
-      }
-    },
-    
-    "created_at": "2026-02-15T20:40:00Z"
+    "tdd_total_cycles": 4,
+    "tdd_cycle_1_name": "Schema Design",
+    "tdd_cycle_1_deliverables": [...]
   }
 }
 ```
 
-**Key Design Decisions:**
-1. **Nested structure:** `planning_deliverables.tdd_cycles` (not top-level)
-2. **Integration per cycle:** E2E tests tracked per TDD cycle (prevents context drift)
-3. **Validation rename:** "integration_plan" → "validation_plan" for clarity
-4. **Documentation plan:** Explicit artifacts + exit criteria
-
----
-
-### Q4: Schema Design - state.json
-
-**Live Cycle Tracking:**
-
+Option 2: Nested structure
 ```json
 {
-  "branch": "feature/146-cycle-tracking",
-  "issue_number": 146,
-  "workflow_name": "feature",
-  "current_phase": "tdd",
-  
-  // NEW: Cycle tracking (only set when in TDD phase)
-  "current_tdd_cycle": 2,
-  
-  // NEW: Cycle transition audit trail
-  "tdd_cycle_transitions": [
-    {
-      "from_cycle": null,
-      "to_cycle": 1,
-      "timestamp": "2026-02-15T21:00:00Z",
-      "human_approval": null,
-      "forced": false,
-      "deliverables_completed": ["projects.json schema", "state.json schema"]
-    },
-    {
-      "from_cycle": 1,
-      "to_cycle": 2,
-      "timestamp": "2026-02-16T10:30:00Z",
-      "human_approval": "User confirmed schema complete",
-      "forced": false,
-      "deliverables_completed": ["finalize_planning tool"]
+  "146": {
+    "planning_deliverables": {
+      "tdd_cycles": {
+        "total": 4,
+        "cycles": [...]
+      }
     }
-  ],
-  
-  "transitions": [ /* phase transitions blijven zoals nu */ ],
-  "created_at": "2026-02-15T20:45:00Z"
+  }
 }
 ```
 
-**Key Design Decisions:**
-1. **Conditional field:** `current_tdd_cycle` only exists when `current_phase == "tdd"`
-2. **Separate audit trail:** `tdd_cycle_transitions` (parallel to phase `transitions`)
-3. **Auto-initialize:** On first TDD entry, set `current_tdd_cycle = 1`
-4. **Clear on exit:** On TDD → next phase, `current_tdd_cycle` retained for historical record
+Option 3: Separate file (`.st3/cycles/issue146.json`)
+
+**Questions Raised:**
+- Which schema balances readability vs extensibility?
+- Should validation_plan and documentation_plan be stored together?
+- How to handle projects without cycles (backward compat)?
+
+### 2.3 State Tracking Gap
+
+**State.json Missing Fields:**
+
+Current (Phase only):
+```json
+{
+  "current_phase": "tdd",
+  "transitions": [...]
+}
+```
+
+Option A: Flat cycle field
+```json
+{
+  "current_phase": "tdd",
+  "current_cycle": 2
+}
+```
+
+Option B: Nested TDD context
+```json
+{
+  "current_phase": "tdd",
+  "tdd_context": {
+    "current_cycle": 2,
+    "cycle_transitions": [...]
+  }
+}
+```
+
+**Questions Raised:**
+- Should current_cycle persist after leaving TDD phase?
+- Should cycle transitions have separate audit trail from phase transitions?
+- How to handle re-entering TDD phase (resume last cycle vs restart)?
+
+### 2.4 Transition Tooling Gap
+
+**PhaseStateEngine has transition/force_transition:**
+```python
+# Phase transitions exist
+transition(branch, to_phase="design")
+force_transition(branch, to_phase="ready", skip_reason="...", human_approval="...")
+```
+
+**Cycle transitions do NOT exist:**
+```python
+# Would need:
+transition_cycle(branch, to_cycle=2)  # ❌ Does not exist
+force_cycle_transition(branch, to_cycle=4, skip_reason="...")  # ❌ Does not exist
+```
+
+**Questions Raised:**
+- Should cycle transitions mirror phase transitions architecture?
+- Should force_cycle_transition require human_approval like force_transition?
+- What's the semantic difference: cycle skip vs phase skip?
 
 ---
 
-### Q5: Tool Contracts
+## 3. Discovery Tools Impact Analysis
 
-#### **finalize_planning Tool**
+### 3.1 Tool Roles in Workflow
 
-```python
-def finalize_planning(
-    issue_number: int,
-    tdd_cycles: list[dict[str, Any]],
-    validation_plan: dict[str, Any],      # ← NEW
-    documentation_plan: dict[str, Any],   # ← NEW
-    human_approval: str | None = None
-) -> dict[str, Any]:
-    """Store planning deliverables in projects.json.
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant get_work_context
+    participant get_project_plan
+    participant state.json
+    participant projects.json
     
-    Called at end of planning phase (or early design phase).
+    Agent->>get_work_context: Where am I?
+    get_work_context->>state.json: Read current_phase
+    state.json-->>get_work_context: "tdd"
+    get_work_context-->>Agent: phase=tdd, sub_phase=red<br/>⚠️ NO cycle info
     
-    Args:
-        issue_number: Issue being planned
-        tdd_cycles: List of cycle definitions
-        validation_plan: Objectives + exit criteria for validation phase
-        documentation_plan: Artifacts + exit criteria for documentation
-        human_approval: Optional approval message
-    
-    Returns:
-        Success + stored deliverables summary
-    
-    Raises:
-        ValidationError: If current_phase not in ["planning", "design"]
-        ValidationError: If cycles malformed (missing cycle number, name, etc.)
-    """
+    Agent->>get_project_plan: What's the plan?
+    get_project_plan->>projects.json: Read issue 146
+    projects.json-->>get_project_plan: workflow=feature, phases=[...]
+    get_project_plan-->>Agent: 6 phases required<br/>⚠️ NO cycle breakdown
 ```
 
-#### **transition_cycle Tool**
+### 3.2 Current Tool Gap
 
-```python
-def transition_cycle(
-    branch: str,
-    to_cycle: int,
-    deliverables_completed: list[str] | None = None,
-    human_approval: str | None = None
-) -> dict[str, Any]:
-    """Validated sequential cycle transition.
-    
-    Args:
-        branch: Branch name
-        to_cycle: Target cycle (must be current + 1)
-        deliverables_completed: Optional list of completed deliverables
-        human_approval: Optional approval message
-    
-    Returns:
-        Success + from_cycle + to_cycle
-    
-    Raises:
-        ValidationError: If current_phase != "tdd"
-        ValidationError: If to_cycle != current + 1 (non-sequential)
-        ValidationError: If to_cycle > total cycles in project plan
-    
-    Example:
-        transition_cycle("feature/146", to_cycle=2, deliverables_completed=["schema"])
-    """
+**get_work_context() Current Output:**
+```json
+{
+  "current_branch": "feature/146-tdd",
+  "workflow_phase": "tdd",
+  "sub_phase": "red",
+  "phase_source": "commit-scope",
+  "recent_commits": [...],
+  "active_issue": {...}
+  // ⚠️ MISSING: current_cycle, total_cycles, cycle_deliverables
+}
 ```
 
-#### **force_cycle_transition Tool**
-
-```python
-def force_cycle_transition(
-    branch: str,
-    to_cycle: int,
-    skip_reason: str,
-    human_approval: str,
-    deliverables_completed: list[str] | None = None
-) -> dict[str, Any]:
-    """Forced non-sequential cycle transition.
-    
-    Bypasses validation (e.g., skip cycle 3, jump to 4).
-    DOES NOT affect commits - only state machine.
-    
-    Args:
-        branch: Branch name
-        to_cycle: Target cycle (any valid cycle)
-        skip_reason: Reason for bypass (REQUIRED for audit)
-        human_approval: Approval message (REQUIRED)
-        deliverables_completed: Optional completed deliverables
-    
-    Returns:
-        Success + from_cycle + to_cycle + forced=True + skip_reason
-    
-    Raises:
-        ValidationError: If current_phase != "tdd"
-        ValidationError: If to_cycle invalid (> total or < 1)
-    
-    Example:
-        force_cycle_transition(
-            "feature/146",
-            to_cycle=4,
-            skip_reason="Cycle 3 scope moved to Issue #147",
-            human_approval="User approved skip on 2026-02-16"
-        )
-    """
+**get_project_plan() Current Output:**
+```json
+{
+  "issue_number": 146,
+  "workflow_name": "feature",
+  "required_phases": ["research", "planning", ..., "tdd", ...],
+  "current_phase": "tdd"
+  // ⚠️ MISSING: tdd_cycles breakdown, validation_plan, documentation_plan
+}
 ```
+
+### 3.3 Desired Tool Enhancement (SRP/DRY Compliant)
+
+**User Constraint:** Extend existing tools, avoid new overlapping tools.
+
+**Approach: Enhance existing discovery tools**
+- `get_work_context()` adds `tdd_cycle_info` section (conditional on TDD phase)
+- `get_project_plan()` adds `planning_deliverables` section (always present if defined)
+
+**Rationale:**
+- ✅ Maintains single responsibility per tool (context vs plan)
+- ✅ No overlap with existing functionality
+- ✅ Follows established SRP pattern from QUALITY_GATES.md:69
+
+**Implementation Notes:**
+- Cycle info visibility: Conditional (only shown during TDD phase in get_work_context) - **Planning Decision Q5**
+- Graceful degradation: Discovery tools (get_work_context, get_project_plan) work without planning_deliverables (show N/A or omit section)
+- **Critical distinction:** Read-only discovery tools degrade gracefully, but TDD workflow (commits, transitions) MUST hard-fail without planning_deliverables (see Section 6.1)
+
+### 3.4 Tool Usage Patterns
+
+**From agent.md analysis:**
+
+```
+# Phase 1: Orientation Protocol
+get_work_context()       → "Where am I?" (frequency: multiple per session)
+get_project_plan(146)    → "What's the plan?" (frequency: 1-2x total)
+```
+
+**With Cycle Tracking:**
+```
+# During TDD Phase
+get_work_context()       → Should show: cycle 2/4, current deliverables
+get_project_plan(146)    → Should show: all 4 cycles defined in planning
+```
+
+**Impact:** Discovery tools are PRIMARY way agents understand context. Missing cycle info → agents improvise cycle numbers.
+
+---
+
+## 4. Backward Compatibility Constraints
+
+### 4.1 User Requirement
+
+**Constraint:** "Minimale backward compatibility - alleen graceful failure met recovery"
+
+**Interpretation:**
+- ❌ NO silent fallbacks to old behavior
+- ❌ NO dual-mode support (with/without cycles)
+- ✅ STRICT validation with actionable errors
+- ✅ MANUAL recovery options (not automatic migration)
+
+### 4.2 Breaking Change Scenarios
+
+**User Constraint Applied:** STRICT validation only, no warnings or opt-in modes.
+
+**Scenario 1: Old project (no planning deliverables)**
+```python
+git_add_or_commit(workflow_phase="tdd", sub_phase="red", message="...")
+# ERROR: "No planning deliverables found for issue #146. Run finalize_planning() first."
+# Recovery: finalize_planning(issue=146, tdd_cycles={...})
+```
+
+**Scenario 2: Missing cycle_number in TDD**
+```python
+git_add_or_commit(workflow_phase="tdd", sub_phase="red", message="...")
+# cycle_number omitted, but project has planning deliverables
+# ERROR: "cycle_number required when project has planning deliverables"
+# Recovery: Add cycle_number=N parameter
+```
+
+**Scenario 3: Invalid cycle_number**
+```python
+git_add_or_commit(cycle_number=99, ...)  # Project has total_cycles=4
+# ERROR: "cycle_number 99 exceeds total_cycles 4"
+# Recovery: Fix commit (git commit --amend) OR update plan (finalize_planning)
+```
+
+### 4.3 Recovery Options Discovery
+
+**User Constraint:** Manual recovery only, no automatic migration.
+
+**For ERROR scenarios:**
+
+| Error | Recovery Option | Notes |
+|-------|----------------|-------|
+| No planning deliverables | Run `finalize_planning()` | Manual definition required |
+| Missing cycle_number | Add `cycle_number=N` to commit call | Explicit parameter required |
+| Invalid cycle_number | `git commit --amend` to fix message | Manual correction |
+|  | OR `finalize_planning()` to update plan | If genuinely need more cycles |
+
+**No Automated Recovery:**
+- ❌ No auto-detection from state.json
+- ❌ No warnings with fallback behavior
+- ❌ No opt-out flags
+- ✅ Only explicit error + manual fix
+
+---
+
+## 5. Alternative Solution Approaches
+
+### 5.1 Cycle Scope Format Enforcement
+
+**Current State:** Both formats technically possible
+```
+P_TDD_SP_RED              ← No cycle (currently accepted)
+P_TDD_SP_C3_RED          ← With cycle (currently accepted)
+```
+
+**User Constraint:** Strict enforcement approach only.
+
+**Enforcement Strategy:**
+- REQUIRE cycle_number for TDD sub-phases when project has planning_deliverables
+- ERROR if missing (no warnings or grace period)
+- Format: `P_TDD_SP_C{N}_{SUBPHASE}` (e.g., `P_TDD_SP_C2_RED`)
+
+**No Backward Compatibility:**
+- ❌ No conditional enforcement based on project age
+- ❌ No opt-in/opt-out flags
+- ❌ No grace period (warning → error transition)
+- ✅ Immediate strict validation
+
+### 5.2 Planning Deliverable Schema
+
+**User Decision:** Comprehensive schema (Option 2) - all planning components in single structure.
+
+```json
+{
+  "planning_deliverables": {
+    "tdd_cycles": {
+      "total": 4,
+      "cycles": [
+        {"cycle": 1, "name": "Schema Design", "deliverables": [...], "exit_criteria": "..."}
+      ]
+    },
+    "validation_plan": {
+      "objectives": ["Smoke tests", "Performance", "Regression"],
+      "exit_criteria": "All smoke tests green"
+    },
+    "documentation_plan": {
+      "sections": ["API Docs", "Architecture Update"],
+      "exit_criteria": "Docs reviewed and merged"
+    }
+  }
+}
+```
+
+**Rationale:**
+- ✅ Complete context for planning phase (Issue #144 planning deliverables)
+- ✅ Single source of truth in projects.json (config-first)
+- ✅ Structured validation, documentation tracking alongside TDD cycles
+- ✅ Extensible for future planning components
+
+**Storage Location:** `.st3/projects.json` per issue (no sidecar files)
+
+### 5.3 Cycle Transition Validation
+
+**User Decision:** Mirror PhaseStateEngine pattern - forward-only with force tool.
+
+**Transition Rules:**
+- ✅ Forward progression allowed: 1→2, 2→3, 3→4
+- ✅ Skip cycles allowed: 1→3, 1→4
+- ❌ Backward transitions blocked: 3→1, 4→2
+- ✅ Force tool for exceptional cases: `force_cycle_transition(to_cycle, skip_reason, human_approval)`
+
+**Rationale:**
+- Matches existing phase transition strictness (PhaseStateEngine)
+- Allows flexibility (skip cycles) while preventing regression (no backwards)
+- Audit trail via force_cycle_transition when skipping needed
+- Consistent developer experience across phase/cycle management
+
+**Implementation Notes:**
+- Sequential check: `to_cycle > current_cycle` (forward-only)
+- Skip detection: `to_cycle != current_cycle + 1` (triggers skip_reason requirement)
+- Force transition: Same pattern as `force_phase_transition` (human_approval + audit)
+
+### 5.4 State Persistence Strategy
+
+**User Decision:** Mirror PhaseStateEngine behavior - persistent state with historical tracking.
+
+**State Fields in `.st3/state.json`:**
+```json
+{
+  "current_tdd_cycle": 3,           // Active cycle during TDD phase
+  "last_tdd_cycle": 3,              // Historical record (persists after TDD exit)
+  "tdd_cycle_history": [            // Audit trail
+    {"cycle": 1, "entered": "2026-02-14T10:00:00Z", "completed": "2026-02-14T14:30:00Z"},
+    {"cycle": 2, "entered": "2026-02-14T14:35:00Z", "completed": "2026-02-15T09:00:00Z"},
+    {"cycle": 3, "entered": "2026-02-15T09:05:00Z"}
+  ]
+}
+```
+
+**Behavior:**
+- `current_tdd_cycle`: Always present during TDD phase, cleared on exit
+- `last_tdd_cycle`: Retained after TDD phase exit (like `last_phase`)
+- Re-entry: Resume from `last_tdd_cycle + 1` or allow manual override
+- History: Complete audit trail with timestamps (like phase_history)
+
+**Rationale:**
+- ✅ Matches existing PhaseStateEngine patterns (consistency)
+- ✅ Historical data preserved for analysis/debugging
+- ✅ Supports resume workflow after phase exit/re-entry
+- ✅ Audit compliance via tdd_cycle_history
+
+---
+
+## 6. Error Message Templates (Discovery)
+
+### 6.1 Missing Planning Deliverables
+
+**Error Pattern:**
+```
+ValidationError: No TDD cycles defined for issue #146
+
+Context:
+- Current phase: tdd
+- Project workflow: feature
+- Planning deliverables: NOT FOUND in projects.json
+
+Recovery:
+Run finalize_planning tool to define cycles:
+   finalize_planning(issue=146, tdd_cycles={...})
+
+Why this matters:
+TDD cycle tracking requires planning deliverables to validate cycle_number.
+Without planning deliverables, the project cannot proceed to TDD phase.
+```
+
+### 6.2 Invalid Cycle Number
+
+**Error Pattern:**
+```
+ValidationError: cycle_number exceeds planned cycles
+
+Attempted: cycle_number=5
+Allowed: 1-4 (total_cycles=4 from projects.json)
+
+Context:
+- Current project: Issue #146
+- Planning deliverables: FOUND
+- Defined cycles: 4
+
+Recovery options:
+1. Fix commit message
+   git commit --amend -m "test(P_TDD_SP_C3_RED): ..."
+2. Update planning (if genuinely need more cycles)
+   finalize_planning(issue=146, tdd_cycles={"total": 5, ...})
+3. Force cycle transition (state only, NOT for commits)
+   force_cycle_transition(to_cycle=4, skip_reason="...")
+
+Note: force_cycle_transition updates STATE, not commit messages.
+```
+
+### 6.3 Missing Cycle Number in TDD
+
+**Error Pattern:**
+```
+ValidationError: cycle_number required for TDD sub-phase
+
+Current: test(P_TDD_SP_RED): add test  ← Missing cycle
+Required: test(P_TDD_SP_C{N}_RED): add test
+
+Context:
+- Current phase: tdd
+- Current sub_phase: red
+- Project has planning deliverables: YES
+- Total cycles: 4
+- Current cycle (from state.json): 2
+
+Valid examples:
+- test(P_TDD_SP_C2_RED): add failing test
+- feat(P_TDD_SP_C2_GREEN): implement feature
+- refactor(P_TDD_SP_C2_REFACTOR): clean code
+
+Recovery:
+Add cycle_number parameter:
+  git_add_or_commit(
+      workflow_phase="tdd",
+      sub_phase="red",
+      cycle_number=2,  ← Add this
+      message="add failing test"
+  )
+```
+
+---
+
+## 7. Open Research Questions
+
+### 7.1 Schema Design
+**Answered in Section 5.2:** Comprehensive nested schema with validation_plan + documentation_plan.
+- Q1: Per-cycle deliverables list or just names?
+- Q2: Exit criteria per cycle vs per project vs both?
+
+### 7.2 Validation Strategy
+**User Constraint:** Always validate, no optional enforcement.
+- Q3: Require cycle_number for ALL TDD commits or only sub-phases?
+
+### 7.3 Backward Compatibility
+**User Constraint:** Strict enforcement only, no grace periods or opt-in modes, no automatic migration.
+- Q4: Error handling when planning_deliverables missing - block TDD entry or fail on first commit?
+
+### 7.4 Discovery Tools
+**Answered in Section 3.3:** Extend existing get_work_context and get_project_plan (SRP compliant).
+- Q5: Show cycle info always or conditional on TDD phase?
+- Q6: How to format cycle deliverables for readability?
+
+### 7.5 Transition Semantics
+**Answered in Section 5.3:** Forward-only with force_cycle_transition tool (mirrors PhaseStateEngine).
+- Q7: Skip cycles requires skip_reason + human_approval?
+- Q8: Re-entry behavior after TDD phase exit?
+
+---
+
+## 8. Integration → Validation Rename Impact
+
+**From research.md v1.1 finding:**
+
+E2E tests are already per TDD cycle (works well). "Integration" phase is confusing.
+
+**Rename Proposal:** `integration` → `validation`
+**Rationale:** Validation = real-life proven operation (staging, smoke tests, regression)
+
+**Impact on Cycle Tracking:**
+```json
+// planning_deliverables schema
+{
+  "tdd_cycles": {
+    "cycles": [
+      {
+        "integration_tests": ["..."]  // ← Per cycle E2E tests (stays)
+      }
+    ]
+  },
+  "validation_plan": {  // ← Renamed from "integration_plan"
+    "objectives": ["Smoke tests", "Performance", "Regression"],
+    "exit_criteria": "All smoke tests green"
+  }
+}
+```
+
+**Questions Raised:**
+- Should rename happen in Issue #146 or separate?
+- Impact on workflows.yaml (all workflows reference "integration")?
+- Migration path for existing projects.json?
+
+---
+
+## Findings Summary
+
+### What EXISTS:
+✅ cycle_number parameter in GitCommitInput
+✅ ScopeEncoder formats cycle into scope (P_TDD_SP_C1_RED)
+✅ PhaseStateEngine transition/force_transition pattern
+✅ Test coverage for cycle format
+
+### What's MISSING:
+❌ Planning deliverables storage (projects.json)
+❌ Live cycle tracking (state.json)
+❌ cycle_number validation logic
+❌ Cycle transition tools
+❌ Discovery tools cycle visibility
+
+### Key Insights:
+1. **Validation Gap:** cycle_number=999 accepted without error
+2. **Storage Gap:** No source of truth for cycle definitions
+3. **Observability Gap:** Agent blind to cycle context (causes invented cycle numbers)
+4. **Semantic Gap:** Unclear when cycle transitions vs phase transitions
+5. **Backward Compat:** User requires strict enforcement, minimal legacy support
+
+---
+
+## Related Documentation
+- **[Issue #138 Design](../issue138/design.md)** - Scope format with cycle_number
+- **[Issue #138 Planning](../issue138/planning.md)** - Vertical cycles concept (4 cycles example)
+- **PhaseStateEngine** - [mcp_server/managers/phase_state_engine.py](../../../mcp_server/managers/phase_state_engine.py#L127-L250)
+- **ScopeEncoder** - [backend/core/scope_encoder.py](../../../backend/core/scope_encoder.py#L57-L147)
+- **GitCommitInput** - [mcp_server/tools/git_tools.py](../../../mcp_server/tools/git_tools.py#L145)
+- **get_work_context** - [mcp_server/tools/discovery_tools.py](../../../mcp_server/tools/discovery_tools.py#L99-L298)
+- **get_project_plan** - [mcp_server/tools/project_tools.py](../../../mcp_server/tools/project_tools.py#L306-L340)
 
 ---
 
 ## Version History
 
-### v1.2 (2026-02-15)
-- **Decision confirmed:** Integration phase renamed to "validation" (user approved)
-- **Rationale added:** E2E per cycle vs validation as real-life testing
-- **Impact documented:** workflows.yaml changes (integration → validation)
-
-### v1.1 (2026-02-15)
-- **Q1 expanded:** Planning phase delivers 3 components (tdd_cycles, validation_plan, documentation_plan)
-- **Q2 corrected:** force_cycle_transition semantics (state-only, NOT for commit fixes)
-- **Q3-Q5 added:** Complete schema designs for projects.json, state.json, tool contracts
-
-### v1.0 (2026-02-15)
-- Initial research structure
-- Problem statement and research goals
-- Basic research questions Q1-Q2
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 2.0 | 2026-02-17 | Agent | Complete research with gap analysis, discovery tools impact, backward compat constraints, Mermaid diagrams |
+| 1.2 | 2026-02-15 | Agent | Integration→validation rename, 3-component planning deliverables |
+| 1.1 | 2026-02-15 | Agent | Expanded to validation/documentation plans |
+| 1.0 | 2026-02-15 | Agent | Initial problem statement |

--- a/docs/development/issue229/design-c5-c7.md
+++ b/docs/development/issue229/design-c5-c7.md
@@ -1,0 +1,190 @@
+# C5–C7 Design: update_planning_deliverables, exit_requires file_glob, phase-generic schema
+
+**Status:** draft  
+**Version:** 1.0  
+**Date:** 2026-02-19  
+**Issue:** #229 (Cycles 5–7)
+
+---
+
+## 1. Problem Statement
+
+Three gaps discovered during the validation phase smoke-test of issue #229:
+
+| Gap | Summary |
+|-----|---------|
+| **GAP-09** | `save_planning_deliverables` is write-once — no update path for evolving cycles. Direct `projects.json` edits were needed multiple times during this issue. |
+| **GAP-10** | `exit_requires` in `workphases.yaml` only supports `key:` checks against `projects.json`. No file-system gate pattern exists, so the research phase has no enforced exit gate. |
+| **GAP-11** | `planning_deliverables` schema is TDD-centric (`tdd_cycles` only). Design, validation, documentation phases have no planning-defined deliverable gates. |
+
+---
+
+## 2. Prerequisites
+
+- C1–C4 complete and all tests passing
+- `DeliverableChecker._check_file_glob()` available (C2)
+- `validate_spec()` available (C4)
+- Skipped-gate warning pattern in `PhaseStateEngine` / `ForceCycleTransitionTool` available (C3)
+
+---
+
+## 3. C5 — UpdatePlanningDeliverablesTool (GAP-09)
+
+### 3.1 Options Considered
+
+**Option A — New `update_planning_deliverables` tool with merge-by-id strategy (CHOSEN)**  
+Keeps `save_planning_deliverables` write-once (intentional first-commit guard). A separate tool handles subsequent mutations. Merge strategy: new cycle_number → append; existing cycle_number + new deliverable id → append; existing cycle_number + existing deliverable id → overwrite in place.
+
+**Option B — Add `allow_overwrite: bool` flag to existing `save_planning_deliverables`**  
+Simpler surface, but blurs the semantic distinction between "initial planning commit" and "iterative update". The write-once guard exists for a reason: forcing explicit action for the first write.
+
+### 3.2 Decision: Option A
+
+### 3.3 Interface Design
+
+```python
+class UpdatePlanningDeliverablesInput(BaseModel):
+    issue_number: int
+    planning_deliverables: dict[str, Any]  # same schema as save
+
+class UpdatePlanningDeliverablesTool(BaseTool):
+    name = "update_planning_deliverables"
+```
+
+**`ProjectManager.update_planning_deliverables(issue_number, planning_deliverables)`**  
+- Raises `ValueError` if `planning_deliverables` key does not yet exist (must call `save_planning_deliverables` first)
+- `tdd_cycles.cycles` merge algorithm:
+  - Build index: `existing_cycles = {c["cycle_number"]: c for c in existing}`
+  - For each incoming cycle: if `cycle_number` not in index → append; else merge `deliverables` by `id` within that cycle
+  - Update `tdd_cycles.total` to `max(existing_total, highest incoming cycle_number)` if changed
+- Layer 2 `validate_spec()` reused (identical to `save_planning_deliverables`)
+- Atomic write (read → merge → write)
+
+---
+
+## 4. C6 — exit_requires file_glob support (GAP-10)
+
+### 4.1 Options Considered
+
+**Option A — Extend `exit_requires` schema with `type: file_glob` variant (CHOSEN)**  
+Data-driven, consistent with the existing `key:` variant. `PhaseStateEngine` dispatches on `type` field. Reuses `DeliverableChecker._check_file_glob()`. `{issue_number}` interpolated at gate-check time.
+
+**Option B — Hardcode file-system checks per phase name in `PhaseStateEngine`**  
+Tight coupling to phase names. Not extensible. Rejected.
+
+### 4.2 Decision: Option A
+
+### 4.3 Schema Extension
+
+`workphases.yaml` research phase (after C6):
+```yaml
+research:
+  exit_requires:
+    - type: file_glob
+      file: "docs/development/issue{issue_number}/*research*.md"
+      description: "Research document aanwezig"
+```
+
+**`PhaseStateEngine` gate-check logic (in `_check_exit_requires`):**
+```python
+for entry in exit_requires:
+    if entry.get("type") == "file_glob":
+        pattern = entry["file"].format(issue_number=issue_number)
+        checker._check_file_glob({"file": pattern})  # raises DeliverableCheckError on no match
+    else:  # existing key: behaviour
+        key = entry["key"]
+        if key not in project_data:
+            raise ValueError(f"Exit requires '{key}' not present in projects.json")
+```
+
+Forced transition: if gate skipped, the existing `skipped_gates` list gets `"research.exit_requires[file_glob: ...]"` appended — same C3 pattern.
+
+### 4.4 Impact
+
+- `WorkphasesConfig` needs to accept `exit_requires` entries without `key:` (currently only `key:` is validated)
+- `DeliverableChecker._check_file_glob()` already exists — no changes needed there
+- `WorkphasesSchema` pydantic model: `exit_requires` items become `Union[KeyRequirement, FileGlobRequirement]`
+
+---
+
+## 5. C7 — planning_deliverables schema generalization (GAP-11)
+
+### 5.1 Options Considered
+
+**Option A — Flat dict with phase keys alongside `tdd_cycles` (CHOSEN)**  
+```json
+{
+  "planning_deliverables": {
+    "tdd_cycles": { ... },
+    "design": { "deliverables": [...] },
+    "validation": { "deliverables": [...] }
+  }
+}
+```
+Single entry point for all deliverables. `PhaseStateEngine` checks `planning_deliverables.<phase>.deliverables` on phase exit when key present.
+
+**Option B — Separate top-level key per phase in `projects.json`**  
+More explicit but fragments the deliverables across multiple top-level keys. Harder to query in one place. Rejected.
+
+### 5.2 Decision: Option A
+
+### 5.3 Gate Behaviour
+
+```
+on_exit_<phase>_phase(branch, issue_number):
+    plan = project_manager.get_project_plan(issue_number)
+    phase_deliverables = plan.get("planning_deliverables", {}).get(phase_name, {})
+    deliverables = phase_deliverables.get("deliverables", [])
+    if not deliverables:
+        return  # gate optional — silent pass when key absent
+    for d in deliverables:
+        checker.check(d["id"], d["validates"])  # raises on failure
+```
+
+### 5.4 Schema Changes
+
+`save_planning_deliverables` validation in `ProjectManager`:
+- Currently rejects keys other than `tdd_cycles` (implicit)
+- After C7: accept any key that is either `tdd_cycles` (validated fully) or a known phase name (`design`, `validation`, `documentation`) with a `deliverables: list` sub-key
+- Unknown keys → `ValueError` with list of valid phase names
+
+`update_planning_deliverables` (C5) handles per-phase deliverables the same way as `tdd_cycles.cycles` — merge by `id`.
+
+### 5.5 Hotfix Exception
+
+`hotfix` workflow has no `planning` phase → no `planning_deliverables` key in `projects.json` → all per-phase gates silently pass. No code change needed; this falls out naturally from the "gate optional when key absent" rule.
+
+---
+
+## 6. Cross-Cutting Concerns
+
+### Dependency Order
+
+```
+C5 (update tool) → C7 (per-phase deliverables, needs update tool for iterative saves)
+C6 (file_glob gate) is independent — can run in parallel with C5/C7
+```
+
+Recommended TDD order: **C5 → C6 → C7** (C5 first unblocks C7).
+
+### Backward Compatibility
+
+| Change | Impact |
+|--------|--------|
+| `exit_requires` accepts `type:` field | New schema variant, old `key:` entries unaffected |
+| `planning_deliverables` new phase keys | Existing `tdd_cycles`-only entries unaffected |
+| `update_planning_deliverables` new tool | Additive only |
+| `on_exit_<phase>_phase` gate check | Pass-through when `planning_deliverables.<phase>` absent — no behaviour change for existing projects |
+
+---
+
+## 7. Related Files
+
+| File | Change |
+|------|--------|
+| `mcp_server/managers/project_manager.py` | Add `update_planning_deliverables()`, relax `planning_deliverables` schema for phase keys |
+| `mcp_server/managers/phase_state_engine.py` | `_check_exit_requires` supports `type:file_glob`; `on_exit_<phase>` gates check per-phase deliverables |
+| `mcp_server/tools/project_tools.py` | Add `UpdatePlanningDeliverablesInput`, `UpdatePlanningDeliverablesTool` |
+| `mcp_server/server.py` | Register `UpdatePlanningDeliverablesTool` |
+| `.st3/workphases.yaml` | Add `exit_requires` to research phase |
+| `mcp_server/core/workphases_config.py` (if exists) | Extend schema for `FileGlobRequirement` |

--- a/docs/development/issue229/design.md
+++ b/docs/development/issue229/design.md
@@ -1,0 +1,239 @@
+<!-- docs/development/issue229/design.md -->
+<!-- template=design version=5827e841 created=2026-02-19 updated= -->
+# Phase Deliverables Enforcement — Design
+
+**Status:** DRAFT
+**Version:** 1.0
+**Last Updated:** 2026-02-19
+
+## Prerequisites
+
+Read these first:
+1. `research.md` — hook architecture, gap analysis
+2. `findings.md` — GAP-01..04, Option C validation strategy, structured `validates` schema
+3. `planning.md` v1.2 — 4 cycle breakdown, test names, success criteria
+
+---
+
+## 1. Context & Requirements
+
+### 1.1. Problem Statement
+
+`PhaseStateEngine` hardcodes phase gate logic: planning deliverables are validated at TDD *entry* (wrong layer), there is no planning *exit* gate, forced transitions bypass all checks silently, and `save_planning_deliverables` is not reachable via MCP. `workphases.yaml` has no mechanism to declare per-phase deliverable contracts.
+
+### 1.2. Requirements
+
+**Functional:**
+- [ ] Leaving planning phase must raise `PhaseDeliverableError` if `exit_requires` entries in `workphases.yaml` are not satisfied
+- [ ] Entering a phase that declares `entry_expects` must log a warning per unsatisfied entry (no block)
+- [ ] Forced transition must log `logger.warning` listing each skipped `exit_requires` and `entry_expects` gate
+- [ ] `DeliverableChecker` must support `file_exists`, `contains_text`, `absent_text`, `key_path` validate types
+- [ ] `save_planning_deliverables` must be callable as an MCP tool
+
+**Non-Functional:**
+- [ ] `DeliverableChecker` is pure — no I/O side effects beyond reading
+- [ ] Existing phases without `exit_requires`/`entry_expects` in `workphases.yaml` load and transition without error
+- [ ] All new behaviour covered by unit tests before wiring into engine (Cycle 1 before Cycle 2)
+
+### 1.3. Constraints
+
+- Must not break existing phases without `exit_requires` (backward compat)
+- `DeliverableChecker` must be pure — no side effects, no state mutation
+- `force_transition()` remains unconditional — only adds a warning, never blocks
+- Existing `on_enter_tdd_phase` cycle-init logic must be preserved after planning-deliverables check is removed
+
+---
+
+## 2. Design Options
+
+### 2.1. Option A — Inline specs in `workphases.yaml`
+
+`exit_requires` lists deliverable specs inline (file, type, text). Engine runs checker directly from YAML.
+
+**Pros:**
+- Single SSOT per phase
+
+**Cons:**
+- Couples phase config to file layout — `workphases.yaml` grows unwieldy
+- Cannot reuse per-issue deliverable context
+
+---
+
+### 2.2. Option B — Indirection via `projects.json` ✅ CHOSEN
+
+`exit_requires` lists key names (e.g. `planning_deliverables`). Engine reads `validates` entries from `projects.json[issue][key]`, runs `DeliverableChecker` on each entry.
+
+**Pros:**
+- Phase config stays stable — `workphases.yaml` only names the required key, not the spec
+- Per-issue deliverable specs live with the issue in `projects.json`
+- `DeliverableChecker` is reusable across any phase/key combination
+
+**Cons:**
+- Two-file lookup (`workphases.yaml` → `projects.json`): slightly more indirection
+
+---
+
+### 2.3. Option C — Hardcoded hooks (status quo extended)
+
+No YAML config. Engine hardcodes which phases have gates (same pattern as current TDD hooks).
+
+**Pros:**
+- Simple, no YAML parsing
+
+**Cons:**
+- Perpetuates the architectural problem — not extensible, goes against #229 goal
+
+---
+
+## 3. Decision
+
+**Option B — Indirection via `projects.json`**
+
+`workphases.yaml` is stable phase metadata; it declares *which key* must exist. `projects.json` carries *what that key must contain*. The `DeliverableChecker` is a pure utility operating on any `validates` spec, regardless of which phase triggered it. The indirection is intentional and clearly bounded.
+
+---
+
+## 4. Rationale
+
+The separation is architecturally meaningful:
+- **What** a phase requires → `workphases.yaml` `exit_requires` (stable, shared across all issues)
+- **What** a specific issue produced → `projects.json` deliverable entries with `validates` specs (per-issue, evolves during planning)
+- **How** to verify a deliverable → `DeliverableChecker` (pure, testable in isolation)
+
+This matches the existing pattern: `workflow_config.validate_transition()` reads `workflows.yaml` for workflow rules; the engine reads `projects.json` for issue state. Adding `workphases.yaml` as a third config layer is consistent.
+
+---
+
+## 5. Interface Contracts
+
+### 5.1. `workphases.yaml` schema extension
+
+```yaml
+planning:
+  display_name: "Planning"
+  # ... existing fields unchanged ...
+  exit_requires:
+    - key: "planning_deliverables"
+      description: "TDD cycle breakdown with structured deliverables"
+  entry_expects: []   # planning produces, does not consume
+
+tdd:
+  # ... existing fields unchanged ...
+  exit_requires: []
+  entry_expects:
+    - key: "planning_deliverables"
+      description: "Expected from planning phase"
+```
+
+Fields are **optional** — phases without them behave identically to current behaviour.
+
+---
+
+### 5.2. `DeliverableChecker`
+
+**Location:** `mcp_server/managers/deliverable_checker.py`
+
+**`validates` spec types:**
+
+| `type` | Required fields | Check performed |
+|--------|----------------|-----------------|
+| `file_exists` | `file` | File present on disk |
+| `contains_text` | `file`, `text` | File contains literal `text` |
+| `absent_text` | `file`, `text` | File does NOT contain `text` |
+| `key_path` | `file`, `path` | Dot-notation path resolves to a value in JSON/YAML |
+
+> **SCAFFOLD-header check** (referenced in `findings.md` as the `.md` deliverable check) is implemented as `contains_text` with `text = "<!-- template="`. No special type needed — this is a concrete application of the generic `contains_text` check.
+
+**Interface:**
+
+```python
+class DeliverableCheckError(ValueError):
+    """Raised when a structural deliverable check fails."""
+
+class DeliverableChecker:
+    def __init__(self, workspace_root: Path) -> None: ...
+
+    def check(self, deliverable_id: str, validates: dict[str, str]) -> None:
+        """Raise DeliverableCheckError if check fails. Silent on success."""
+```
+
+---
+
+### 5.3. `PhaseStateEngine` hook dispatch (Cycle 2)
+
+`transition()` already calls `on_exit_tdd_phase` / `on_enter_tdd_phase` by name. The same pattern is extended:
+
+```python
+# Pseudo-code — no implementation detail
+if from_phase == "planning":
+    self.on_exit_planning_phase(branch, issue_number)   # hard gate
+
+if to_phase in <phases with entry_expects>:
+    self.on_enter_{to_phase}_phase(branch, issue_number)  # soft warning
+```
+
+`on_exit_planning_phase` reads `workphases.yaml` exit_requires, resolves each key from `projects.json`, runs `DeliverableChecker.check()` per `validates` entry. Raises `PhaseDeliverableError` on first failure.
+
+`on_enter_tdd_phase` retains only cycle auto-init logic. Planning deliverables check is removed entirely.
+
+---
+
+### 5.4. `force_transition()` skipped-gate warning (Cycle 3)
+
+After recording the transition, reads `workphases.yaml` for:
+- `exit_requires` on `from_phase`
+- `entry_expects` on `to_phase`
+
+Logs one `logger.warning` per non-empty gate list:
+
+```
+WARNING: force_transition skipped exit_requires gate on 'planning': ['planning_deliverables']
+WARNING: force_transition skipped entry_expects gate on 'tdd': ['planning_deliverables']
+```
+
+No blocking. No re-checking deliverable presence — warning is unconditional if the gate *exists* in YAML.
+
+---
+
+### 5.5. `SavePlanningDeliverablesTool` (Cycle 4)
+
+**Location:** `mcp_server/tools/project_tools.py`  
+**Pattern:** follows `InitializeProjectTool` (existing `BaseTool` subclass in same file)
+
+```python
+class SavePlanningDeliverablesInput(BaseModel):
+    issue_number: int
+    tdd_cycles: dict  # validated by ProjectManager
+
+class SavePlanningDeliverablesTool(BaseTool):
+    # Wraps ProjectManager.save_planning_deliverables()
+    # Delegates validation to existing ProjectManager logic
+    # Registered in server.py alongside InitializeProjectTool
+```
+
+---
+
+## 6. Open Questions
+
+- **`entry_expects` hard block vs warning?** → Soft warning only. Consuming phase must not be held hostage by producing phase. Cycle 2 implements warning only.
+- **`DeliverableChecker` path resolution?** → Relative to `workspace_root` — same convention as all other managers.
+
+---
+
+## Related Documentation
+
+- **[docs/development/issue229/research.md](research.md)**
+- **[docs/development/issue229/planning.md](planning.md)**
+- **[docs/development/issue229/findings.md](findings.md)**
+- **[mcp_server/managers/phase_state_engine.py](../../../mcp_server/managers/phase_state_engine.py)**
+- **[mcp_server/managers/project_manager.py](../../../mcp_server/managers/project_manager.py)**
+- **[mcp_server/tools/project_tools.py](../../../mcp_server/tools/project_tools.py)**
+- **[.st3/workphases.yaml](../../../.st3/workphases.yaml)**
+
+---
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-02-19 | Agent | Initial draft |

--- a/docs/development/issue229/findings.md
+++ b/docs/development/issue229/findings.md
@@ -1,0 +1,382 @@
+# Issue #229 — Trial Run Findings
+
+**Type:** LIVING DOCUMENT  
+**Branch:** `feature/229-phase-deliverables-enforcement`  
+**Last Updated:** 2026-02-20
+
+This document records gaps and observations found during the live trial run of the #229 branch. It covers both #146 machinery validation and newly discovered gaps not present in research.md.
+
+---
+
+## Gap Index
+
+| ID | Severity | Area | Status |
+|----|----------|------|--------|
+| [GAP-01](#gap-01) | High | PhaseStateEngine | ✅ Fixed (C2) |
+| [GAP-02](#gap-02) | High | PhaseStateEngine | ✅ Fixed (C2) |
+| [GAP-03](#gap-03) | Medium | PhaseStateEngine | ✅ Fixed (C3) |
+| [GAP-04](#gap-04) | Medium | MCP Tools | ✅ Fixed (C4) |
+| [GAP-05](#gap-05) | Medium | DeliverableChecker | ✅ Fixed (C2 re-run) |
+| [GAP-06](#gap-06) | Medium | SavePlanningDeliverablesTool | ✅ Fixed (C4) |
+| [GAP-07](#gap-07) | Medium | MCP Git Tool | ✅ Fixed (C2 re-run) |
+| [GAP-08](#gap-08) | Medium | ForceCycleTransitionTool | ✅ Fixed (C3) |
+| [GAP-09](#gap-09) | Medium | SavePlanningDeliverablesTool | ✅ Fixed (C5) |
+| [GAP-10](#gap-10) | Medium | PhaseStateEngine / workphases.yaml | ✅ Fixed (C6) |
+| [GAP-11](#gap-11) | Medium | PhaseStateEngine / planning schema | ✅ Fixed (C7) |
+| [GAP-12](#gap-12) | Low | UpdatePlanningDeliverablesTool | Pending |
+| [GAP-13](#gap-13) | Low | UpdatePlanningDeliverablesTool | Pending |
+| [GAP-14](#gap-14) | Medium | projects.json / D7 validates specs | Pending |
+| [GAP-15](#gap-15) | High | ProjectManager / update_planning_deliverables | Pending |
+| [GAP-16](#gap-16) | High | PhaseStateEngine / exit hooks | Pending |
+| [GAP-17](#gap-17) | High | ForcePhaseTool / force_cycle_transition response format | Pending |
+
+---
+
+## GAP-01
+
+**Title:** Planning exit is silent — no deliverable gate  
+**Severity:** High  
+**Observed:** `planning → design` transition succeeded with no `planning_deliverables` in `projects.json`  
+**Expected:** `ValueError` blocking the transition until deliverables are saved  
+**Root cause:** `transition()` has no `on_exit_planning_phase` hook; only TDD hooks are wired  
+**Addressed by:** #229 (this issue)
+
+---
+
+## GAP-02
+
+**Title:** TDD entry gate placed at wrong layer  
+**Severity:** High  
+**Observed:** `design → tdd` raised `ValueError: Planning deliverables not found for issue 229`  
+**Expected:** The check should have fired on Planning *exit*, not TDD *entry*  
+**Root cause:** `on_enter_tdd_phase` validates planning deliverables — violates separation of concerns  
+**Addressed by:** #229 (this issue)
+
+---
+
+## GAP-03
+
+**Title:** Forced transition bypasses all hooks and deliverable checks  
+**Severity:** Medium  
+**Observed:** `force_transition(tdd → planning)` succeeded with no hooks, no warnings, no checks  
+**Expected:** At minimum a `logger.warning` that a forced transition skipped deliverable validation  
+**Note:** Forced transitions already require `skip_reason + human_approval` — the audit trail exists, but nothing is logged about skipped gates  
+**Addressed by:** #229 Cycle 3 — forced transition skipped-gate warning
+
+---
+
+## GAP-04
+
+**Title:** `save_planning_deliverables` not exposed as MCP tool  
+**Severity:** Medium  
+**Observed:** No MCP tool exists to save planning deliverables — only `ProjectManager.save_planning_deliverables()` as internal API  
+**Expected:** Agent/user should be able to call a tool to persist deliverables from the planning phase without directly editing `projects.json`  
+**Impact:** Trial run required direct `projects.json` editing to set up deliverables — not a valid workflow  
+**Addressed by:** #229 Cycle 4 (D4.1/D4.2) — `SavePlanningDeliverablesTool` in `project_tools.py` + registered in `server.py`
+
+---
+
+## Post-Implementation Gaps (2026-02-19 smoke-test session)
+
+Discovered during smoke-test of the live implementation and follow-up Q&A after C1+C2 completion.
+
+| ID | Severity | Area | Status |
+|----|----------|------|--------|
+| [GAP-05](#gap-05) | Medium | DeliverableChecker | ✅ Fixed |
+| [GAP-06](#gap-06) | Medium | SavePlanningDeliverablesTool | ✅ Fixed (C4) |
+| [GAP-07](#gap-07) | Medium | MCP Git Tool | ✅ Fixed (C2 re-run) |
+| [GAP-08](#gap-08) | Medium | ForceCycleTransitionTool | ✅ Fixed (C3) |
+| [GAP-09](#gap-09) | Medium | SavePlanningDeliverablesTool | Pending |
+| [GAP-10](#gap-10) | Medium | PhaseStateEngine / workphases.yaml | Pending |
+| [GAP-11](#gap-11) | Medium | PhaseStateEngine / planning schema | Pending |
+
+---
+
+## GAP-05
+
+**Title:** `file_exists` has no glob/pattern support  
+**Severity:** Medium  
+**Observed:** `_check_file_exists` resolves `spec["file"]` as a literal path via `Path(relative_file)`. A pattern like `docs/development/issue229/*research*.md` is interpreted as a filename and fails because no such literal file exists.  
+**Expected:** Agents should be able to declare deliverables without knowing the exact filename upfront — e.g. "a `*research*.md` file must exist in `docs/development/issue229/`".  
+**Root cause:** `_resolve()` always produces a single `Path` object; `glob()` is never called.  
+**Proposed fix:** Add `file_glob` check type (or optional `glob: true` flag on `file_exists`) that uses `Path.glob()` and raises if no matches are found.  
+**Addressed by:** #229 Cycle 2 re-run
+
+---
+
+## GAP-06
+
+**Title:** `SavePlanningDeliverablesTool` has no input schema validation  
+**Severity:** Medium  
+**Observed (anticipated):** The tool will accept any JSON payload via MCP. An agent can save deliverables with invalid or incomplete `validates` entries (wrong `type`, missing `file`, etc.) that only fail at planning exit gate — not at save time.  
+**Expected:** The tool should validate each `validates` entry on write, and return a structured error listing available types and required fields per type — matching the pattern established by the scaffold tool.  
+**Note:** MCP tool input schema (JSON Schema exposed via the MCP protocol) serves as Layer 1 contract — agents know the top-level parameter shape. Layer 2 (semantic validation inside the tool at runtime) is needed for the `validates` sub-entries which are dynamically typed (`type` determines which other fields are required).  
+**Addressed by:** #229 Cycle 4 scope extension (schema validation + helpful error messages)
+
+---
+
+## GAP-07
+
+**Title:** `git_add_or_commit` does not validate `workflow_phase` + `cycle_number` against `state.json`  
+**Severity:** Medium  
+**Observed:** Agent committed with `workflow_phase="tdd"`, `cycle_number=2` while `state.json.current_phase="design"`. Tool accepted the call without error. Commits were scoped correctly per the parameters, but the state was inconsistent — no enforcement of the actual project phase.  
+**Expected:** Tool blocks when the provided `workflow_phase` doesn't match `state.json.current_phase`, or (in TDD) when `cycle_number` doesn't match `state.json.current_tdd_cycle`. Error message should name the mismatch and the transitions needed to resolve it.  
+**Root cause:** `git_add_or_commit` uses `workflow_phase` / `cycle_number` purely for commit message scope generation — it never reads `state.json`.  
+**Proposed fix:** Before generating the commit, read `state.json`, compare `workflow_phase` vs `current_phase` (and `cycle_number` vs `current_tdd_cycle` when phase is `tdd`), raise `CommitPhaseMismatchError` with actionable message if mismatched.  
+**Addressed by:** #229 Cycle 2 re-run (D2.4) — small addition to existing C2 scope
+
+---
+
+## GAP-08
+
+**Title:** `force_cycle_transition` does not warn when skipped cycles have unvalidated deliverables  
+**Severity:** Medium  
+**Observed:** `force_cycle_transition(to_cycle=4)` while cycle 3 deliverables (D3.1) not yet validated — tool succeeded silently. The `skipped_cycles` list is written to the audit trail, but no warning is surfaced about unvalidated work.  
+**Expected:** Tool warns when any skipped cycle has deliverables that don't pass `DeliverableChecker`. The transition still succeeds (forced = unconditional escape hatch), but the agent/user sees which deliverables were bypassed.  
+**Root cause:** `ForceCycleTransitionTool.execute()` checks `planning_deliverables` for existence but never runs `DeliverableChecker` on the skipped cycles' deliverables.  
+**Proposed fix:** After computing `skipped_cycles`, iterate each skipped cycle's `deliverables` list, run `DeliverableChecker.check()` per entry, collect failures, and append `⚠️ Unvalidated cycle deliverables: cycle:N:ID (description)` to the tool response — same pattern as GAP-03.  
+**Addressed by:** #229 Cycle 3 (D3.2) — scope extension aligned with GAP-03 pattern
+
+---
+
+## Validation Strategy Discussion
+
+**Decision: Structural checks only — no acceptance tests per phase**
+
+Rationale:
+- Acceptance tests written by the same agent doing the phase work = "slager keurt eigen vlees" — self-verification without independence
+- Per-phase test files distract the agent from the actual phase deliverable
+- Content-level validation of scaffold output against template structure is not yet possible (no template-vs-artifact diff tooling)
+- Extensibility: structural checks are a sound foundation to layer richer checks on later
+
+**Selected approach:**
+
+| Deliverable type | Check | Mechanism |
+|-----------------|-------|-----------|
+| Scaffolded document (`.md`) | File exists + `<!-- template=X version=Y -->` SCAFFOLD header present | Engine reads first 3 lines |
+| Config key (YAML/JSON) | Key path exists in file | Engine resolves dot-notation path |
+| Future | Structural diff against template schema | Not in scope for #229 |
+
+**Response verbosity design:**
+
+| Scenario | Response |
+|----------|----------|
+| Transition with exit gate — deliverables pass | `✅ planning → design \| exit gate: N/N deliverables checked (D1.1 ✓ D1.2 ✓ ...)` |
+| Transition without exit gate | `✅ research → planning` (stil, geen gate) |
+| Transition with exit gate — deliverable fails | `❌ ... \| exit gate: D1.2 FAILED — file not found: mcp_server/managers/deliverable_checker.py` |
+
+Conditionally verbose: alleen rapporteren wanneer er daadwerkelijk een gate was. Onderdeel van Cycle 2.
+
+**Deliberately out of scope for #229:**
+- Validating scaffold output *content* against template structure
+- YAML-key value validation (presence is enough)
+- Acceptance test files per phase
+- Detailed validation logic per artifact type beyond the two checks above
+
+**Extension path:** The `validates` schema on each deliverable entry is intentionally simple now. A future issue can add `type: yaml_key_value`, `type: test_passes`, etc. without breaking existing deliverables.
+
+---
+
+---
+
+## GAP-09
+
+**Title:** `save_planning_deliverables` is write-once — no update path for evolving cycles  
+**Severity:** Medium  
+**Observed:** A second call to `save_planning_deliverables` for the same issue raises `ValueError: Cannot overwrite existing deliverables`. During the #229 trial run, D3.2 (GAP-08) and several cycle extensions were applied via direct `safe_edit_file` on `projects.json` — bypassing the tool entirely.  
+**Expected:** The agent must be able to add cycles, update deliverable specs, or append entries to existing planning deliverables as the project evolves during research/planning iterations.  
+**Root cause:** `ProjectManager.save_planning_deliverables()` has an explicit write-once guard. There is no update/merge operation.  
+**Proposed fix:** Add `update_planning_deliverables` MCP tool (**Optie A**) with merge-strategy: new cycles append, existing cycle deliverables merge by `id`. Keep the original `save_planning_deliverables` as the initial write (write-once stays intentional for the first commit).  
+**Addressed by:** #229 pending — new TDD cycle
+
+---
+
+## GAP-10
+
+**Title:** `exit_requires` in `workphases.yaml` only supports `key:` checks — no file-system gates  
+**Severity:** Medium  
+**Observed:** The `research` phase has no `exit_requires` entry. Adding a file-existence gate (e.g. "a `*research*.md` must exist") requires a new `type: file_glob` variant — the current mechanism only checks for keys in `projects.json`.  
+**Expected:** `workphases.yaml` should support static file-system exit gates per phase, with `{issue_number}` interpolation, so the research phase can enforce artifact existence before transitioning to planning.  
+**Root cause:** `PhaseStateEngine.force_transition()` / `transition()` only read `key:` entries from `exit_requires`; `DeliverableChecker` runs only on `planning_deliverables`, not on phase config.  
+**Proposed fix:** Extend `exit_requires` schema with `type: file_glob` + `file:` with `{issue_number}` placeholder. Interpolate at gate-check time and delegate to `DeliverableChecker._check_file_glob()`. Then configure:
+```yaml
+research:
+  exit_requires:
+    - type: file_glob
+      file: "docs/development/issue{issue_number}/*research*.md"
+      description: "Research document aanwezig"
+```
+**Addressed by:** #229 pending — new TDD cycle
+
+---
+
+## GAP-11
+
+**Title:** `planning_deliverables` schema is TDD-centric — no deliverable gates for design/validation/documentation phases  
+**Severity:** Medium  
+**Observed:** `save_planning_deliverables` only accepts `tdd_cycles` as the structured key. Phases like `design`, `validation`, and `documentation` cannot have planning-defined deliverable gates — meaning those phase transitions are always unvalidated, even when deliverables are known upfront.  
+**Expected:** Planning should be able to define expected deliverables for *any* phase in the workflow, e.g.:
+```json
+{
+  "planning_deliverables": {
+    "tdd_cycles": { "total": 2, "cycles": [...] },
+    "design": { "deliverables": [...] },
+    "validation": { "deliverables": [...] },
+    "documentation": { "deliverables": [...] }
+  }
+}
+```
+`PhaseStateEngine` should then check `planning_deliverables.<phase>.deliverables` as the exit gate for each respective phase (same `DeliverableChecker` pattern).  
+**Root cause:** Schema design in `save_planning_deliverables` and `PhaseStateEngine` assumes TDD is the only phase with structured deliverables.  
+**Note:** `hotfix` workflow intentionally has no planning phase and therefore no deliverable gates — accepted trade-off.  
+**Addressed by:** #229 pending — new TDD cycle (requires design phase for schema impact analysis)
+
+---
+
+---
+
+## Validation Phase Findings (2026-02-20)
+
+Discovered during live validation of cycles 5–7 in the validation phase. Tests run via Python engine invocations and live MCP tool calls.
+
+### Cycle 5 validation — UpdatePlanningDeliverablesTool ✅ (with gaps)
+
+| Test | Result |
+|------|--------|
+| Merge bestaande cycle (D7.1 desc bijgewerkt, D7.2 intact) | ✅ |
+| Nieuwe cycle appenden | ✅ |
+| Update vóór save (geïnitialiseerd project zonder plan) | ✅ Duidelijk foutbericht |
+| Update op niet-bestaand issue | ✅ Duidelijk foutbericht |
+
+### Cycle 6 validation — research exit gate ✅
+
+| Test | Result |
+|------|--------|
+| Transitie zonder `*research*.md` → blokkeert | ✅ `DeliverableCheckError` met pad in bericht |
+| Transitie met `*research*.md` aanwezig → passeert | ✅ |
+
+### Cycle 7 validation — per-fase exit gate (live tests 2026-02-20)
+
+| Test | R | Resultaat |
+|------|---|-----------|
+| `save_planning_deliverables` met `design` key → persisted | R1 | ✅ PASS |
+| Design gate via `transition(design→tdd)` op bestaand bestand | R2/R3 | ✅ PASS |
+| Design gate via `transition(design→tdd)` op niet-bestaand bestand | R2 | ✅ BLOKKEERT correct |
+| `update_planning_deliverables` met `design` key → genegeerd | R4 | ❌ GAP-15 |
+| `transition(validation→documentation)` met falende spec → passeert | R6 | ❌ GAP-16 |
+| `phase_deliverables` letterlijk aanwezig in code | — | ❌ GAP-14 |
+
+---
+
+## GAP-12
+
+**Title:** `exit_criteria` op cycle-niveau wordt niet geüpdated bij merge  
+**Severity:** Low  
+**Observed:** `update_planning_deliverables` met gewijzigde `exit_criteria` op een bestaande cycle → `exit_criteria` bleef de originele waarde; alleen deliverables in die cycle werden gemerged by id.  
+**Expected:** Als `exit_criteria` meegegeven wordt in een update, wordt die ook overschreven (shallow merge op het cycle-object).  
+**Root cause:** De merge-logica itereert alleen over `deliverables` by id; andere cycle-velden worden genegeerd.  
+**Impact:** Low — agenten kunnen `exit_criteria` niet corrigeren zonder `projects.json` direct te editen.
+
+---
+
+## GAP-13
+
+**Title:** Geen mechanisme om een foutief toegevoegde cycle te verwijderen  
+**Severity:** Low  
+**Observed:** Na een test-cycle (cycle 8) toe te voegen via `update_planning_deliverables` was er geen tool-call om die cycle weer te verwijderen. Cleanup vereiste directe `projects.json` edit.  
+**Expected:** Ofwel een `delete_planning_cycle` tool, ofwel expliciete vermelding in documentatie dat cycles permanent zijn na toevoeging.  
+**Impact:** Low — bewuste keuze is verdedigbaar (immutability), maar niet gedocumenteerd.
+
+---
+
+## GAP-14
+
+**Title:** D7.1 en D7.2 `validates.text` specs komen niet overeen met de werkelijke implementatietekst  
+**Severity:** Medium  
+**Observed:** Deliverable specs in `projects.json` (issue 229) bevatten:  
+- D7.1: `{"type": "contains_text", "file": "mcp_server/managers/project_manager.py", "text": "phase_deliverables"}`
+- D7.2: `{"type": "contains_text", "file": "mcp_server/managers/phase_state_engine.py", "text": "phase_deliverables"}`  
+De tekst `"phase_deliverables"` komt **niet voor** in beide bestanden. De implementatie gebruikt:
+- `project_manager.py`: `_known_phase_keys = {"tdd_cycles", "design", "validation", ...}`
+- `phase_state_engine.py`: `.get("planning_deliverables", {}).get("design", {})`  
+**Expected:** `validates.text` spec matcht een string die daadwerkelijk in de implementatie staat.  
+**Root cause:** Specs zijn geschreven vóór implementatie; namen zijn afgedwaald tijdens het codeerproces.  
+**Impact:** Medium — als de DeliverableChecker gebruikt zou worden om D7 te valideren, zouden beide checks falen terwijl de functionaliteit correct is geïmplementeerd. Misleidend voor toekomstige sessies.  
+**Proposed fix:** D7.1 `text` aanpassen naar `_known_phase_keys` of `"design"`, D7.2 naar `on_exit_design_phase`.
+
+---
+
+## GAP-15
+
+**Title:** `update_planning_deliverables` negeert per-fase keys (`design`, `validation`, `documentation`) volledig  
+**Severity:** High  
+**Observed:** Live test (2026-02-20) via `update_planning_deliverables(9900, {"design": {"deliverables": [...]}})` — server gaf `✅ Planning deliverables updated` terug, maar na `get_project_plan(9900)` bleek het `design.deliverables` payload volledig genegeerd. Het opgeslagen bestand (via `safe_edit_file`) wél aanpast worden.  
+**Expected:** Per-fase keys worden op dezelfde manier door `update_planning_deliverables` verwerkt als `tdd_cycles`: bestaande deliverables worden gemerged by id, nieuwe worden toegevoegd.  
+**Root cause:** `update_planning_deliverables` in `project_manager.py` haalt uitsluitend `incoming_tc = planning_deliverables.get("tdd_cycles", {})` op. Per-fase keys worden nooit gelezen uit de payload.  
+**Impact:** High — per-fase gate specs kunnen niet worden gecorrigeerd of aangevuld via de tool API. Workaround vereist directe `projects.json` edit. In cycle 7-context: de design gate werkt correct bij save, maar aanpassingen daarna zijn onmogelijk via de tool.  
+**Proposed fix:** `update_planning_deliverables` uitbreiden met een merge-loop over `_known_phase_keys - {"tdd_cycles", "validates"}` analoog aan de tdd_cycles merge.
+
+---
+
+## GAP-16
+
+**Title:** Geen `on_exit_validation_phase` en `on_exit_documentation_phase` hooks — per-fase gates vuren niet bij validation en documentation  
+**Severity:** High  
+**Observed:** Live test (2026-02-20): `validation.deliverables` spec toegevoegd met niet-bestaand bestand (`validation-DOES-NOT-EXIST.md`). Transitie `validation → documentation` via normale `transition_phase` — **slaagde zonder fout**, terwijl het bestand niet bestaat.  
+**Expected:** Net als de `design` fase heeft `validation` een `on_exit_validation_phase` hook in `PhaseStateEngine.transition()` die `planning_deliverables.validation.deliverables` controleert vóór doorgang.  
+**Root cause:** `phase_state_engine.py` `transition()` heeft exit hooks voor `planning`, `research`, `design`, `tdd` — maar **niet** voor `validation` of `documentation`. Methoden `on_exit_validation_phase` en `on_exit_documentation_phase` bestaan niet.  
+**Impact:** High — het per-fase gate systeem dat C7 introduceert is onvolledig. Validation en documentation deliverables worden opgeslagen in `projects.json` maar nooit gecontroleerd; enforcement geldt enkel voor de `design` fase.  
+**Proposed fix:** `on_exit_validation_phase` en `on_exit_documentation_phase` methoden implementeren analoog aan `on_exit_design_phase`, en ze wiren in `transition()` bij de overeenkomstige `from_phase` checks.
+
+---
+
+## GAP-17
+
+**Title:** Force transition tool response buries actionable warnings below `✅` success line — agents miss them  
+**Severity:** High  
+**Observed:** Live session 2026-02-20: `force_phase_transition(planning → tdd)` returned:
+```
+✅ Forced transition ... succeeded
+⚠️ Skipped gates: entry:tdd:planning_deliverables
+```
+Agent parsed `✅` as completion signal and proceeded without resolving the missing `planning_deliverables`. The same pattern caused a second missed warning during the same session. `force_cycle_transition` has the same response structure.  
+**Expected:** Skipped gates that **would have blocked** a normal transition are surfaced **before** the success line, in an `ACTION REQUIRED` format that cannot be overlooked:
+```
+⚠️ ACTION REQUIRED: 1 skipped gate would have BLOCKED a normal transition:
+  - entry:tdd:planning_deliverables (key absent in projects.json)
+  Verify or resolve before proceeding.
+✅ Forced transition succeeded
+```
+Gates that would have **passed** normally remain informational and can be omitted or shown below the success line.  
+**Root cause:** Both `force_phase_transition` and `force_cycle_transition` tool responses place `✅` first, regardless of whether any skipped gates represent real blockers. The current code collects `skipped_gates` but does not distinguish passing gates from blocking gates — all are appended to a flat warning after the success message.  
+**Impact:** High — agents operating in tool-call loops consistently treat `✅` as a terminal success signal. Blocking warnings placed below it are effectively invisible in practice, as confirmed by two missed instances in session.  
+**Proposed fix:**  
+1. In `force_phase_transition` and `force_cycle_transition`: evaluate each skipped gate with `DeliverableChecker` / key-presence check to classify as `would_block` vs `would_pass`  
+2. Emit `⚠️ ACTION REQUIRED` block **first** for any `would_block` gate, listing gate id + reason  
+3. Emit `✅ Forced transition succeeded` **last**  
+4. Omit or append `would_pass` gates as low-priority info after the success line
+
+---
+
+## #146 Trial Observations *(pre-remediation snapshot)*
+
+> These observations were recorded before planning was finalised. They reflect the system state with no deliverable gates in place. Do not use as post-remediation validation — see design/TDD phase for that.
+
+| Step | Result | Notes |
+|------|--------|-------|
+| `initialize_project(229)` | ✅ | `state.json` created with `current_tdd_cycle=None`, `tdd_cycle_history=[]` |
+| `research → planning` (sequential) | ✅ | No issues |
+| `planning → research` (forced backward) | ✅ | `forced=True`, `skip_reason` recorded in `state.json` |
+| `planning → design` (no deliverables) | ✅ silent | **GAP-01 confirmed** — exit gate missing |
+| `design → tdd` (no deliverables) | ❌ blocked | **GAP-02 confirmed** — gate fires on wrong layer |
+| `force_transition(tdd → planning)` | ✅ no hooks | **GAP-03 confirmed** — forced bypasses everything |
+| `save_planning_deliverables` via tool | ❌ no tool | **GAP-04 confirmed** — internal API only |
+
+Pending (after planning deliverables are legitimately produced):
+
+| Step | #146 Feature | Expected |
+|------|-------------|---------|
+| `planning → design → tdd` with deliverables | `on_enter_tdd_phase` init | `current_tdd_cycle=1` |
+| Commit `cycle_number=1, sub_phase="red"` | Scope generation | `test(P_TDD_SP_C1_RED): ...` |
+| `transition_cycle(to_cycle=2)` | Cycle history | `current_tdd_cycle=2` |
+| `tdd → validation` | `on_exit_tdd_phase` | `last_tdd_cycle=2`, `current_tdd_cycle=None` |

--- a/docs/development/issue229/planning.md
+++ b/docs/development/issue229/planning.md
@@ -1,0 +1,370 @@
+<!-- D:\dev\SimpleTraderV3\docs\development\issue229\planning.md -->
+<!-- template=planning version=130ac5ea created=2026-02-19 updated= -->
+# Phase Deliverables Enforcement — Planning
+
+**Status:** DRAFT  
+**Version:** 1.2  
+**Last Updated:** 2026-02-20
+
+---
+
+## Purpose
+
+Plan the TDD cycles needed to implement phase deliverable enforcement in PhaseStateEngine and workphases.yaml, fixing the architectural gap confirmed during the #146 trial run (GAP-01/02/03/04).
+
+## Scope
+
+**In Scope:**
+- Add `exit_requires` / `entry_expects` schema to `workphases.yaml` per phase
+- Per-phase structural deliverable checker: `file_exists`, `file_glob`, SCAFFOLD-header for `.md`, key-path for `.yaml`/`.json`
+- Hard exit gate on the planning phase — blocked transition when declared deliverables are absent
+- Soft entry warning on phases that declare `entry_expects`
+- Expose `save_planning_deliverables` as MCP tool with Layer 2 schema validation (fixing GAP-04 + GAP-06)
+
+**Out of Scope:**
+- Content validation of scaffold output against template structure (separate issue, already in progress)
+- YAML key-value validation (presence check is sufficient for now)
+- Acceptance test files per phase
+- Phase deliverable enforcement for non-Python artifact types
+
+## Prerequisites
+
+Read these first:
+1. `research.md` approved (findings + gap analysis complete)
+2. `findings.md` updated with validation strategy decision (structural checks only — no acceptance tests per phase)
+3. State in `state.json`: planning phase, no `planning_deliverables` in `projects.json` yet
+
+---
+
+## Summary
+
+Issue #229 introduces a two-layer enforcement model for phase deliverables: a hard exit gate on phases that produce required deliverables, and a soft entry warning on phases that consume them. Validation is structural only: file existence + SCAFFOLD-header for documents, key-path presence for config/JSON. Content validation against template schema is explicitly out of scope and deferred to a future issue.
+
+---
+
+## Dependencies
+
+- Requires #146 machinery active (scope format, cycle tracking) — branch is already based on `feature/146-tdd-cycle-tracking`
+- `workphases.yaml` must be extensible without breaking existing phase definitions (additive fields only)
+
+---
+
+## TDD Cycles
+
+### Cycle 1: workphases.yaml schema + structural deliverable checker
+
+**Goal:** Extend `workphases.yaml` with `exit_requires` and `entry_expects` fields per phase, and introduce a structural checker that can validate each declared deliverable (`file_exists`, SCAFFOLD-header, key-path). No engine wiring yet — this cycle produces the foundational component.
+
+**Tests:**
+- `test_workphases_schema_exit_requires_field_is_parsed`
+- `test_workphases_schema_entry_expects_field_is_parsed`
+- `test_workphases_schema_backward_compat_phases_without_field`
+- `test_deliverable_checker_file_not_found_raises`
+- `test_deliverable_checker_md_missing_scaffold_header_raises`
+- `test_deliverable_checker_md_valid_scaffold_header_passes`
+- `test_deliverable_checker_json_key_path_present_passes`
+- `test_deliverable_checker_json_key_path_missing_raises`
+
+**Success Criteria:**
+- All existing phases without `exit_requires` load without error (backward compat)
+- Structural checker validates SCAFFOLD-header presence in `.md` files
+- Structural checker resolves dot-notation key paths in JSON/YAML files
+- All 8 unit tests pass
+
+---
+
+### Cycle 2: Gate relocation + file_glob support + commit phase guard — GAP-01 + GAP-02 + GAP-05 + GAP-07
+
+**Goal:** Fix the architectural misplacement identified in GAP-01 and GAP-02. Wire the structural checker into the planning phase exit. Remove the planning-deliverables check from TDD entry. Add `file_glob` check type to `DeliverableChecker` (GAP-05) — agents need pattern-based file existence checks without knowing exact filenames. Add phase/cycle mismatch guard to `git_add_or_commit` (GAP-07) — tool should block commits when the provided phase/cycle doesn't match `state.json`.
+
+**Tests (original — gate relocation):**
+- `test_planning_exit_gate_blocks_transition_when_deliverables_missing`
+- `test_planning_exit_gate_passes_when_deliverables_present`
+- `test_planning_exit_gate_uses_workphases_config_for_required_keys`
+- `test_planning_exit_gate_runs_deliverable_checker_on_validates_entries`
+- `test_tdd_entry_no_longer_validates_planning_deliverables`
+- `test_transition_from_planning_calls_exit_planning_gate`
+
+**Tests (re-run addition — file_glob):**
+- `test_deliverable_checker_file_glob_match_passes`
+- `test_deliverable_checker_file_glob_no_match_raises`
+- `test_deliverable_checker_file_glob_pattern_in_subdir_passes`
+
+**Tests (re-run addition — commit phase guard):**
+- `test_git_add_or_commit_raises_on_phase_mismatch`
+
+**Success Criteria:**
+- `planning → design` raises when `exit_requires` deliverables are absent
+- `planning → design` passes when all deliverables present
+- Entering TDD no longer independently blocks on planning deliverables
+- `file_glob` type: at least one matching file → pass; zero matches → `DeliverableCheckError`
+- `git_add_or_commit` raises `CommitPhaseMismatchError` when `workflow_phase` ≠ `state.json.current_phase` (or `cycle_number` ≠ `current_tdd_cycle`)
+- All tests pass
+
+**Dependencies:** Cycle 1
+
+---
+
+### Cycle 3: Forced transition skipped-gate warning — GAP-03 + GAP-08
+
+**Goal:** When a forced transition bypasses one or more exit or entry gates, log a warning that lists which gates were skipped (GAP-03). Additionally, when `force_cycle_transition` skips cycles with unvalidated deliverables, warn about those too (GAP-08). Both transitions remain unconditional escape hatches — warnings are informational only.
+
+**Tests:**
+- `test_force_transition_logs_warning_for_skipped_exit_gate`
+- `test_force_transition_logs_warning_for_skipped_entry_expects`
+- `test_force_transition_without_gates_logs_no_warning`
+- `test_force_cycle_transition_warns_unvalidated_skipped_cycle_deliverables` *(D3.2)*
+- `test_force_cycle_transition_no_warning_when_skipped_cycles_pass_checks` *(D3.2)*
+
+**Success Criteria:**
+- Forced transition on a phase with `exit_requires` produces a `logger.warning` naming the skipped gates
+- Forced transition on a phase without gates remains silent
+- `force_cycle_transition` skip from C2→C4 produces `⚠️ Unvalidated cycle deliverables: cycle:3:D3.1 (...)` in tool response when C3 deliverables fail checks
+- `force_cycle_transition` skip produces no warning when all skipped cycle deliverables pass checks
+- All 5 tests pass
+
+**Dependencies:** Cycle 2 (gates must exist to have something to skip)
+
+---
+
+### Cycle 4: SavePlanningDeliverablesTool + schema validation — GAP-04 + GAP-06
+
+**Goal:** Expose `save_planning_deliverables` as a callable MCP tool. Extend it with Layer 2 schema validation: every `validates` entry in the payload is validated before persisting. On error, the tool returns a structured message listing the valid `type` values and their required fields — matching the pattern of the scaffold tool.
+
+**Layer model:**
+- **Layer 1** (free): MCP tool JSON Schema exposes parameter shapes to agents automatically
+- **Layer 2** (this cycle): Runtime validation of `validates` entries — catches invalid `type`, missing `file`, missing `text`/`path` per type, before writing to disk
+
+**Tests:**
+- `test_save_planning_deliverables_tool_persists_to_projects_json`
+- `test_save_planning_deliverables_tool_rejects_duplicate`
+- `test_save_planning_deliverables_tool_rejects_missing_tdd_cycles`
+- `test_save_planning_deliverables_tool_rejects_unknown_validates_type`
+- `test_save_planning_deliverables_tool_rejects_validates_missing_required_field`
+- `test_save_planning_deliverables_tool_error_lists_available_types_and_fields`
+
+**Success Criteria:**
+- Tool callable via MCP; persists to `projects.json` correctly
+- Duplicate calls rejected with clear error
+- Invalid `validates.type` rejected with message: `"Unknown type 'X'. Valid types: file_exists, file_glob, contains_text, absent_text, key_path. Required fields: ..."`
+- Missing required field (e.g. `file`, `text`) rejected with per-type field list
+- All 6 tests pass
+
+**Dependencies:** None (orthogonal to Cycles 1–3)
+
+---
+
+### Cycle 5: update_planning_deliverables tool — GAP-09
+
+**Goal:** Add `update_planning_deliverables` MCP tool with merge-strategy so cycles and deliverables can evolve after the initial write. Keep `save_planning_deliverables` write-once (intentional first-commit guard). The new tool merges: new cycles append by cycle number; existing cycle deliverables merge by `id`; existing entries update in place.
+
+**Tests:**
+- `test_update_planning_deliverables_tool_appends_new_cycle`
+- `test_update_planning_deliverables_tool_merges_deliverable_by_id`
+- `test_update_planning_deliverables_tool_updates_existing_deliverable_by_id`
+- `test_update_planning_deliverables_tool_rejects_before_initial_save`
+- `test_update_planning_deliverables_tool_validates_validates_entry_schema`
+
+**Success Criteria:**
+- New cycle appended without touching existing cycles
+- Existing deliverable with matching `id` updated (description/validates)
+- New deliverable with new `id` added to existing cycle
+- Call before `save_planning_deliverables` raises clear error
+- Layer 2 validates-schema validation identical to `save_planning_deliverables`
+- All tests pass
+
+**Dependencies:** Cycle 4 (Layer 2 `validate_spec` reusable)
+
+---
+
+### Cycle 6: exit_requires file_glob support + research phase gate — GAP-10
+
+**Goal:** Extend `exit_requires` in `workphases.yaml` with a `type: file_glob` variant that checks the file system instead of `projects.json`. Support `{issue_number}` placeholder interpolation. Configure the research phase with a gate requiring a `*research*.md` file.
+
+**Tests:**
+- `test_exit_requires_file_glob_passes_when_file_exists`
+- `test_exit_requires_file_glob_blocks_when_no_match`
+- `test_exit_requires_file_glob_interpolates_issue_number`
+- `test_research_exit_gate_blocks_without_research_doc`
+- `test_research_exit_gate_passes_with_research_doc`
+
+**Success Criteria:**
+- `PhaseStateEngine` reads `type: file_glob` entries from `exit_requires`
+- `{issue_number}` in `file:` is interpolated at gate-check time
+- Research → planning blocked when no `*research*.md` exists for issue
+- Research → planning passes when file exists
+- Forced transition logs `⚠️ Skipped gates: research.exit_requires[0]` (reuses C3 pattern)
+- All tests pass
+
+**Dependencies:** Cycle 1 (DeliverableChecker._check_file_glob), Cycle 3 (skipped-gate warning pattern)
+
+---
+
+### Cycle 7: planning_deliverables schema generalization — GAP-11
+
+**Goal:** Extend `planning_deliverables` to support per-phase deliverable definitions beyond `tdd_cycles`. `PhaseStateEngine` exit gate for each phase checks `planning_deliverables.<phase>.deliverables` via `DeliverableChecker`. `hotfix` workflow remains exempt (no planning phase).
+
+**Tests:**
+- `test_save_planning_deliverables_accepts_design_phase_deliverables`
+- `test_save_planning_deliverables_accepts_validation_phase_deliverables`
+- `test_phase_exit_gate_checks_planning_deliverables_for_phase`
+- `test_phase_exit_gate_skips_when_no_phase_key_in_planning_deliverables`
+- `test_update_planning_deliverables_accepts_non_tdd_phase_deliverables`
+
+**Success Criteria:**
+- `save_planning_deliverables` accepts `design`, `validation`, `documentation` keys alongside `tdd_cycles`
+- `PhaseStateEngine` exit gate for `design` checks `planning_deliverables.design.deliverables` when present
+- When key absent, gate is skipped (optional — not all agents plan all phases)
+- `DeliverableChecker` reused without modification
+- `hotfix` workflow unaffected
+- All tests pass
+
+**Dependencies:** Cycle 5 (update_planning_deliverables for evolving phase deliverables), Cycle 6 (gate pattern)
+
+---
+
+### Cycle 8: update_planning_deliverables completeness — GAP-12 + GAP-15
+
+**Goal:** Two gaps found during C7 live validation reveal that `update_planning_deliverables` is incomplete in two distinct ways.
+
+**GAP-15:** Per-fase keys (`design`, `validation`, `documentation`) are silently ignored. A call with `{"design": {"deliverables": [...]}}` returns `✅ Planning deliverables updated` but nothing changes in `projects.json`. The merge loop only processes `tdd_cycles`. Without this fix, agents cannot evolve per-phase gate specs after the initial `save_planning_deliverables` call — a direct `projects.json` edit is the only workaround.
+
+**GAP-12:** `exit_criteria` at the cycle level is ignored during merge. When a cycle update includes a corrected `exit_criteria`, only the `deliverables` list is merged by id; the cycle-level `exit_criteria` string is left unchanged. This makes it impossible to fix a typo or tighten criteria after the initial save.
+
+**Rationale for combining in one cycle:** Both gaps are in the same method (`ProjectManager.update_planning_deliverables`). Fixing one without the other leaves the tool partially broken. The test surface is small and self-contained; splitting into two cycles would add overhead without benefit.
+
+**Note on GAP-13** (no mechanism to delete a cycle): Treated as a design decision rather than a bug — cycles are intentionally append-only to preserve audit history. This will be documented as a constraint in the tool's docstring rather than fixed.
+
+**Tests:**
+- `test_update_planning_deliverables_merges_design_key`
+- `test_update_planning_deliverables_merges_validation_key`
+- `test_update_planning_deliverables_merges_documentation_key`
+- `test_update_planning_deliverables_per_phase_merge_by_id`
+- `test_update_planning_deliverables_updates_exit_criteria_on_existing_cycle`
+- `test_update_planning_deliverables_tdd_cycles_backward_compat`
+
+**Success Criteria:**
+- `update_planning_deliverables(229, {"design": {"deliverables": [...]}})` updates `projects.json` design deliverables
+- Per-fase merge by id: existing entry with matching `id` updated, new `id` appended
+- `exit_criteria` on an existing cycle is overwritten when provided in the update payload
+- `tdd_cycles` merge behaviour unchanged (backward compat)
+- All 6 tests pass
+
+**Dependencies:** Cycle 7 (per-fase keys schema in place), Cycle 5 (original tdd_cycles merge logic to extend)
+
+---
+
+### Cycle 9: validation + documentation exit hooks — GAP-16
+
+**Goal:** C7 introduced per-phase deliverable exit gates but only wired `on_exit_design_phase`. GAP-16, confirmed by live test on 2026-02-20: a `validation → documentation` transition passes without error even when `planning_deliverables.validation.deliverables` contains a spec pointing to a non-existent file. The same gap exists for `documentation → done`. `on_exit_validation_phase` and `on_exit_documentation_phase` do not exist; neither is wired in `transition()`.
+
+**Rationale:** The design intent in C7 was to generalise gate enforcement to all non-tdd phases. The implementation stopped at `design`. Completing enforcement for `validation` and `documentation` is a direct continuation of that design — the pattern (`on_exit_<phase>_phase` → `DeliverableChecker`) is already established and reusable.
+
+**Note on GAP-14** (`validates.text` specs in D7.1/D7.2 not matching actual implementation): Fixed as part of this cycle's success criteria — D7.1 and D7.2 specs in the live `projects.json` will be corrected via `update_planning_deliverables` once C8 is implemented.
+
+**Tests:**
+- `test_validation_exit_gate_blocks_transition_when_deliverable_missing`
+- `test_validation_exit_gate_passes_when_deliverable_present`
+- `test_validation_exit_gate_skips_when_no_validation_key_in_plan`
+- `test_documentation_exit_gate_blocks_transition_when_deliverable_missing`
+- `test_documentation_exit_gate_passes_when_deliverable_present`
+- `test_documentation_exit_gate_skips_when_no_documentation_key_in_plan`
+
+**Success Criteria:**
+- `on_exit_validation_phase` implemented and wired in `transition()` for `from_phase == "validation"`
+- `on_exit_documentation_phase` implemented and wired in `transition()` for `from_phase == "documentation"`
+- Both gates are optional: silent pass when key absent in `planning_deliverables`
+- `DeliverableChecker` reused without modification
+- Forced transition still bypasses hooks (uses existing C3 skip-warning pattern)
+- D7.1 and D7.2 `validates.text` specs in `projects.json` corrected via `update_planning_deliverables` (GAP-14 resolved)
+- All 6 tests pass
+
+**Dependencies:** Cycle 7 (on_exit_design_phase pattern), Cycle 8 (update_planning_deliverables per-fase merge needed to fix GAP-14 specs)
+
+---
+
+### Cycle 10: Force transition response format — GAP-17
+
+**Goal:** Force transition tool responses (`force_phase_transition`, `force_cycle_transition`) currently place `✅` first and any gate warnings below — causing agents to miss actionable blockers. Confirmed by two live misses in session 2026-02-20: agent parsed `✅` as completion signal and proceeded without resolving the skipped gate.
+
+**Root cause:** The tools do not distinguish between skipped gates that *would have passed* (informational) and those that *would have blocked* (actionable). All are emitted as a flat warning after the success line.
+
+**Fix:** Evaluate each skipped gate at force-transition time. Gates that would block are promoted to `⚠️ ACTION REQUIRED` and emitted **before** the `✅` line. Gates that would pass are informational and appended after. The transition itself remains unconditional — only the response ordering changes.
+
+**Response format (new):**
+```
+⚠️ ACTION REQUIRED: N skipped gate(s) would have BLOCKED a normal transition:
+  - entry:tdd:planning_deliverables (key absent in projects.json)
+  Verify or resolve before proceeding.
+✅ Forced transition succeeded
+```
+
+**Tests:**
+- `test_force_phase_transition_response_blocking_gate_appears_before_success`
+- `test_force_phase_transition_response_passing_gate_appears_after_success`
+- `test_force_phase_transition_response_no_gates_no_warning`
+- `test_force_cycle_transition_response_blocking_deliverable_appears_before_success`
+- `test_force_cycle_transition_response_passing_deliverable_appears_after_success`
+
+**Success Criteria:**
+- `⚠️ ACTION REQUIRED` block emitted before `✅` whenever any skipped gate would have blocked
+- Gates that would have passed appear after `✅` or are omitted
+- No change to transition behaviour — forced transitions remain unconditional
+- Both `force_phase_transition` and `force_cycle_transition` follow the new format
+- All 5 tests pass
+
+**Dependencies:** Cycle 3 (existing skipped-gate collection logic to extend), Cycle 8 (per-fase key check needed for complete gate evaluation)
+
+---
+
+## Risks & Mitigation
+
+- **Risk:** `workphases.yaml` additive fields break existing phase load
+  - **Mitigation:** Backward compat test for all existing phases without `exit_requires` in Cycle 1
+- **Risk:** Phase engine mishandles phases with no `exit_requires` defined
+  - **Mitigation:** Explicit test case for phases without the field in Cycle 2
+- **Risk:** Relocating the planning deliverables gate changes observable behavior for existing tests
+  - **Mitigation:** Backward compat test verifying TDD entry no longer raises independently (Cycle 2)
+
+---
+
+## Milestones
+
+- Cycle 1 GREEN: `workphases.yaml` schema + structural checker passing (8 tests)
+- Cycle 2 GREEN: planning exit gate wired, TDD entry gate removed, `file_glob` type added (GAP-01 + GAP-02 + GAP-05)
+- Cycle 3 GREEN: forced transition logs skipped gates (GAP-03 fixed); force_cycle_transition warns unvalidated skipped cycles (GAP-08 fixed)
+- Cycle 4 GREEN: `save_planning_deliverables` callable via MCP with Layer 2 schema validation (GAP-04 + GAP-06 fixed)
+- Cycle 5 GREEN: `update_planning_deliverables` tool with merge-strategy (GAP-09 fixed)
+- Cycle 6 GREEN: `exit_requires` supports `type: file_glob` + `{issue_number}` interpolation; research phase gate configured (GAP-10 fixed)
+- Cycle 7 GREEN: `planning_deliverables` generalised to all phases; exit gates per phase (GAP-11 fixed)
+- Cycle 8 GREEN: `update_planning_deliverables` merges per-fase keys + `exit_criteria` (GAP-12 + GAP-15 fixed)
+- Cycle 9 GREEN: `on_exit_validation_phase` + `on_exit_documentation_phase` wired; GAP-14 specs corrected (GAP-16 fixed)
+- Cycle 10 GREEN: force transition response emits `⚠️ ACTION REQUIRED` before `✅` for blocking gates (GAP-17 fixed)
+- All gaps confirmed resolved in `findings.md`
+
+## Related Documentation
+- **[docs/development/issue229/research.md][related-1]**
+- **[docs/development/issue229/findings.md][related-2]**
+- **[mcp_server/managers/phase_state_engine.py][related-3]**
+- **[.st3/workphases.yaml][related-4]**
+
+<!-- Link definitions -->
+
+[related-1]: docs/development/issue229/research.md
+[related-2]: docs/development/issue229/findings.md
+[related-3]: mcp_server/managers/phase_state_engine.py
+[related-4]: .st3/workphases.yaml
+
+---
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.7 | 2026-02-20 | Agent | Added C10 (GAP-17): force transition response format — blocking gates before ✅ |
+| 1.6 | 2026-02-20 | Agent | Added C8 (GAP-12 + GAP-15) and C9 (GAP-16); GAP-13 as design decision; GAP-14 resolved in C9; milestones updated |
+| 1.5 | 2026-02-19 | Agent | Added C5 (GAP-09), C6 (GAP-10), C7 (GAP-11) — discovered during validation phase smoke-test |
+| 1.3 | 2026-02-19 | Agent | C2 extended with file_glob (GAP-05); C4 extended with Layer 2 schema validation + error messages (GAP-06); scope + milestones updated |
+| 1.2 | 2026-02-19 | Agent | Expanded to 4 cycles: C1 infrastructure, C2 GAP-01/02, C3 GAP-03, C4 GAP-04; milestones aligned |
+| 1.1 | 2026-02-19 | Agent | Remove design creep from scope/goals/criteria/risks; fix GAP-04 scope |
+| 1.0 | 2026-02-19 | Agent | Initial draft |

--- a/docs/development/issue229/research.md
+++ b/docs/development/issue229/research.md
@@ -1,0 +1,215 @@
+<!-- docs/development/issue229/research.md -->
+<!-- template=research version=8b7bb3ab created=2026-02-19 updated=2026-02-19 -->
+# Phase Deliverables Enforcement — exit gate (hard) + entry warning (soft)
+
+**Status:** DRAFT  
+**Version:** 1.2  
+**Last Updated:** 2026-02-19
+
+---
+
+## Purpose
+
+Investigate the current implementation of phase-transition hooks in `PhaseStateEngine` and establish the requirements for a config-driven deliverables enforcement strategy.
+
+## Scope
+
+**In Scope:**
+- `PhaseStateEngine`: `on_enter_tdd_phase`, `on_exit_tdd_phase`, `transition()`, `force_transition()`
+- `workphases.yaml`: current structure and extensibility
+- `projects.json`: `planning_deliverables` schema (as introduced in #146)
+- Existing tests touching phase hooks and transition validation
+
+**Out of Scope:**
+- Design decisions for the new implementation (→ design.md)
+- Implementation of `exit_requires` / `entry_expects` (→ TDD phase)
+- Deliverable types beyond `planning_deliverables` and `tdd_cycle_history`
+- Changes to `workflow_config.py` or `workflows.yaml`
+
+## Prerequisites
+
+Read these first:
+1. Issue #146 branch: `feature/146-tdd-cycle-tracking`
+2. `PhaseStateEngine` architecture: [mcp_server/managers/phase_state_engine.py](../../../mcp_server/managers/phase_state_engine.py)
+3. `workphases.yaml`: [.st3/workphases.yaml](../../../.st3/workphases.yaml)
+
+---
+
+## Problem Statement
+
+The current `on_enter_tdd_phase` hook validates whether `planning_deliverables` exist in `projects.json`, raising a `ValueError` if they are absent. This is architecturally incorrect: the TDD phase has no responsibility for the output of the Planning phase. Furthermore, the check can be bypassed entirely via a forced transition. There is no consistent mechanism for validating deliverables at phase exit or entry.
+
+## Research Goals
+
+- Understand how the current phase-transition hooks are implemented in `PhaseStateEngine`
+- Inventory which deliverables are relevant per phase (current and extensible)
+- Determine whether `workphases.yaml` is suitable as SSOT for per-phase deliverable contracts
+- Establish how the engine can dynamically read and enforce `exit_requires` / `entry_expects`
+- Inventory which existing tests must be updated
+- Document open questions for the planning phase
+
+---
+
+## Background
+
+Issue #146 (TDD Cycle Tracking) introduced `on_enter_tdd_phase` as a hook that validates the presence of `planning_deliverables`. During the validation phase of #146, it was identified that this gate is placed at the wrong layer: the TDD phase should not be responsible for Planning output. At the same time, there is no exit gate on the Planning phase itself, meaning deliverables are never enforced when leaving that phase. This issue introduces a generic, config-driven solution.
+
+---
+
+## Findings
+
+### Current hook flow
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant PSE as PhaseStateEngine
+    participant PM as ProjectManager
+
+    Note over Caller,PM: Current situation — gate placed at wrong layer
+
+    Caller->>PSE: transition(branch, to_phase="tdd")
+    PSE->>PSE: workflow_config.validate_transition()
+    PSE->>PSE: on_enter_tdd_phase(branch, issue_number)
+    PSE->>PM: get_project_plan(issue_number)
+    PM-->>PSE: plan (with / without planning_deliverables)
+    alt planning_deliverables missing
+        PSE-->>Caller: ValueError — gate fires on TDD entry
+    else present
+        PSE->>PSE: current_tdd_cycle = 1 (auto-init)
+        PSE-->>Caller: success
+    end
+
+    Note over Caller,PM: Forced transition bypasses everything
+
+    Caller->>PSE: force_transition(branch, to_phase="tdd", ...)
+    PSE-->>Caller: success — no hooks, no checks
+```
+
+### Hook implementation details
+
+- **`on_enter_tdd_phase` (line 552):** Validates `planning_deliverables` present in project plan → raises `ValueError` if absent. Hard gate on TDD entry — architecturally incorrect.
+- **`on_exit_tdd_phase` (line 574):** Preserves `last_tdd_cycle`, clears `current_tdd_cycle`. Logs a warning if the phase is exited without any cycles — does not block (soft gate).
+- **`transition()` (line 129):** Calls `on_exit_tdd_phase` when leaving TDD, and `on_enter_tdd_phase` when entering. Both hooks are hardcoded by phase name — no generic mechanism.
+- **`force_transition()` (line 193):** Bypasses all workflow validation and phase hooks entirely — no deliverable check possible on forced transitions.
+
+### Configuration and schema
+
+- **`workphases.yaml`:** Currently defines `subphases`, `default_commit_type`, and `display_name` per phase. No `exit_requires` or `entry_expects` fields — extensible without breaking changes.
+- **`projects.json` schema:** `planning_deliverables` is stored via `save_planning_deliverables()` in `ProjectManager`. Key structure: `{ tdd_cycles: { total, cycles: [...] } }`. Field is optional — not all issues populate it.
+
+### Test impact
+
+- **`tests/unit/managers/test_phase_state_engine.py`** — `TestTDDPhaseHooks` and `TestTransitionHooksWiring` must be revised when refactoring `on_enter_tdd_phase`.
+
+---
+
+## Issue #146 Validation Opportunities
+
+This branch (`feature/229-phase-deliverables-enforcement`) is based on `feature/146-tdd-cycle-tracking`, making every workflow action on this branch a live exercise of #146 machinery. The table below maps each planned #229 workflow step to the #146 feature it exercises, and what the expected observable outcome is.
+
+```mermaid
+flowchart TD
+    subgraph "Issue #146 features under live test"
+        A[initialize_project] -->|auto-init state.json fields| B[research phase]
+        B -->|sequential transition| C[planning phase]
+        C -->|save_planning_deliverables| D[projects.json populated]
+        D -->|planning → design → tdd| E[on_enter_tdd_phase hook]
+        E -->|current_tdd_cycle = 1| F[TDD cycles]
+        F -->|commit cycle_number + sub_phase| G["P_TDD_SP_CN_PHASE scope"]
+        F -->|cycle_number out of range| H[ValueError — range gate]
+        F -->|transition_cycle| I[cycle history updated]
+        I -->|tdd → validation| J[on_exit_tdd_phase hook]
+        J -->|last_tdd_cycle preserved| K[validation phase]
+    end
+```
+
+| #229 Workflow Step | #146 Feature Exercised | Expected Outcome |
+|--------------------|------------------------|------------------|
+| `initialize_project(229)` | State init with `current_tdd_cycle=None`, `tdd_cycle_history=[]` | Fields present in `state.json` |
+| `research → planning` (sequential) | `workflow_config.validate_transition()` | Transition succeeds |
+| `planning → research` (forced) | `force_transition()` audit trail | `forced=True`, `skip_reason` in `state.json` |
+| `save_planning_deliverables(229, {...})` | `ProjectManager.save_planning_deliverables()` | Key present in `projects.json["229"]` |
+| `planning → design → tdd` | `on_enter_tdd_phase` hook | `current_tdd_cycle=1` auto-initialized |
+| Commit with `cycle_number=1, sub_phase="red"` | Scope generation `P_TDD_SP_C{N}_{PHASE}` | Commit message: `test(P_TDD_SP_C1_RED): ...` |
+| Commit with `cycle_number=1, sub_phase="green"` | Scope generation | Commit message: `feat(P_TDD_SP_C1_GREEN): ...` |
+| `transition_cycle(to_cycle=2)` | Cycle transition + history append | `current_tdd_cycle=2`, cycle 1 in `tdd_cycle_history` |
+| Commit with `cycle_number=99` (out of range) | Range validation `_validate_cycle_number_range` | `ValueError: cycle_number must be in range [1..N]` |
+| `tdd → validation` | `on_exit_tdd_phase` hook | `last_tdd_cycle` set, `current_tdd_cycle=None` |
+
+### What #146 does NOT yet enforce (expected gaps)
+
+These are the gaps that #229 itself will close — observing them during the trial confirms the need for this issue:
+
+| Gap | Where it manifests |
+|-----|--------------------|
+| Leaving Planning without `planning_deliverables` is silent | `planning → design` succeeds with no deliverables present |
+| Entering TDD with missing `planning_deliverables` raises in wrong place | `on_enter_tdd_phase` raises `ValueError` — should be planning exit |
+| Forced `design → tdd` skips the planning deliverables check entirely | No error, no warning |
+
+### MCP tool registration pattern
+
+New tools follow the `BaseTool` subclass pattern. Tools in `mcp_server/tools/project_tools.py` already handle `initialize_project` and `get_project_plan`. `save_planning_deliverables` will become `SavePlanningDeliverablesTool` in that same file, registered in `server.py` alongside the existing project tools.
+
+### Structured deliverables schema (`projects.json`)
+
+During the planning phase trial, the `planning_deliverables` schema was extended with a `validates` key per deliverable — the same schema that the Option-C checker will consume at phase exit:
+
+```jsonc
+{
+  "id": "D1.2",
+  "description": "DeliverableChecker implementation",
+  "validates": {
+    "type": "file_exists",           // file_exists | contains_text | absent_text | key_path
+    "file": "mcp_server/managers/deliverable_checker.py"
+  }
+}
+```
+
+Supported `type` values:
+
+| Type | Applies to | Check |
+|------|-----------|-------|
+| `file_exists` | Any file | File is present on disk |
+| `contains_text` | `.py`, `.md`, any text | File contains literal string `text` |
+| `absent_text` | `.py`, `.md`, any text | File does NOT contain `text` |
+| `key_path` | `.json`, `.yaml` | Dot-notation path resolves to a value |
+
+Note: SCAFFOLD-header check (original Option-C formulation) is a special case of `contains_text` where `text = "<!-- template="`.
+
+---
+
+## Open Questions
+
+- ✅ **Should `force_transition()` invoke hooks?** No — forced transitions are an audit-trail escape hatch by design. Invoking gates would defeat the purpose. GAP-03 scope: log a warning listing which gates were skipped. Not blocked.
+- ✅ **`entry_expects` before or after saving transition to `state.json`?** Before — a failed entry warning should never leave residual state.
+- ✅ **Phases with no deliverables — empty `exit_requires: []` or absence of field?** Absence of field = no-op. Empty list also = no-op. Existing phases without the field must not break.
+- ✅ **`exit_requires` references — top-level keys or nested paths?** Nested dot-notation paths allowed; the checker resolves them in JSON/YAML. Python files use `contains_text`/`absent_text` instead.
+- ✅ **Is `tdd_cycle_history` a meaningful exit gate for TDD?** Out of scope for #229 — too strict, breaks legitimate 0-cycle exits. Not added to `exit_requires` on `tdd` phase.
+
+---
+
+## Related Documentation
+
+- **[PhaseStateEngine implementation][related-1]**
+- **[workphases.yaml — phase metadata SSOT][related-2]**
+- **[ProjectManager — save_planning_deliverables(), get_project_plan()][related-3]**
+- **[test_phase_state_engine.py — TestTDDPhaseHooks, TestTransitionHooksWiring][related-4]**
+- **[Issue #146 design — TDD cycle tracking + planning_deliverables schema][related-5]**
+
+<!-- Link definitions -->
+[related-1]: ../../../mcp_server/managers/phase_state_engine.py
+[related-2]: ../../../.st3/workphases.yaml
+[related-3]: ../../../mcp_server/managers/project_manager.py
+[related-4]: ../../../tests/unit/managers/test_phase_state_engine.py
+[related-5]: ../issue146/design.md
+
+---
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.2 | 2026-02-19 | Agent | Added structured deliverables schema, MCP tool pattern, answered all open questions |
+| 1.1 | 2026-02-19 | Agent | Translated to English, fixed list rendering, added Mermaid diagram |
+| 1.0 | 2026-02-19 | Agent | Initial draft |

--- a/mcp_server/config/workphases_config.py
+++ b/mcp_server/config/workphases_config.py
@@ -1,0 +1,90 @@
+"""WorkphasesConfig — reader for workphases.yaml exit_requires/entry_expects.
+
+Provides structured access to per-phase deliverable gate declarations
+defined in .st3/workphases.yaml (Issue #229).
+
+Schema extension (optional fields per phase):
+    exit_requires:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown"
+    entry_expects:
+      - key: "planning_deliverables"
+        description: "Expected from planning phase"
+
+Quality Requirements:
+- Pyright: strict mode passing
+- Ruff: all configured rules passing
+- Coverage: 100% for this module
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+class WorkphasesConfig:
+    """Read-only accessor for workphases.yaml deliverable gate fields.
+
+    Attributes:
+        _data: Parsed YAML content as a dict.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Load workphases.yaml from *path*.
+
+        Args:
+            path: Absolute or relative path to the workphases.yaml file.
+
+        Raises:
+            FileNotFoundError: If *path* does not exist.
+            yaml.YAMLError: If the file is not valid YAML.
+        """
+        with path.open(encoding="utf-8") as fh:
+            self._data: dict = yaml.safe_load(fh) or {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_exit_requires(self, phase: str) -> list[dict]:
+        """Return the exit_requires list for *phase*, or [] if absent.
+
+        Args:
+            phase: Phase name (e.g. "planning", "design").
+
+        Returns:
+            List of deliverable gate dicts, empty list when field absent.
+        """
+        return self._get_phase_field(phase, "exit_requires")
+
+    def get_entry_expects(self, phase: str) -> list[dict]:
+        """Return the entry_expects list for *phase*, or [] if absent.
+
+        Args:
+            phase: Phase name (e.g. "tdd", "integration").
+
+        Returns:
+            List of deliverable gate dicts, empty list when field absent.
+        """
+        return self._get_phase_field(phase, "entry_expects")
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_phase_field(self, phase: str, field: str) -> list[dict]:
+        """Return *field* from the *phase* block, or [] when absent.
+
+        Args:
+            phase: Phase name key in ``phases`` mapping.
+            field: YAML field name ("exit_requires" or "entry_expects").
+
+        Returns:
+            Parsed list of dicts; empty list for absent/null values.
+        """
+        phases: dict = self._data.get("phases", {})
+        phase_block: dict = phases.get(phase, {})
+        result = phase_block.get(field, [])
+        return result if isinstance(result, list) else []

--- a/mcp_server/managers/deliverable_checker.py
+++ b/mcp_server/managers/deliverable_checker.py
@@ -1,0 +1,209 @@
+"""DeliverableChecker — structural validation of issue deliverables (Issue #229).
+
+Validates deliverable specs declared in projects.json ``validates`` entries.
+Supported check types:
+
+    file_exists     File must be present at relative *file* path.
+    contains_text   File must contain *text* substring.
+    absent_text     File must NOT contain *text* substring.
+    key_path        JSON/YAML file must contain dot-notation *path*.
+
+All ``file`` paths are resolved relative to *workspace_root*.
+
+Quality Requirements:
+- Pyright: strict mode passing
+- Ruff: all configured rules passing
+- Coverage: 100% for this module
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class DeliverableCheckError(ValueError):
+    """Raised when a deliverable validation check fails.
+
+    The error message always contains the deliverable ID for tracing.
+    """
+
+
+class DeliverableChecker:
+    """Runs structural checks on deliverable specs from projects.json.
+
+    Attributes:
+        _workspace_root: Absolute root path; all file paths resolved from here.
+    """
+
+    def __init__(self, workspace_root: Path) -> None:
+        """Initialise with *workspace_root* as the file resolution base.
+
+        Args:
+            workspace_root: Absolute directory used to resolve relative paths
+                in deliverable specs.
+        """
+        self._workspace_root = workspace_root
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def check(self, deliverable_id: str, validates: dict) -> None:
+        """Validate one deliverable spec.
+
+        Args:
+            deliverable_id: Human-readable ID for error messages (e.g. "D1.1").
+            validates: Spec dict with at minimum a ``type`` key.
+
+        Raises:
+            DeliverableCheckError: When the check fails.
+            ValueError: When ``type`` is unknown or required keys are missing.
+        """
+        check_type: str = validates.get("type", "")
+        dispatch = {
+            "file_exists": self._check_file_exists,
+            "file_glob": self._check_file_glob,
+            "contains_text": self._check_contains_text,
+            "absent_text": self._check_absent_text,
+            "key_path": self._check_key_path,
+        }
+        handler = dispatch.get(check_type)
+        if handler is None:
+            raise ValueError(
+                f"[{deliverable_id}] Unknown check type: '{check_type}'. "
+                f"Valid types: {list(dispatch)}"
+            )
+        handler(deliverable_id, validates)
+
+    # ------------------------------------------------------------------
+    # Private check handlers
+    # ------------------------------------------------------------------
+
+    def _resolve(self, relative_file: str) -> Path:
+        """Resolve *relative_file* against workspace root.
+
+        Args:
+            relative_file: Slash-separated path relative to workspace root.
+
+        Returns:
+            Absolute Path.
+        """
+        return self._workspace_root / Path(relative_file)
+
+    def _check_file_exists(self, deliverable_id: str, spec: dict) -> None:
+        """Raise if file at spec['file'] does not exist.
+
+        Args:
+            deliverable_id: ID for error message.
+            spec: Must contain ``file`` key.
+
+        Raises:
+            DeliverableCheckError: File not found.
+        """
+        path = self._resolve(spec["file"])
+        if not path.exists():
+            raise DeliverableCheckError(
+                f"[{deliverable_id}] file_exists FAILED: '{spec['file']}' not found "
+                f"(resolved: {path})"
+            )
+
+    def _check_file_glob(self, deliverable_id: str, spec: dict) -> None:
+        """Raise if no files match spec['pattern'] inside spec['dir'].
+
+        Args:
+            deliverable_id: ID for error message.
+            spec: Must contain ``dir`` and ``pattern`` keys.
+                  ``dir`` is relative to workspace root; ``pattern`` is a glob expression.
+
+        Raises:
+            DeliverableCheckError: No matching files found.
+        """
+        base = self._workspace_root / Path(spec["dir"])
+        pattern: str = spec["pattern"]
+        matches = list(base.glob(pattern))
+        if not matches:
+            raise DeliverableCheckError(
+                f"[{deliverable_id}] file_glob FAILED: no files matching '{pattern}' "
+                f"in '{spec['dir']}' (resolved: {base})"
+            )
+
+    def _check_contains_text(self, deliverable_id: str, spec: dict) -> None:
+        """Raise if file at spec['file'] does not contain spec['text'].
+
+        Args:
+            deliverable_id: ID for error message.
+            spec: Must contain ``file`` and ``text`` keys.
+
+        Raises:
+            DeliverableCheckError: File missing or text not found.
+        """
+        path = self._resolve(spec["file"])
+        if not path.exists():
+            raise DeliverableCheckError(
+                f"[{deliverable_id}] contains_text FAILED: '{spec['file']}' not found"
+            )
+        content = path.read_text(encoding="utf-8")
+        expected: str = spec["text"]
+        if expected not in content:
+            raise DeliverableCheckError(
+                f"[{deliverable_id}] contains_text FAILED: "
+                f"'{expected}' not found in '{spec['file']}'"
+            )
+
+    def _check_absent_text(self, deliverable_id: str, spec: dict) -> None:
+        """Raise if file at spec['file'] CONTAINS spec['text'].
+
+        Args:
+            deliverable_id: ID for error message.
+            spec: Must contain ``file`` and ``text`` keys.
+
+        Raises:
+            DeliverableCheckError: File missing or forbidden text present.
+        """
+        path = self._resolve(spec["file"])
+        if not path.exists():
+            raise DeliverableCheckError(
+                f"[{deliverable_id}] absent_text FAILED: '{spec['file']}' not found"
+            )
+        content = path.read_text(encoding="utf-8")
+        forbidden: str = spec["text"]
+        if forbidden in content:
+            raise DeliverableCheckError(
+                f"[{deliverable_id}] absent_text FAILED: "
+                f"'{forbidden}' found in '{spec['file']}' (must be absent)"
+            )
+
+    def _check_key_path(self, deliverable_id: str, spec: dict) -> None:
+        """Raise if dot-notation path spec['path'] is missing from JSON/YAML.
+
+        Args:
+            deliverable_id: ID for error message.
+            spec: Must contain ``file`` and ``path`` keys.
+                  ``path`` is dot-separated (e.g. "229.planning_deliverables").
+
+        Raises:
+            DeliverableCheckError: File missing or key path absent.
+        """
+        path = self._resolve(spec["file"])
+        if not path.exists():
+            raise DeliverableCheckError(
+                f"[{deliverable_id}] key_path FAILED: '{spec['file']}' not found"
+            )
+        content = path.read_text(encoding="utf-8")
+        suffix = path.suffix.lower()
+        data: Any = json.loads(content) if suffix == ".json" else yaml.safe_load(content)
+
+        key_path: str = spec["path"]
+        current: Any = data
+        for segment in key_path.split("."):
+            if not isinstance(current, dict) or segment not in current:
+                raise DeliverableCheckError(
+                    f"[{deliverable_id}] key_path FAILED: "
+                    f"'{key_path}' not found in '{spec['file']}' "
+                    f"(missing at segment '{segment}')"
+                )
+            current = current[segment]

--- a/mcp_server/managers/project_manager.py
+++ b/mcp_server/managers/project_manager.py
@@ -27,6 +27,11 @@ from backend.core.phase_detection import ScopeDecoder
 from mcp_server.config.workflows import workflow_config
 from mcp_server.managers.git_manager import GitManager
 
+# Per-phase keys recognised in planning_deliverables (C8/GAP-15)
+_known_phase_keys: frozenset[str] = frozenset(
+    {"tdd_cycles", "design", "validation", "documentation", "validates"}
+)
+
 
 @dataclass
 class ProjectInitOptions:
@@ -165,6 +170,247 @@ class ProjectManager:
             "skip_reason": plan.skip_reason,
             "parent_branch": plan.parent_branch,
         }
+
+    def save_planning_deliverables(
+        self, issue_number: int, planning_deliverables: dict[str, Any]
+    ) -> None:
+        """Save planning deliverables to projects.json.
+
+        Args:
+            issue_number: GitHub issue number
+            planning_deliverables: Planning deliverables dict (tdd_cycles, validation_plan, etc.)
+
+        Raises:
+            ValueError: If project not found, deliverables already exist, or schema invalid:
+                - total != len(cycles)
+                - Non-sequential or duplicate cycle numbers
+                - Empty deliverables arrays
+                - Empty exit_criteria strings
+        """
+        if not self.projects_file.exists():
+            msg = f"Project {issue_number} not found - initialize_project must be called first"
+            raise ValueError(msg)
+
+        # Load existing projects
+        projects = json.loads(self.projects_file.read_text(encoding="utf-8-sig"))
+
+        # Check project exists
+        if str(issue_number) not in projects:
+            msg = f"Project {issue_number} not found - initialize_project must be called first"
+            raise ValueError(msg)
+
+        # Guard: Check if planning_deliverables already exist
+        if "planning_deliverables" in projects[str(issue_number)]:
+            msg = (
+                f"Planning deliverables already exist for issue {issue_number}. "
+                "Cannot overwrite existing deliverables."
+            )
+            raise ValueError(msg)
+
+        # Validate schema: tdd_cycles required
+        if "tdd_cycles" not in planning_deliverables:
+            msg = "planning_deliverables must contain 'tdd_cycles' key"
+            raise ValueError(msg)
+
+        tdd_cycles = planning_deliverables["tdd_cycles"]
+
+        # Validate tdd_cycles structure
+        if not isinstance(tdd_cycles, dict):
+            msg = "tdd_cycles must be a dict"
+            raise ValueError(msg)
+
+        if "total" not in tdd_cycles:
+            msg = "tdd_cycles must contain 'total' key"
+            raise ValueError(msg)
+
+        if not isinstance(tdd_cycles["total"], int) or tdd_cycles["total"] < 1:
+            msg = "tdd_cycles.total must be a positive integer"
+            raise ValueError(msg)
+
+        if "cycles" not in tdd_cycles:
+            msg = "tdd_cycles must contain 'cycles' key"
+            raise ValueError(msg)
+        if not isinstance(tdd_cycles["cycles"], list):
+            msg = "tdd_cycles.cycles must be a list"
+            raise ValueError(msg)
+
+        # Validate: total must match actual cycle count
+        if tdd_cycles["total"] != len(tdd_cycles["cycles"]):
+            msg = (
+                f"tdd_cycles.total ({tdd_cycles['total']}) must equal "
+                f"len(tdd_cycles.cycles) ({len(tdd_cycles['cycles'])})"
+            )
+            raise ValueError(msg)
+
+        # Validate each cycle: sequential numbers, non-empty fields
+        for idx, cycle in enumerate(tdd_cycles["cycles"]):
+            expected_number = idx + 1
+
+            # Check cycle_number exists and is sequential
+            if "cycle_number" not in cycle:
+                msg = f"Cycle at index {idx} missing 'cycle_number' key"
+                raise ValueError(msg)
+
+            if cycle["cycle_number"] != expected_number:
+                msg = (
+                    f"Cycle at index {idx} has cycle_number {cycle['cycle_number']}, "
+                    f"expected {expected_number} (must be sequential 1-based)"
+                )
+                raise ValueError(msg)
+
+            # Check deliverables array
+            if "deliverables" not in cycle:
+                msg = f"Cycle {expected_number} missing 'deliverables' key"
+                raise ValueError(msg)
+
+            if not isinstance(cycle["deliverables"], list) or not cycle["deliverables"]:
+                msg = f"Cycle {expected_number} deliverables must be a non-empty list"
+                raise ValueError(msg)
+
+            # Check exit_criteria string
+            if "exit_criteria" not in cycle:
+                msg = f"Cycle {expected_number} missing 'exit_criteria' key"
+                raise ValueError(msg)
+
+            if not isinstance(cycle["exit_criteria"], str) or not cycle["exit_criteria"].strip():
+                msg = f"Cycle {expected_number} exit_criteria must be a non-empty string"
+                raise ValueError(msg)
+
+        # Validate optional phase keys (D7.1 — Issue #229 C7)
+        _phase_entry_keys = {"design", "validation", "documentation"}
+        for key, value in planning_deliverables.items():
+            if key not in _known_phase_keys:
+                msg = (
+                    f"Unknown key '{key}' in planning_deliverables. "
+                    "Valid phase keys: tdd_cycles, design, validation, documentation"
+                )
+                raise ValueError(msg)
+            if key in _phase_entry_keys and (
+                not isinstance(value, dict) or not isinstance(value.get("deliverables"), list)
+            ):
+                msg = f"planning_deliverables['{key}'] must be a dict with a 'deliverables' list"
+                raise ValueError(msg)
+
+        # Add planning_deliverables to project
+        projects[str(issue_number)]["planning_deliverables"] = planning_deliverables
+
+        # Write to file
+        self.projects_file.write_text(json.dumps(projects, indent=2))
+
+    def update_planning_deliverables(
+        self, issue_number: int, planning_deliverables: dict[str, Any]
+    ) -> None:
+        """Merge incoming planning deliverables into existing ones (Issue #229, C5/C8).
+
+        Merge strategy for ``tdd_cycles.cycles``:
+        - New ``cycle_number`` → append cycle
+        - Existing ``cycle_number`` + new deliverable ``id`` → append deliverable
+        - Existing ``cycle_number`` + existing deliverable ``id`` → overwrite in place
+        - ``exit_criteria`` on existing cycle → overwritten when provided (C8/GAP-12)
+        - ``tdd_cycles.total`` updated to max(existing, highest incoming cycle_number)
+
+        Merge strategy for per-phase keys (design, validation, documentation) (C8/GAP-15):
+        - Key absent in existing → set from incoming
+        - Key present in existing → merge deliverables by id (same strategy as tdd_cycles)
+        - New deliverable ``id`` → append; existing ``id`` → overwrite in place
+
+        Args:
+            issue_number: GitHub issue number
+            planning_deliverables: Partial or full planning deliverables to merge in.
+
+        Raises:
+            ValueError: If project not found or planning_deliverables not yet initialised
+                (call save_planning_deliverables first).
+        """
+        if not self.projects_file.exists():
+            msg = f"Project {issue_number} not found - initialize_project must be called first"
+            raise ValueError(msg)
+
+        projects = json.loads(self.projects_file.read_text(encoding="utf-8-sig"))
+
+        if str(issue_number) not in projects:
+            msg = f"Project {issue_number} not found - initialize_project must be called first"
+            raise ValueError(msg)
+
+        project = projects[str(issue_number)]
+
+        if "planning_deliverables" not in project:
+            msg = (
+                f"No planning deliverables found for issue {issue_number}. "
+                "Call save_planning_deliverables first before updating."
+            )
+            raise ValueError(msg)
+
+        existing_pd = project["planning_deliverables"]
+        incoming_tc = planning_deliverables.get("tdd_cycles", {})
+        incoming_cycles = incoming_tc.get("cycles", [])
+
+        existing_tc = existing_pd.setdefault("tdd_cycles", {})
+        existing_cycles_list: list[dict[str, Any]] = existing_tc.setdefault("cycles", [])
+
+        # Build lookup: cycle_number → index in existing_cycles_list
+        existing_cycle_index: dict[int, int] = {
+            c["cycle_number"]: i for i, c in enumerate(existing_cycles_list)
+        }
+
+        for incoming_cycle in incoming_cycles:
+            cn: int = incoming_cycle["cycle_number"]
+            if cn not in existing_cycle_index:
+                # New cycle → append
+                existing_cycles_list.append(incoming_cycle)
+                existing_cycle_index[cn] = len(existing_cycles_list) - 1
+            else:
+                # Existing cycle → merge deliverables by id + overwrite exit_criteria (C8/GAP-12)
+                target_cycle = existing_cycles_list[existing_cycle_index[cn]]
+                if "exit_criteria" in incoming_cycle:
+                    target_cycle["exit_criteria"] = incoming_cycle["exit_criteria"]
+                existing_deliverables: list[dict[str, Any]] = target_cycle.setdefault(
+                    "deliverables", []
+                )
+                existing_deliv_index: dict[str, int] = {
+                    d["id"]: i for i, d in enumerate(existing_deliverables)
+                }
+                for incoming_deliv in incoming_cycle.get("deliverables", []):
+                    d_id: str = incoming_deliv["id"]
+                    if d_id in existing_deliv_index:
+                        # Overwrite in place
+                        existing_deliverables[existing_deliv_index[d_id]] = incoming_deliv
+                    else:
+                        # Append new deliverable
+                        existing_deliverables.append(incoming_deliv)
+                        existing_deliv_index[d_id] = len(existing_deliverables) - 1
+
+        # Update total to reflect highest cycle number seen
+        if existing_cycles_list:
+            highest_cn = max(c["cycle_number"] for c in existing_cycles_list)
+            existing_tc["total"] = max(existing_tc.get("total", 0), highest_cn)
+
+        # Merge per-phase keys (design, validation, documentation) (C8/GAP-15)
+        _phase_keys = _known_phase_keys - {"tdd_cycles", "validates"}
+        for incoming_phase in _phase_keys:
+            if incoming_phase not in planning_deliverables:
+                continue
+            incoming_phase_data: dict[str, Any] = planning_deliverables[incoming_phase]
+            if incoming_phase not in existing_pd:
+                # Phase key absent → set from incoming
+                existing_pd[incoming_phase] = incoming_phase_data
+            else:
+                # Phase key present → merge deliverables by id
+                existing_phase_delivs: list[dict[str, Any]] = existing_pd[
+                    incoming_phase
+                ].setdefault("deliverables", [])
+                existing_phase_deliv_index: dict[str, int] = {
+                    d["id"]: i for i, d in enumerate(existing_phase_delivs)
+                }
+                for incoming_deliv in incoming_phase_data.get("deliverables", []):
+                    d_id = incoming_deliv["id"]
+                    if d_id in existing_phase_deliv_index:
+                        existing_phase_delivs[existing_phase_deliv_index[d_id]] = incoming_deliv
+                    else:
+                        existing_phase_delivs.append(incoming_deliv)
+                        existing_phase_deliv_index[d_id] = len(existing_phase_delivs) - 1
+
+        self.projects_file.write_text(json.dumps(projects, indent=2))
 
     def get_project_plan(self, issue_number: int) -> dict[str, Any] | None:
         """Get stored project plan with current phase detection.

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -51,6 +51,7 @@ from mcp_server.tools.git_tools import (
     GitRestoreTool,
     GitStashTool,
     GitStatusTool,
+    build_phase_guard,
 )
 from mcp_server.tools.health_tools import HealthCheckTool
 
@@ -76,13 +77,19 @@ from mcp_server.tools.milestone_tools import (
 )
 from mcp_server.tools.phase_tools import ForcePhaseTransitionTool, TransitionPhaseTool
 from mcp_server.tools.pr_tools import CreatePRTool, ListPRsTool, MergePRTool
-from mcp_server.tools.project_tools import GetProjectPlanTool, InitializeProjectTool
+from mcp_server.tools.project_tools import (
+    GetProjectPlanTool,
+    InitializeProjectTool,
+    SavePlanningDeliverablesTool,
+    UpdatePlanningDeliverablesTool,
+)
 from mcp_server.tools.quality_tools import RunQualityGatesTool
 from mcp_server.tools.safe_edit_tool import SafeEditTool
 from mcp_server.tools.scaffold_artifact import ScaffoldArtifactTool
 from mcp_server.tools.template_validation_tool import TemplateValidationTool
 from mcp_server.tools.test_tools import RunTestsTool
 from mcp_server.tools.tool_result import ToolResult
+from mcp_server.tools.transition_tools import ForceCycleTransitionTool, TransitionCycleTool
 from mcp_server.tools.validation_tools import ValidateDTOTool, ValidationTool
 
 # Initialize logging
@@ -129,7 +136,7 @@ class MCPServer:
             # Git tools
             CreateBranchTool(),
             GitStatusTool(),
-            GitCommitTool(),
+            GitCommitTool(phase_guard=build_phase_guard(Path(settings.server.workspace_root))),
             GitCheckoutTool(),
             GitFetchTool(),
             GitPullTool(),
@@ -155,9 +162,14 @@ class MCPServer:
             # Project tools (Phase 0.5)
             InitializeProjectTool(workspace_root=Path(settings.server.workspace_root)),
             GetProjectPlanTool(workspace_root=Path(settings.server.workspace_root)),
+            SavePlanningDeliverablesTool(workspace_root=Path(settings.server.workspace_root)),
+            UpdatePlanningDeliverablesTool(workspace_root=Path(settings.server.workspace_root)),
             # Phase tools (Phase B)
             TransitionPhaseTool(workspace_root=Path(settings.server.workspace_root)),
             ForcePhaseTransitionTool(workspace_root=Path(settings.server.workspace_root)),
+            # TDD Cycle tools (Issue #146)
+            TransitionCycleTool(),
+            ForceCycleTransitionTool(),
             # Scaffold tools (unified artifact scaffolding)
             ScaffoldArtifactTool(
                 manager=ArtifactManager(

--- a/mcp_server/tools/transition_tools.py
+++ b/mcp_server/tools/transition_tools.py
@@ -1,0 +1,343 @@
+"""Transition tools for TDD cycle management.
+
+Issue #146 Cycle 4: transition_cycle and force_cycle_transition tools.
+"""
+
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from mcp_server.config.settings import settings
+from mcp_server.managers.deliverable_checker import DeliverableChecker
+from mcp_server.managers.git_manager import GitManager
+from mcp_server.managers.phase_state_engine import PhaseStateEngine
+from mcp_server.managers.project_manager import ProjectManager
+from mcp_server.tools.base import BaseTool
+from mcp_server.tools.tool_result import ToolResult
+
+
+class TransitionCycleInput(BaseModel):
+    """Input for transition_cycle tool."""
+
+    to_cycle: int = Field(..., description="Target cycle number (forward-only)")
+    issue_number: int | None = Field(
+        default=None, description="Issue number (auto-detected from branch if omitted)"
+    )
+
+
+class TransitionCycleTool(BaseTool):
+    """Tool to transition to next TDD cycle with validation."""
+
+    name = "transition_cycle"
+    description = (
+        "Transition to next TDD cycle (forward-only, sequential). "
+        "Use force_cycle_transition to skip cycles or go backwards."
+    )
+    args_model = TransitionCycleInput
+
+    async def execute(self, params: TransitionCycleInput) -> ToolResult:
+        """Execute cycle transition with validation."""
+        try:
+            # Get workspace root
+            workspace_root = Path(settings.server.workspace_root)
+
+            # Auto-detect issue number from branch if not provided
+            git_manager = GitManager()
+            branch = git_manager.get_current_branch()
+
+            issue_number = params.issue_number
+            if issue_number is None:
+                issue_number = self._extract_issue_number(branch)
+                if issue_number is None:
+                    return ToolResult.error("Cannot detect issue number from branch")
+
+            # Initialize managers
+            project_manager = ProjectManager(workspace_root=workspace_root)
+            state_engine = PhaseStateEngine(
+                workspace_root=workspace_root, project_manager=project_manager
+            )
+
+            # Get current state
+            state = state_engine.get_state(branch)
+            current_phase = state.get("current_phase")
+            current_cycle = state.get("current_tdd_cycle")
+
+            # Validation 1: Check TDD phase
+            if current_phase != "tdd":
+                return ToolResult.error(
+                    f"Not in TDD phase (current: {current_phase}). "
+                    "Cycle transitions only allowed during TDD phase."
+                )
+
+            # Validation 2: Check planning deliverables exist
+            project_plan = project_manager.get_project_plan(issue_number)
+            if project_plan is None:
+                return ToolResult.error("Project plan not found")
+
+            planning_deliverables = project_plan.get("planning_deliverables")
+            if not planning_deliverables:
+                return ToolResult.error(
+                    "Planning deliverables not found. "
+                    "Create planning deliverables before transitioning cycles."
+                )
+
+            tdd_cycles = planning_deliverables.get("tdd_cycles", {})
+            total_cycles = tdd_cycles.get("total", 0)
+
+            # Validation 3: Check valid cycle range
+            if params.to_cycle < 1 or params.to_cycle > total_cycles:
+                return ToolResult.error(
+                    f"Invalid cycle number {params.to_cycle}. Valid range: 1-{total_cycles}"
+                )
+
+            # Validation 4: Check forward-only
+            if current_cycle is not None and params.to_cycle <= current_cycle:
+                return ToolResult.error(
+                    f"Backwards transition not allowed (current: {current_cycle}, "
+                    f"target: {params.to_cycle}). "
+                    "Use force_cycle_transition for backwards transitions."
+                )
+
+            # Validation 5: Check sequential
+            if current_cycle is not None and params.to_cycle != current_cycle + 1:
+                return ToolResult.error(
+                    f"Non-sequential transition not allowed (current: {current_cycle}, "
+                    f"target: {params.to_cycle}). "
+                    "Use force_cycle_transition to skip cycles."
+                )
+
+            # Validation 6: Check exit criteria of current cycle
+            if current_cycle is not None:
+                cycles_list = tdd_cycles.get("cycles", [])
+                current_cycle_data = next(
+                    (c for c in cycles_list if c.get("cycle_number") == current_cycle), None
+                )
+                if current_cycle_data is not None:
+                    exit_criteria = current_cycle_data.get("exit_criteria", "")
+                    if not exit_criteria or not exit_criteria.strip():
+                        return ToolResult.error(
+                            f"Cycle {current_cycle} exit criteria not defined. "
+                            "Define exit_criteria in planning deliverables before transitioning."
+                        )
+
+            # Execute transition
+            from_cycle = current_cycle or 0
+            state["last_tdd_cycle"] = from_cycle
+            state["current_tdd_cycle"] = params.to_cycle
+
+            # Update history (if not exists, create empty list)
+            if "tdd_cycle_history" not in state:
+                state["tdd_cycle_history"] = []
+
+            history_entry = {
+                "cycle_number": params.to_cycle,
+                "forced": False,
+                "entered": datetime.now(UTC).isoformat(),
+            }
+            state["tdd_cycle_history"].append(history_entry)
+
+            # Save state
+            state_engine._save_state(branch, state)
+
+            # Get cycle name for message
+            cycles = tdd_cycles.get("cycles", [])
+            cycle_details = next(
+                (c for c in cycles if c.get("cycle_number") == params.to_cycle), None
+            )
+            cycle_name = cycle_details.get("name") if cycle_details else "Unknown"
+
+            # Success message
+            message = f"✅ Transitioned to TDD Cycle {params.to_cycle}/{total_cycles}: {cycle_name}"
+
+            return ToolResult.text(message)
+
+        except (OSError, ValueError, RuntimeError, KeyError) as e:
+            return ToolResult.error(f"Transition failed: {e}")
+
+    def _extract_issue_number(self, branch: str) -> int | None:
+        """Extract issue number from branch name."""
+        patterns = [
+            r"(?:feature|fix|refactor|docs)/(\d+)-",
+            r"issue-(\d+)",
+            r"#(\d+)",
+        ]
+
+        for pattern in patterns:
+            match = re.search(pattern, branch)
+            if match:
+                return int(match.group(1))
+
+        return None
+
+
+class ForceCycleTransitionInput(BaseModel):
+    """Input for force_cycle_transition tool."""
+
+    to_cycle: int = Field(..., description="Target cycle number (any direction)")
+    skip_reason: str = Field(..., description="Reason for forced transition (backward/skip)")
+    human_approval: str = Field(
+        ..., description="Human approval (name + date, e.g., 'John approved on 2026-02-17')"
+    )
+    issue_number: int | None = Field(
+        default=None, description="Issue number (auto-detected from branch if omitted)"
+    )
+
+
+class ForceCycleTransitionTool(BaseTool):
+    """Tool to force TDD cycle transition (backward/skip) with human approval."""
+
+    name = "force_cycle_transition"
+    description = (
+        "Force transition to any TDD cycle (backward or skip). "
+        "Requires skip_reason and human_approval for audit trail."
+    )
+    args_model = ForceCycleTransitionInput
+
+    async def execute(self, params: ForceCycleTransitionInput) -> ToolResult:
+        """Execute forced cycle transition with audit trail."""
+        try:
+            # Validation 1: Check skip_reason not empty
+            if not params.skip_reason or params.skip_reason.strip() == "":
+                return ToolResult.error(
+                    "skip_reason is required for forced transitions. "
+                    "Provide justification for backward/skip transition."
+                )
+
+            # Validation 2: Check human_approval not empty
+            if not params.human_approval or params.human_approval.strip() == "":
+                return ToolResult.error(
+                    "human_approval is required for forced transitions. "
+                    "Provide approval (e.g., 'John approved on 2026-02-17')."
+                )
+
+            # Get workspace root
+            workspace_root = Path(settings.server.workspace_root)
+
+            # Auto-detect issue number from branch if not provided
+            git_manager = GitManager()
+            branch = git_manager.get_current_branch()
+
+            issue_number = params.issue_number
+            if issue_number is None:
+                issue_number = TransitionCycleTool()._extract_issue_number(branch)
+                if issue_number is None:
+                    return ToolResult.error("Cannot detect issue number from branch")
+
+            # Initialize managers
+            project_manager = ProjectManager(workspace_root=workspace_root)
+            state_engine = PhaseStateEngine(
+                workspace_root=workspace_root, project_manager=project_manager
+            )
+
+            # Get current state
+            state = state_engine.get_state(branch)
+            current_phase = state.get("current_phase")
+            current_cycle = state.get("current_tdd_cycle")
+
+            # Validation 3: Check TDD phase
+            if current_phase != "tdd":
+                return ToolResult.error(
+                    f"Not in TDD phase (current: {current_phase}). "
+                    "Cycle transitions only allowed during TDD phase."
+                )
+
+            # Validation 4: Check planning deliverables exist
+            project_plan = project_manager.get_project_plan(issue_number)
+            if project_plan is None:
+                return ToolResult.error("Project plan not found")
+
+            planning_deliverables = project_plan.get("planning_deliverables")
+            if not planning_deliverables:
+                return ToolResult.error(
+                    "Planning deliverables not found. "
+                    "Create planning deliverables before transitioning cycles."
+                )
+
+            tdd_cycles = planning_deliverables.get("tdd_cycles", {})
+            total_cycles = tdd_cycles.get("total", 0)
+
+            # Validation 5: Check valid cycle range
+            if params.to_cycle < 1 or params.to_cycle > total_cycles:
+                return ToolResult.error(
+                    f"Invalid cycle number {params.to_cycle}. Valid range: 1-{total_cycles}"
+                )
+
+            # Execute forced transition
+            from_cycle = current_cycle or 0
+            state["last_tdd_cycle"] = from_cycle
+            state["current_tdd_cycle"] = params.to_cycle
+
+            # Get cycle name (needed for audit entry)
+            cycles = tdd_cycles.get("cycles", [])
+            cycle_details = next(
+                (c for c in cycles if c.get("cycle_number") == params.to_cycle), None
+            )
+            cycle_name = cycle_details.get("name") if cycle_details else "Unknown"
+
+            # Create audit trail entry (spec: cycle_number, forced, skipped_cycles)
+            if "tdd_cycle_history" not in state:
+                state["tdd_cycle_history"] = []
+
+            skipped_cycles = list(
+                range(min(from_cycle, params.to_cycle) + 1, max(from_cycle, params.to_cycle))
+            )
+            audit_entry = {
+                "cycle_number": params.to_cycle,
+                "name": cycle_name,
+                "entered": datetime.now(UTC).isoformat(),
+                "forced": True,
+                "skip_reason": params.skip_reason,
+                "human_approval": params.human_approval,
+                "skipped_cycles": skipped_cycles,
+            }
+            state["tdd_cycle_history"].append(audit_entry)
+
+            # Save state
+            state_engine._save_state(branch, state)
+
+            # Check deliverables in skipped cycles: split blocking vs validated (C10/GAP-17)
+            checker = DeliverableChecker(workspace_root=workspace_root)
+            unvalidated: list[str] = []
+            validated: list[str] = []
+            for cycle_num in skipped_cycles:
+                cycle_data = next((c for c in cycles if c.get("cycle_number") == cycle_num), None)
+                if cycle_data is None:
+                    continue
+                for deliverable in cycle_data.get("deliverables", []):
+                    if not isinstance(deliverable, dict):
+                        continue  # Skip plain-string deliverables (backward compat)
+                    validates = deliverable.get("validates")
+                    if validates is None:
+                        continue
+                    d_id = deliverable.get("id", "?")
+                    d_desc = deliverable.get("description", "")
+                    label = f"cycle:{cycle_num}:{d_id} ({d_desc})"
+                    try:
+                        checker.check(d_id, validates)
+                        validated.append(label)
+                    except Exception:
+                        unvalidated.append(label)
+
+            # Build response: blocking BEFORE ✅, informational AFTER ✅ (C10/GAP-17)
+            direction = "backward" if params.to_cycle < from_cycle else "skip"
+            success_line = (
+                f"✅ Forced {direction} transition to TDD Cycle "
+                f"{params.to_cycle}/{total_cycles}: {cycle_name}\n"
+                f"Reason: {params.skip_reason}\n"
+                f"Approval: {params.human_approval}"
+            )
+
+            parts: list[str] = []
+            if unvalidated:
+                parts.append(f"⚠️ Unvalidated cycle deliverables: {', '.join(unvalidated)}")
+            parts.append(success_line)
+            if validated:
+                parts.append(f"ℹ️ Validated skipped deliverables: {', '.join(validated)}")
+            message = "\n".join(parts)
+
+            return ToolResult.text(message)
+
+        except (OSError, ValueError, RuntimeError, KeyError) as e:
+            return ToolResult.error(f"Forced transition failed: {e}")

--- a/tests/integration/mcp_server/test_server_tool_registration.py
+++ b/tests/integration/mcp_server/test_server_tool_registration.py
@@ -33,3 +33,43 @@ def test_scaffold_artifact_tool_has_correct_name():
     tool = scaffold_tools[0]
     assert tool.name == 'scaffold_artifact', \
         f"Expected name 'scaffold_artifact', got '{tool.name}'"
+
+
+def test_transition_cycle_tool_registered():
+    """Verify TransitionCycleTool is registered in server tools list (Issue #146)."""
+    server = MCPServer()
+    tool_names = [type(t).__name__ for t in server.tools]
+    assert 'TransitionCycleTool' in tool_names, (
+        f"TransitionCycleTool not found in registered tools. "
+        f"Registered: {tool_names}"
+    )
+
+
+def test_force_cycle_transition_tool_registered():
+    """Verify ForceCycleTransitionTool is registered in server tools list (Issue #146)."""
+    server = MCPServer()
+    tool_names = [type(t).__name__ for t in server.tools]
+    assert 'ForceCycleTransitionTool' in tool_names, (
+        f"ForceCycleTransitionTool not found in registered tools. "
+        f"Registered: {tool_names}"
+    )
+
+
+def test_transition_cycle_tool_has_correct_name():
+    """Verify TransitionCycleTool MCP name matches expected value (Issue #146)."""
+    server = MCPServer()
+    tools = [t for t in server.tools if type(t).__name__ == 'TransitionCycleTool']
+    assert len(tools) == 1, "Expected exactly one TransitionCycleTool"
+    assert tools[0].name == 'transition_cycle', (
+        f"Expected name 'transition_cycle', got '{tools[0].name}'"
+    )
+
+
+def test_force_cycle_transition_tool_has_correct_name():
+    """Verify ForceCycleTransitionTool MCP name matches expected value (Issue #146)."""
+    server = MCPServer()
+    tools = [t for t in server.tools if type(t).__name__ == 'ForceCycleTransitionTool']
+    assert len(tools) == 1, "Expected exactly one ForceCycleTransitionTool"
+    assert tools[0].name == 'force_cycle_transition', (
+        f"Expected name 'force_cycle_transition', got '{tools[0].name}'"
+    )

--- a/tests/integration/test_workflow_cycle_e2e.py
+++ b/tests/integration/test_workflow_cycle_e2e.py
@@ -212,6 +212,24 @@ def test_full_workflow_cycle_with_scope_detection(git_repo: Path) -> None:
     assert result["workflow_phase"] == "design"
     assert result["source"] == "commit-scope"
 
+    # Save planning deliverables (required by on_enter_tdd_phase hook, Issue #146)
+    pm.save_planning_deliverables(
+        999,
+        {
+            "tdd_cycles": {
+                "total": 1,
+                "cycles": [
+                    {
+                        "cycle_number": 1,
+                        "name": "End-to-end TDD cycle",
+                        "deliverables": ["test_workflow_cycle_e2e"],
+                        "exit_criteria": "E2E test passes",
+                    }
+                ],
+            }
+        },
+    )
+
     # Transition to TDD
     state_engine.transition(branch="feature/999-e2e-test", to_phase="tdd")
 
@@ -262,20 +280,20 @@ def test_full_workflow_cycle_with_scope_detection(git_repo: Path) -> None:
     assert result["sub_phase"] == "refactor"
     assert result["source"] == "commit-scope"
 
-    # Transition to INTEGRATION
-    state_engine.transition(branch="feature/999-e2e-test", to_phase="integration")
+    # Transition to VALIDATION
+    state_engine.transition(branch="feature/999-e2e-test", to_phase="validation")
 
-    # Phase 5: INTEGRATION
-    test_file.write_text("integration phase\n")
+    # Phase 5: VALIDATION
+    test_file.write_text("validation phase\n")
     git_manager.commit_with_scope(
-        workflow_phase="integration",
-        message="add integration tests",
+        workflow_phase="validation",
+        message="add validation tests",
         files=[str(test_file)],
     )
 
     commits = git_manager.get_recent_commits(limit=1)
     result = decoder.detect_phase(commit_message=commits[0], fallback_to_state=False)
-    assert result["workflow_phase"] == "integration"
+    assert result["workflow_phase"] == "validation"
     assert result["source"] == "commit-scope"
 
     # Transition to DOCUMENTATION

--- a/tests/unit/managers/test_phase_state_engine.py
+++ b/tests/unit/managers/test_phase_state_engine.py
@@ -1,0 +1,684 @@
+"""Tests for PhaseStateEngine entry/exit hooks.
+
+Issue #146 Cycle 4: TDD phase lifecycle hooks.
+Issue #229 Cycle 6: Research phase exit gate — file_glob support (GAP-10).
+Issue #229 Cycle 7: Per-phase deliverable gate on design exit (GAP-11/D7.2).
+Issue #229 Cycle 9: Per-phase deliverable gates for validation and documentation exit (GAP-16).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcp_server.managers.deliverable_checker import DeliverableCheckError
+from mcp_server.managers.phase_state_engine import PhaseStateEngine
+from mcp_server.managers.project_manager import ProjectManager
+
+
+class TestTDDPhaseHooks:
+    """Tests for TDD phase entry/exit hooks.
+
+    Issue #146 Cycle 4: on_enter_tdd_phase and on_exit_tdd_phase.
+    """
+
+    @pytest.fixture()
+    def setup_project(self, tmp_path: Path) -> tuple[Path, int]:
+        """Create project with planning deliverables."""
+        workspace_root = tmp_path
+        issue_number = 146
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+
+        # Initialize project
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="TDD Cycle Tracking",
+            workflow_name="feature",
+        )
+
+        # Save planning deliverables (4 cycles)
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": 1,
+                        "name": "Schema & Storage",
+                        "deliverables": ["Schema"],
+                        "exit_criteria": "Tests pass",
+                    },
+                    {
+                        "cycle_number": 2,
+                        "name": "Validation Logic",
+                        "deliverables": ["Validators"],
+                        "exit_criteria": "All scenarios covered",
+                    },
+                    {
+                        "cycle_number": 3,
+                        "name": "Discovery Tools",
+                        "deliverables": ["get_work_context"],
+                        "exit_criteria": "Tools return cycle info",
+                    },
+                    {
+                        "cycle_number": 4,
+                        "name": "Transition Tools",
+                        "deliverables": ["transition_cycle", "force_cycle_transition"],
+                        "exit_criteria": "All transitions working",
+                    },
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(
+            issue_number=issue_number, planning_deliverables=planning_deliverables
+        )
+
+        return workspace_root, issue_number
+
+    def test_on_enter_tdd_phase_initializes_cycle_1(self, setup_project: tuple[Path, int]) -> None:
+        """Test that entering TDD phase auto-initializes cycle 1."""
+        # Arrange
+        workspace_root, issue_number = setup_project
+        branch = "feature/146-tdd-cycle-tracking"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        # Initialize branch in design phase
+        state_engine.initialize_branch(
+            branch=branch, issue_number=issue_number, initial_phase="design"
+        )
+
+        # Verify no TDD cycle yet
+        state = state_engine.get_state(branch)
+        assert state.get("current_tdd_cycle") is None
+
+        # Act
+        state_engine.on_enter_tdd_phase(branch, issue_number)
+
+        # Assert
+        state = state_engine.get_state(branch)
+        assert state.get("current_tdd_cycle") == 1
+        assert state.get("last_tdd_cycle") == 0
+
+    def test_on_enter_tdd_phase_does_not_block_without_planning_deliverables(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that entering TDD phase does NOT block on missing planning deliverables.
+
+        GAP-02 fix (Issue #229 C2): the planning-deliverables check was moved to
+        on_exit_planning_phase. TDD entry must no longer enforce this contract.
+        """
+        # Arrange
+        workspace_root = tmp_path
+        issue_number = 146
+        branch = "feature/146-tdd-cycle-tracking"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        # Initialize project WITHOUT planning deliverables
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="TDD Cycle Tracking",
+            workflow_name="feature",
+        )
+
+        state_engine.initialize_branch(
+            branch=branch, issue_number=issue_number, initial_phase="design"
+        )
+
+        # Act & Assert — must NOT raise; gate lives at planning exit now
+        state_engine.on_enter_tdd_phase(branch, issue_number)
+        state = state_engine.get_state(branch)
+        assert state.get("current_tdd_cycle") == 1
+
+    def test_on_exit_tdd_phase_preserves_last_cycle(self, setup_project: tuple[Path, int]) -> None:
+        """Test that exiting TDD phase preserves last_tdd_cycle."""
+        # Arrange
+        workspace_root, issue_number = setup_project
+        branch = "feature/146-tdd-cycle-tracking"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        # Initialize in TDD phase at cycle 3
+        state_engine.initialize_branch(
+            branch=branch, issue_number=issue_number, initial_phase="tdd"
+        )
+        state = state_engine.get_state(branch)
+        state["current_tdd_cycle"] = 3
+        state_engine._save_state(branch, state)
+
+        # Act
+        state_engine.on_exit_tdd_phase(branch)
+
+        # Assert
+        state = state_engine.get_state(branch)
+        assert state.get("last_tdd_cycle") == 3
+        assert state.get("current_tdd_cycle") is None
+
+    def test_on_exit_tdd_phase_validates_completion(self, setup_project: tuple[Path, int]) -> None:
+        """Test that exiting TDD phase validates all cycles completed."""
+        # Arrange
+        workspace_root, issue_number = setup_project
+        branch = "feature/146-tdd-cycle-tracking"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        # Initialize in TDD phase at cycle 2 (not completed)
+        state_engine.initialize_branch(
+            branch=branch, issue_number=issue_number, initial_phase="tdd"
+        )
+        state = state_engine.get_state(branch)
+        state["current_tdd_cycle"] = 2
+        state_engine._save_state(branch, state)
+
+        # Act
+        # Design decision: Allow exit with warning (logs but doesn't block)
+        state_engine.on_exit_tdd_phase(branch)
+
+        # Assert
+        state = state_engine.get_state(branch)
+        assert state.get("last_tdd_cycle") == 2
+        assert state.get("current_tdd_cycle") is None
+
+
+class TestTransitionHooksWiring:
+    """Tests that transition() automatically calls entry/exit hooks (Issue #146 Cycle 5 D3)."""
+
+    @pytest.fixture()
+    def setup_project(self, tmp_path: Path) -> tuple[Path, int]:
+        """Create project with planning deliverables."""
+        workspace_root = tmp_path
+        issue_number = 999
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Hook Wiring Test",
+            workflow_name="feature",
+        )
+        project_manager.save_planning_deliverables(
+            issue_number=issue_number,
+            planning_deliverables={
+                "tdd_cycles": {
+                    "total": 1,
+                    "cycles": [
+                        {
+                            "cycle_number": 1,
+                            "name": "Basic",
+                            "deliverables": ["A"],
+                            "exit_criteria": "pass",
+                        }
+                    ],
+                }
+            },
+        )
+        return workspace_root, issue_number
+
+    def test_transition_to_tdd_calls_enter_hook(self, setup_project: tuple[Path, int]) -> None:
+        """Test that transition() to 'tdd' auto-calls on_enter_tdd_phase (Issue #146)."""
+        workspace_root, issue_number = setup_project
+        branch = "feature/999-hook-wiring"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        # Initialize branch in design phase
+        state_engine.initialize_branch(
+            branch=branch, issue_number=issue_number, initial_phase="design"
+        )
+
+        # Verify no TDD cycle before transition
+        state = state_engine.get_state(branch)
+        assert state.get("current_tdd_cycle") is None
+
+        # Transition to TDD - should auto-call on_enter_tdd_phase
+        state_engine.transition(branch=branch, to_phase="tdd")
+
+        # Assert: hook was triggered and cycle 1 was initialized
+        state = state_engine.get_state(branch)
+        assert state.get("current_tdd_cycle") == 1, (
+            "on_enter_tdd_phase was not called by transition() - "
+            "current_tdd_cycle should be 1 after entering TDD phase"
+        )
+
+    def test_transition_from_tdd_calls_exit_hook(self, setup_project: tuple[Path, int]) -> None:
+        """Test that transition() from 'tdd' auto-calls on_exit_tdd_phase (Issue #146)."""
+        workspace_root, issue_number = setup_project
+        branch = "feature/999-hook-wiring"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        # Initialize branch in TDD phase at cycle 2
+        state_engine.initialize_branch(
+            branch=branch, issue_number=issue_number, initial_phase="tdd"
+        )
+        state = state_engine.get_state(branch)
+        state["current_tdd_cycle"] = 2
+        state_engine._save_state(branch, state)
+
+        # Transition away from TDD - should auto-call on_exit_tdd_phase
+        state_engine.transition(branch=branch, to_phase="validation")
+
+        # Assert: hook was triggered and last_tdd_cycle was preserved
+        state = state_engine.get_state(branch)
+        assert state.get("last_tdd_cycle") == 2, (
+            "on_exit_tdd_phase was not called by transition() - "
+            "last_tdd_cycle should be 2 after exiting TDD phase"
+        )
+        assert state.get("current_tdd_cycle") is None, (
+            "current_tdd_cycle should be None after exiting TDD phase"
+        )
+
+
+class TestResearchExitGate:
+    """Tests for research phase exit gate (Issue #229 C6, GAP-10).
+
+    on_exit_research_phase() reads exit_requires from workphases.yaml for 'research'.
+    Supports type: file_glob with {issue_number} interpolation.
+    - D6.1: file_glob dispatch in PhaseStateEngine
+    - D6.2: research.exit_requires in workphases.yaml
+    """
+
+    def _workphases_yaml(self, tmp_path: Path, research_exit_requires: list | None = None) -> Path:
+        """Write a minimal workphases.yaml to tmp_path / .st3 / workphases.yaml."""
+        content: dict = {"version": "1.0", "phases": {"research": {}}}
+        if research_exit_requires is not None:
+            content["phases"]["research"]["exit_requires"] = research_exit_requires
+        path = tmp_path / ".st3" / "workphases.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.dump(content))
+        return path
+
+    def _setup_project(self, tmp_path: Path, issue_number: int, phase: str = "research") -> None:
+        """Initialize a project in the given phase."""
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Research exit gate test",
+            workflow_name="feature",
+        )
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=manager)
+        engine.initialize_branch(
+            branch=f"feature/{issue_number}-test",
+            issue_number=issue_number,
+            initial_phase=phase,
+        )
+
+    def test_on_exit_research_phase_silent_when_no_exit_requires(self, tmp_path: Path) -> None:
+        """No exit_requires configured → passes without raising. (D6.1)"""
+        self._workphases_yaml(tmp_path, research_exit_requires=None)
+        self._setup_project(tmp_path, issue_number=300)
+        manager = ProjectManager(workspace_root=tmp_path)
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=manager)
+
+        # Must not raise
+        engine.on_exit_research_phase(branch="feature/300-test", issue_number=300)
+
+    def test_on_exit_research_phase_passes_when_file_glob_matches(self, tmp_path: Path) -> None:
+        """file_glob exit gate passes when at least one file matches. (D6.1)"""
+        self._workphases_yaml(
+            tmp_path,
+            research_exit_requires=[
+                {
+                    "type": "file_glob",
+                    "file": "docs/development/issue{issue_number}/*research*.md",
+                    "description": "Research document aanwezig",
+                }
+            ],
+        )
+        self._setup_project(tmp_path, issue_number=301)
+
+        # Create matching file
+        doc_dir = tmp_path / "docs" / "development" / "issue301"
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "my-research-notes.md").write_text("# Research")
+
+        manager = ProjectManager(workspace_root=tmp_path)
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=manager)
+
+        # Must not raise
+        engine.on_exit_research_phase(branch="feature/301-test", issue_number=301)
+
+    def test_on_exit_research_phase_raises_when_file_glob_not_found(self, tmp_path: Path) -> None:
+        """file_glob exit gate raises when no file matches the pattern. (D6.1)"""
+        self._workphases_yaml(
+            tmp_path,
+            research_exit_requires=[
+                {
+                    "type": "file_glob",
+                    "file": "docs/development/issue{issue_number}/*research*.md",
+                    "description": "Research document aanwezig",
+                }
+            ],
+        )
+        self._setup_project(tmp_path, issue_number=302)
+
+        # No matching file created
+        manager = ProjectManager(workspace_root=tmp_path)
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=manager)
+
+        with pytest.raises(DeliverableCheckError):
+            engine.on_exit_research_phase(branch="feature/302-test", issue_number=302)
+
+    def test_on_exit_research_phase_interpolates_issue_number(self, tmp_path: Path) -> None:
+        """Pattern {issue_number} is substituted before globbing. (D6.1)"""
+        issue_number = 303
+        self._workphases_yaml(
+            tmp_path,
+            research_exit_requires=[
+                {
+                    "type": "file_glob",
+                    "file": "docs/development/issue{issue_number}/*research*.md",
+                    "description": "Research document",
+                }
+            ],
+        )
+        self._setup_project(tmp_path, issue_number=issue_number)
+
+        # Create file for the WRONG issue number — must still fail
+        wrong_dir = tmp_path / "docs" / "development" / "issue999"
+        wrong_dir.mkdir(parents=True)
+        (wrong_dir / "my-research.md").write_text("# Research")
+
+        manager = ProjectManager(workspace_root=tmp_path)
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=manager)
+
+        with pytest.raises(DeliverableCheckError):
+            engine.on_exit_research_phase(branch="feature/303-test", issue_number=issue_number)
+
+    def test_transition_from_research_triggers_exit_hook(self, tmp_path: Path) -> None:
+        """transition(research→planning) calls on_exit_research_phase. (D6.1 wiring)"""
+        issue_number = 304
+        self._workphases_yaml(
+            tmp_path,
+            research_exit_requires=[
+                {
+                    "type": "file_glob",
+                    "file": "docs/development/issue{issue_number}/*research*.md",
+                    "description": "Research document aanwezig",
+                }
+            ],
+        )
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Transition wiring test",
+            workflow_name="feature",
+        )
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=manager)
+        engine.initialize_branch(
+            branch="feature/304-test",
+            issue_number=issue_number,
+            initial_phase="research",
+        )
+
+        # No matching file → transition must raise DeliverableCheckError
+        with pytest.raises(DeliverableCheckError):
+            engine.transition(branch="feature/304-test", to_phase="planning")
+
+
+class TestPerPhaseDeliverableGate:
+    """Tests for per-phase deliverable gate on design exit (Issue #229 C7, GAP-11).
+
+    on_exit_design_phase() reads planning_deliverables.design.deliverables and
+    runs DeliverableChecker.check() for each entry that has a validates spec.
+    - D7.1: save_planning_deliverables accepts optional phase keys
+    - D7.2: gate check in PhaseStateEngine.on_exit_design_phase()
+    """
+
+    def _make_engine(
+        self, tmp_path: Path, issue_number: int = 229, deliverables_state: dict | None = None
+    ) -> PhaseStateEngine:
+        """Build a PhaseStateEngine in design phase with optional planning_deliverables injected."""
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Per-phase deliverable gate test",
+            workflow_name="feature",
+        )
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=manager)
+        engine.initialize_branch(
+            branch=f"feature/{issue_number}-test",
+            issue_number=issue_number,
+            initial_phase="design",
+        )
+        # Inject planning_deliverables into projects.json (gate reads from project plan)
+        if deliverables_state is not None:
+            projects_path = tmp_path / ".st3" / "projects.json"
+            projects_data: dict = json.loads(projects_path.read_text())
+            projects_data[str(issue_number)]["planning_deliverables"] = deliverables_state
+            projects_path.write_text(json.dumps(projects_data, indent=2))
+        return engine
+
+    def test_on_exit_design_gate_silent_when_phase_key_absent(self, tmp_path: Path) -> None:
+        """Gate is optional: no planning_deliverables.design → silent pass."""
+        engine = self._make_engine(tmp_path, deliverables_state={"tdd_cycles": {}})
+        # Should not raise even though no design key present
+        engine.on_exit_design_phase(branch="feature/229-test", issue_number=229)
+
+    def test_on_exit_design_gate_passes_when_validates_spec_satisfied(self, tmp_path: Path) -> None:
+        """Gate passes when DeliverableChecker.check() succeeds for all deliverables."""
+        # Create matching file in tmp_path (which is the workspace root used by _make_engine)
+        docs_dir = tmp_path / "docs" / "development" / "issue229"
+        docs_dir.mkdir(parents=True)
+        (docs_dir / "design.md").write_text("# Design")
+
+        deliverables_state = {
+            "design": {
+                "deliverables": [
+                    {
+                        "id": "D7.1",
+                        "description": "Design document",
+                        "validates": {
+                            "type": "file_glob",
+                            "dir": "docs/development/issue229",
+                            "pattern": "design*.md",
+                        },
+                    }
+                ]
+            }
+        }
+        engine = self._make_engine(tmp_path, deliverables_state=deliverables_state)
+        # Should not raise
+        engine.on_exit_design_phase(branch="feature/229-test", issue_number=229)
+
+    def test_on_exit_design_gate_raises_when_validates_spec_fails(self, tmp_path: Path) -> None:
+        """Gate raises DeliverableCheckError when required file is missing."""
+        deliverables_state = {
+            "design": {
+                "deliverables": [
+                    {
+                        "id": "D7.1",
+                        "description": "Design document",
+                        "validates": {
+                            "type": "file_glob",
+                            "dir": "docs/development/issue229",
+                            "pattern": "design*.md",
+                        },
+                    }
+                ]
+            }
+        }
+        engine = self._make_engine(tmp_path, deliverables_state=deliverables_state)
+        with pytest.raises(DeliverableCheckError):
+            engine.on_exit_design_phase(branch="feature/229-test", issue_number=229)
+
+
+class TestValidationAndDocumentationExitGates:
+    """Tests for on_exit_validation_phase and on_exit_documentation_phase (Issue #229 C9, GAP-16).
+
+    Both hooks mirror on_exit_design_phase: optional, run DeliverableChecker for each
+    deliverable that has a 'validates' spec, silent pass when phase key absent.
+    - D9.1: on_exit_validation_phase implemented
+    - D9.2: on_exit_documentation_phase implemented
+    - D9.3: both wired in transition() for the matching from_phase
+    """
+
+    def _make_engine(
+        self,
+        tmp_path: Path,
+        issue_number: int = 229,
+        initial_phase: str = "validation",
+        deliverables_state: dict | None = None,
+    ) -> PhaseStateEngine:
+        """Build a PhaseStateEngine in the given phase with optional planning_deliverables."""
+        from mcp_server.managers.project_manager import ProjectManager
+
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Validation/documentation gate test",
+            workflow_name="feature",
+        )
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=manager)
+        engine.initialize_branch(
+            branch=f"feature/{issue_number}-test",
+            issue_number=issue_number,
+            initial_phase=initial_phase,
+        )
+        if deliverables_state is not None:
+            projects_path = tmp_path / ".st3" / "projects.json"
+            projects_data: dict = json.loads(projects_path.read_text())
+            projects_data[str(issue_number)]["planning_deliverables"] = deliverables_state
+            projects_path.write_text(json.dumps(projects_data, indent=2))
+        return engine
+
+    # --- on_exit_validation_phase ---
+
+    def test_validation_exit_gate_skips_when_no_validation_key_in_plan(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate is optional: no planning_deliverables.validation → silent pass."""
+        engine = self._make_engine(tmp_path, deliverables_state={"tdd_cycles": {}})
+        engine.on_exit_validation_phase(branch="feature/229-test", issue_number=229)
+
+    def test_validation_exit_gate_passes_when_deliverable_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate passes when DeliverableChecker.check() succeeds for spec file."""
+        report_dir = tmp_path / "docs" / "development" / "issue229"
+        report_dir.mkdir(parents=True)
+        (report_dir / "validation_report.md").write_text("# Validation Report")
+
+        deliverables_state = {
+            "validation": {
+                "deliverables": [
+                    {
+                        "id": "Dval.1",
+                        "description": "Validation report",
+                        "validates": {
+                            "type": "file_glob",
+                            "dir": "docs/development/issue229",
+                            "pattern": "validation_report*.md",
+                        },
+                    }
+                ]
+            }
+        }
+        engine = self._make_engine(tmp_path, deliverables_state=deliverables_state)
+        engine.on_exit_validation_phase(branch="feature/229-test", issue_number=229)
+
+    def test_validation_exit_gate_blocks_transition_when_deliverable_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate raises DeliverableCheckError when required file is missing."""
+        deliverables_state = {
+            "validation": {
+                "deliverables": [
+                    {
+                        "id": "Dval.1",
+                        "description": "Validation report",
+                        "validates": {
+                            "type": "file_glob",
+                            "dir": "docs/development/issue229",
+                            "pattern": "validation_report*.md",
+                        },
+                    }
+                ]
+            }
+        }
+        engine = self._make_engine(tmp_path, deliverables_state=deliverables_state)
+        with pytest.raises(DeliverableCheckError):
+            engine.on_exit_validation_phase(branch="feature/229-test", issue_number=229)
+
+    # --- on_exit_documentation_phase ---
+
+    def test_documentation_exit_gate_skips_when_no_documentation_key_in_plan(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate is optional: no planning_deliverables.documentation → silent pass."""
+        engine = self._make_engine(
+            tmp_path, initial_phase="documentation", deliverables_state={"tdd_cycles": {}}
+        )
+        engine.on_exit_documentation_phase(branch="feature/229-test", issue_number=229)
+
+    def test_documentation_exit_gate_passes_when_deliverable_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate passes when DeliverableChecker.check() succeeds for spec file."""
+        docs_dir = tmp_path / "docs" / "development" / "issue229"
+        docs_dir.mkdir(parents=True)
+        (docs_dir / "README_feature.md").write_text("# Docs")
+
+        deliverables_state = {
+            "documentation": {
+                "deliverables": [
+                    {
+                        "id": "Ddoc.1",
+                        "description": "Feature docs",
+                        "validates": {
+                            "type": "file_glob",
+                            "dir": "docs/development/issue229",
+                            "pattern": "README_feature*.md",
+                        },
+                    }
+                ]
+            }
+        }
+        engine = self._make_engine(
+            tmp_path, initial_phase="documentation", deliverables_state=deliverables_state
+        )
+        engine.on_exit_documentation_phase(branch="feature/229-test", issue_number=229)
+
+    def test_documentation_exit_gate_blocks_transition_when_deliverable_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate raises DeliverableCheckError when required file is missing."""
+        deliverables_state = {
+            "documentation": {
+                "deliverables": [
+                    {
+                        "id": "Ddoc.1",
+                        "description": "Feature docs",
+                        "validates": {
+                            "type": "file_glob",
+                            "dir": "docs/development/issue229",
+                            "pattern": "README_feature*.md",
+                        },
+                    }
+                ]
+            }
+        }
+        engine = self._make_engine(
+            tmp_path, initial_phase="documentation", deliverables_state=deliverables_state
+        )
+        with pytest.raises(DeliverableCheckError):
+            engine.on_exit_documentation_phase(branch="feature/229-test", issue_number=229)

--- a/tests/unit/mcp_server/config/test_workflow_config.py
+++ b/tests/unit/mcp_server/config/test_workflow_config.py
@@ -1,4 +1,4 @@
-﻿"""Tests for workflow configuration (WorkflowConfig, WorkflowTemplate).
+"""Tests for workflow configuration (WorkflowConfig, WorkflowTemplate).
 
 Test Coverage:
 - Config loading (valid YAML, missing file, invalid YAML, invalid schema)
@@ -38,15 +38,15 @@ def valid_workflows_yaml(tmp_path: Path) -> Path:
                 "name": "feature",
                 "description": "Full development workflow",
                 "default_execution_mode": "interactive",
-                "phases": ["research", "planning", "design", "tdd", "integration", "documentation"]
+                "phases": ["research", "planning", "design", "tdd", "validation", "documentation"],
             },
             "hotfix": {
                 "name": "hotfix",
                 "description": "Emergency fix workflow",
                 "default_execution_mode": "autonomous",
-                "phases": ["tdd", "integration", "documentation"]
-            }
-        }
+                "phases": ["tdd", "validation", "documentation"],
+            },
+        },
     }
 
     yaml_path = tmp_path / "workflows.yaml"
@@ -87,9 +87,9 @@ def invalid_schema_yaml(tmp_path: Path) -> Path:
             "broken": {
                 "name": "broken",
                 # Missing required 'phases' field
-                "default_execution_mode": "interactive"
-            }
-        }
+                "default_execution_mode": "interactive",
+            },
+        },
     }
 
     yaml_path = tmp_path / "invalid_schema.yaml"
@@ -102,6 +102,7 @@ def invalid_schema_yaml(tmp_path: Path) -> Path:
 # =============================================================================
 # Phase 1: Config Loading Tests (GREEN)
 # =============================================================================
+
 
 class TestWorkflowConfigLoading:
     """Test WorkflowConfig.load() method."""
@@ -215,7 +216,7 @@ class TestWorkflowTemplateValidation:
             WorkflowTemplate(
                 name="test",
                 phases=["research", "planning", "research"],  # Duplicate
-                default_execution_mode="interactive"
+                default_execution_mode="interactive",
             )
 
         error_msg = str(exc_info.value)
@@ -234,7 +235,7 @@ class TestWorkflowTemplateValidation:
             WorkflowTemplate(
                 name="test",
                 phases=["research", "  ", "planning"],  # Empty phase
-                default_execution_mode="interactive"
+                default_execution_mode="interactive",
             )
 
         error_msg = str(exc_info.value)
@@ -252,7 +253,7 @@ class TestWorkflowTemplateValidation:
             WorkflowTemplate(
                 name="test",
                 phases=["research"],
-                default_execution_mode="manual"  # type: ignore[arg-type]
+                default_execution_mode="manual",  # type: ignore[arg-type]
             )
 
         error_msg = str(exc_info.value)
@@ -262,6 +263,7 @@ class TestWorkflowTemplateValidation:
 # =============================================================================
 # Phase 2: Workflow Lookup Tests (RED)
 # =============================================================================
+
 
 class TestWorkflowLookup:
     """Test WorkflowConfig.get_workflow() method."""
@@ -284,7 +286,12 @@ class TestWorkflowLookup:
         assert isinstance(workflow, WorkflowTemplate)
         assert workflow.name == "feature"
         assert workflow.phases == [
-            "research", "planning", "design", "tdd", "integration", "documentation"
+            "research",
+            "planning",
+            "design",
+            "tdd",
+            "validation",
+            "documentation",
         ]
         assert workflow.default_execution_mode == "interactive"
 
@@ -317,6 +324,7 @@ class TestWorkflowLookup:
 # Phase 3: Transition Validation Tests (RED)
 # =============================================================================
 
+
 class TestTransitionValidation:
     """Test WorkflowConfig.validate_transition() method."""
 
@@ -332,10 +340,10 @@ class TestTransitionValidation:
         """
         config = WorkflowConfig.load(valid_workflows_yaml)
 
-        # Valid transitions: research ÔåÆ planning, planning ÔåÆ design, etc.
+        # Valid transitions: research -> planning, planning -> design, etc.
         assert config.validate_transition("feature", "research", "planning") is True
         assert config.validate_transition("feature", "planning", "design") is True
-        assert config.validate_transition("hotfix", "tdd", "integration") is True
+        assert config.validate_transition("hotfix", "tdd", "validation") is True
 
     def test_validate_transition_skip_phase(self, valid_workflows_yaml: Path) -> None:
         """Test validating transition that skips a phase (invalid).
@@ -382,9 +390,7 @@ class TestTransitionValidation:
         assert "design" in error_msg
         assert "planning" in error_msg
 
-    def test_validate_transition_invalid_current_phase(
-        self, valid_workflows_yaml: Path
-    ) -> None:
+    def test_validate_transition_invalid_current_phase(self, valid_workflows_yaml: Path) -> None:
         """Test validation with invalid current phase.
 
         Expected behavior:
@@ -404,9 +410,7 @@ class TestTransitionValidation:
         assert "Current phase 'invalid' not in workflow 'feature'" in error_msg
         assert "Valid phases:" in error_msg
 
-    def test_validate_transition_invalid_target_phase(
-        self, valid_workflows_yaml: Path
-    ) -> None:
+    def test_validate_transition_invalid_target_phase(self, valid_workflows_yaml: Path) -> None:
         """Test validation with invalid target phase.
 
         Expected behavior:

--- a/tests/unit/mcp_server/integration/test_all_tools.py
+++ b/tests/unit/mcp_server/integration/test_all_tools.py
@@ -91,11 +91,18 @@ class TestGitToolsIntegration:
             mock_adapter.return_value.commit.return_value = "abc123def"
 
             tool = GitCommitTool()
-            result = await tool.execute(GitCommitInput(phase="green", message="implement feature"))
+            result = await tool.execute(
+                GitCommitInput(
+                    workflow_phase="tdd",
+                    cycle_number=1,
+                    sub_phase="green",
+                    message="implement feature",
+                )
+            )
 
             assert "abc123def" in result.content[0]["text"]
             mock_adapter.return_value.commit.assert_called_with(
-                "feat(P_TDD_SP_GREEN): implement feature",
+                "feat(P_TDD_SP_C1_GREEN): implement feature",
                 files=None,
             )
 

--- a/tests/unit/mcp_server/managers/test_deliverable_checker.py
+++ b/tests/unit/mcp_server/managers/test_deliverable_checker.py
@@ -1,0 +1,282 @@
+"""Tests for DeliverableChecker and WorkphasesConfig schema extension.
+
+Issue #229 Cycle 1: workphases.yaml exit_requires/entry_expects schema +
+structural deliverable checker (file_exists, contains_text, absent_text, key_path).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mcp_server.config.workphases_config import WorkphasesConfig
+from mcp_server.managers.deliverable_checker import (
+    DeliverableChecker,
+    DeliverableCheckError,
+)
+
+# ---------------------------------------------------------------------------
+# WorkphasesConfig schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkphasesConfigSchema:
+    """Verify exit_requires / entry_expects fields parse correctly."""
+
+    def test_workphases_schema_exit_requires_field_is_parsed(self, tmp_path: Path) -> None:
+        """Phase with exit_requires list is parsed into WorkphasesConfig.
+
+        Issue #229 C1: exit_requires must be readable per phase.
+        """
+        workphases_path = tmp_path / "workphases.yaml"
+        workphases_path.write_text(
+            """
+phases:
+  planning:
+    display_name: "Planning"
+    exit_requires:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown"
+"""
+        )
+
+        config = WorkphasesConfig(workphases_path)
+        exit_requires = config.get_exit_requires("planning")
+
+        assert len(exit_requires) == 1
+        assert exit_requires[0]["key"] == "planning_deliverables"
+
+    def test_workphases_schema_entry_expects_field_is_parsed(self, tmp_path: Path) -> None:
+        """Phase with entry_expects list is parsed into WorkphasesConfig.
+
+        Issue #229 C1: entry_expects must be readable per phase.
+        """
+        workphases_path = tmp_path / "workphases.yaml"
+        workphases_path.write_text(
+            """
+phases:
+  tdd:
+    display_name: "TDD"
+    entry_expects:
+      - key: "planning_deliverables"
+        description: "Expected from planning phase"
+"""
+        )
+
+        config = WorkphasesConfig(workphases_path)
+        entry_expects = config.get_entry_expects("tdd")
+
+        assert len(entry_expects) == 1
+        assert entry_expects[0]["key"] == "planning_deliverables"
+
+    def test_workphases_schema_backward_compat_phases_without_field(self, tmp_path: Path) -> None:
+        """Phases without exit_requires/entry_expects return empty list.
+
+        Issue #229 C1: existing phases must not break when fields are absent.
+        """
+        workphases_path = tmp_path / "workphases.yaml"
+        workphases_path.write_text(
+            """
+phases:
+  research:
+    display_name: "Research"
+    subphases: []
+  planning:
+    display_name: "Planning"
+    exit_requires:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown"
+"""
+        )
+
+        config = WorkphasesConfig(workphases_path)
+
+        # research has no exit_requires or entry_expects — must return []
+        assert config.get_exit_requires("research") == []
+        assert config.get_entry_expects("research") == []
+
+        # planning has exit_requires but no entry_expects
+        assert config.get_entry_expects("planning") == []
+
+
+# ---------------------------------------------------------------------------
+# DeliverableChecker tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeliverableChecker:
+    """Verify DeliverableChecker validates deliverable specs correctly."""
+
+    @pytest.fixture
+    def checker(self, tmp_path: Path) -> DeliverableChecker:
+        return DeliverableChecker(workspace_root=tmp_path)
+
+    # --- file_exists ---
+
+    def test_deliverable_checker_file_not_found_raises(self, checker: DeliverableChecker) -> None:
+        """file_exists check raises DeliverableCheckError when file absent.
+
+        Issue #229 C1.
+        """
+        with pytest.raises(DeliverableCheckError, match="D1.1"):
+            checker.check(
+                "D1.1",
+                {"type": "file_exists", "file": "mcp_server/managers/deliverable_checker.py"},
+            )
+
+    # --- contains_text (SCAFFOLD-header) ---
+
+    def test_deliverable_checker_md_missing_scaffold_header_raises(
+        self, checker: DeliverableChecker, tmp_path: Path
+    ) -> None:
+        """contains_text raises when SCAFFOLD header absent from .md file.
+
+        Issue #229 C1: SCAFFOLD-header = contains_text with text='<!-- template='.
+        """
+        md_file = tmp_path / "docs" / "planning.md"
+        md_file.parent.mkdir(parents=True)
+        md_file.write_text("# Planning\n\nNo header here.\n")
+
+        with pytest.raises(DeliverableCheckError, match="D1.2"):
+            checker.check(
+                "D1.2",
+                {
+                    "type": "contains_text",
+                    "file": "docs/planning.md",
+                    "text": "<!-- template=",
+                },
+            )
+
+    def test_deliverable_checker_md_valid_scaffold_header_passes(
+        self, checker: DeliverableChecker, tmp_path: Path
+    ) -> None:
+        """contains_text passes silently when SCAFFOLD header present.
+
+        Issue #229 C1.
+        """
+        md_file = tmp_path / "docs" / "planning.md"
+        md_file.parent.mkdir(parents=True)
+        md_file.write_text(
+            "<!-- template=planning version=abc created=2026-02-19 -->\n# Planning\n"
+        )
+
+        # Must not raise
+        checker.check(
+            "D1.2",
+            {
+                "type": "contains_text",
+                "file": "docs/planning.md",
+                "text": "<!-- template=",
+            },
+        )
+
+    # --- key_path (JSON) ---
+
+    def test_deliverable_checker_json_key_path_present_passes(
+        self, checker: DeliverableChecker, tmp_path: Path
+    ) -> None:
+        """key_path passes silently when dot-notation path resolves in JSON.
+
+        Issue #229 C1.
+        """
+        json_file = tmp_path / ".st3" / "projects.json"
+        json_file.parent.mkdir(parents=True)
+        json_file.write_text(
+            json.dumps({"229": {"planning_deliverables": {"tdd_cycles": {"total": 2}}}})
+        )
+
+        # Must not raise
+        checker.check(
+            "D1.3",
+            {
+                "type": "key_path",
+                "file": ".st3/projects.json",
+                "path": "229.planning_deliverables",
+            },
+        )
+
+    def test_deliverable_checker_json_key_path_missing_raises(
+        self, checker: DeliverableChecker, tmp_path: Path
+    ) -> None:
+        """key_path raises DeliverableCheckError when path absent in JSON.
+
+        Issue #229 C1.
+        """
+        json_file = tmp_path / ".st3" / "projects.json"
+        json_file.parent.mkdir(parents=True)
+        json_file.write_text(json.dumps({"229": {}}))
+
+        with pytest.raises(DeliverableCheckError, match="D1.4"):
+            checker.check(
+                "D1.4",
+                {
+                    "type": "key_path",
+                    "file": ".st3/projects.json",
+                    "path": "229.planning_deliverables",
+                },
+            )
+
+    # --- file_glob ---
+
+    def test_deliverable_checker_file_glob_match_passes(
+        self, checker: DeliverableChecker, tmp_path: Path
+    ) -> None:
+        """file_glob passes silently when at least one file matches the pattern.
+
+        Issue #229 C2 re-run — GAP-05: agents should not need exact filenames.
+        """
+        docs = tmp_path / "docs" / "development" / "issue229"
+        docs.mkdir(parents=True)
+        (docs / "research_summary.md").write_text("# Research\n")
+
+        # Must not raise — one match exists
+        checker.check(
+            "D2.3",
+            {
+                "type": "file_glob",
+                "dir": "docs/development/issue229",
+                "pattern": "*research*.md",
+            },
+        )
+
+    def test_deliverable_checker_file_glob_no_match_raises(
+        self, checker: DeliverableChecker, tmp_path: Path
+    ) -> None:
+        """file_glob raises DeliverableCheckError when no files match the pattern.
+
+        Issue #229 C2 re-run — GAP-05.
+        """
+        docs = tmp_path / "docs" / "development" / "issue229"
+        docs.mkdir(parents=True)
+        (docs / "planning.md").write_text("# Planning\n")
+
+        with pytest.raises(DeliverableCheckError, match="D2.4"):
+            checker.check(
+                "D2.4",
+                {
+                    "type": "file_glob",
+                    "dir": "docs/development/issue229",
+                    "pattern": "*research*.md",
+                },
+            )
+
+    def test_deliverable_checker_file_glob_pattern_in_subdir_passes(
+        self, checker: DeliverableChecker, tmp_path: Path
+    ) -> None:
+        """file_glob resolves dir relative to workspace_root and matches recursively.
+
+        Issue #229 C2 re-run — GAP-05: dir + pattern together locate the file.
+        """
+        nested = tmp_path / "mcp_server" / "managers"
+        nested.mkdir(parents=True)
+        (nested / "deliverable_checker.py").write_text("# module\n")
+
+        # Must not raise — file matches *.py in mcp_server/managers
+        checker.check(
+            "D2.5",
+            {
+                "type": "file_glob",
+                "dir": "mcp_server/managers",
+                "pattern": "deliverable_*.py",
+            },
+        )

--- a/tests/unit/mcp_server/managers/test_phase_state_engine.py
+++ b/tests/unit/mcp_server/managers/test_phase_state_engine.py
@@ -4,6 +4,7 @@ Issue #79: Tests for parent_branch in state management.
 - initialize_branch with parent_branch
 - Auto-recovery includes parent_branch from projects.json
 """
+
 from pathlib import Path
 
 import pytest
@@ -40,9 +41,7 @@ class TestPhaseStateEngineParentBranch:
         return ProjectManager(workspace_root=workspace_root)
 
     @pytest.fixture
-    def engine(
-        self, workspace_root: Path, project_manager: ProjectManager
-    ) -> PhaseStateEngine:
+    def engine(self, workspace_root: Path, project_manager: ProjectManager) -> PhaseStateEngine:
         """Create PhaseStateEngine instance.
 
         Args:
@@ -52,9 +51,7 @@ class TestPhaseStateEngineParentBranch:
         Returns:
             PhaseStateEngine instance
         """
-        return PhaseStateEngine(
-            workspace_root=workspace_root, project_manager=project_manager
-        )
+        return PhaseStateEngine(workspace_root=workspace_root, project_manager=project_manager)
 
     def test_initialize_branch_with_explicit_parent_branch(
         self, engine: PhaseStateEngine, project_manager: ProjectManager
@@ -68,7 +65,7 @@ class TestPhaseStateEngineParentBranch:
             issue_number=79,
             issue_title="Test",
             workflow_name="feature",
-            options=ProjectInitOptions(parent_branch="main")
+            options=ProjectInitOptions(parent_branch="main"),
         )
 
         # Execute - initialize branch with different parent (override)
@@ -76,7 +73,7 @@ class TestPhaseStateEngineParentBranch:
             branch="feature/79-test",
             issue_number=79,
             initial_phase="research",
-            parent_branch="epic/76-qa"  # Override project's "main"
+            parent_branch="epic/76-qa",  # Override project's "main"
         )
 
         # Verify
@@ -99,14 +96,14 @@ class TestPhaseStateEngineParentBranch:
             issue_number=80,
             issue_title="Test",
             workflow_name="bug",
-            options=ProjectInitOptions(parent_branch="epic/76-qa")
+            options=ProjectInitOptions(parent_branch="epic/76-qa"),
         )
 
         # Execute - initialize branch WITHOUT parent_branch parameter
         result = engine.initialize_branch(
             branch="bug/80-test",
             issue_number=80,
-            initial_phase="tdd"
+            initial_phase="tdd",
             # No parent_branch - should inherit from project
         )
 
@@ -127,16 +124,12 @@ class TestPhaseStateEngineParentBranch:
         """
         # Setup - create project WITHOUT parent_branch
         project_manager.initialize_project(
-            issue_number=81,
-            issue_title="Old Project",
-            workflow_name="docs"
+            issue_number=81, issue_title="Old Project", workflow_name="docs"
         )
 
         # Execute - initialize branch
         result = engine.initialize_branch(
-            branch="docs/81-test",
-            issue_number=81,
-            initial_phase="documentation"
+            branch="docs/81-test", issue_number=81, initial_phase="documentation"
         )
 
         # Verify
@@ -148,8 +141,7 @@ class TestPhaseStateEngineParentBranch:
         assert state["parent_branch"] is None
 
     def test_reconstruct_branch_state_includes_parent_branch(
-        self, engine: PhaseStateEngine, project_manager: ProjectManager,
-        workspace_root: Path
+        self, engine: PhaseStateEngine, project_manager: ProjectManager, workspace_root: Path
     ) -> None:
         """Test auto-recovery reconstructs parent_branch from projects.json.
 
@@ -160,7 +152,7 @@ class TestPhaseStateEngineParentBranch:
             issue_number=82,
             issue_title="Test Reconstruction",
             workflow_name="feature",
-            options=ProjectInitOptions(parent_branch="epic/76-qa")
+            options=ProjectInitOptions(parent_branch="epic/76-qa"),
         )
 
         # Simulate cross-machine: delete state.json but keep projects.json
@@ -177,8 +169,7 @@ class TestPhaseStateEngineParentBranch:
         assert state["workflow_name"] == "feature"
 
     def test_reconstruct_branch_state_with_none_parent_branch(
-        self, engine: PhaseStateEngine, project_manager: ProjectManager,
-        workspace_root: Path
+        self, engine: PhaseStateEngine, project_manager: ProjectManager, workspace_root: Path
     ) -> None:
         """Test auto-recovery handles missing parent_branch gracefully.
 
@@ -186,9 +177,7 @@ class TestPhaseStateEngineParentBranch:
         """
         # Setup - create project WITHOUT parent_branch
         project_manager.initialize_project(
-            issue_number=83,
-            issue_title="Old Project",
-            workflow_name="bug"
+            issue_number=83, issue_title="Old Project", workflow_name="bug"
         )
 
         # Simulate cross-machine: delete state.json
@@ -203,3 +192,322 @@ class TestPhaseStateEngineParentBranch:
         assert state["parent_branch"] is None
         assert state["reconstructed"] is True
         assert state["workflow_name"] == "bug"
+
+
+class TestTddCycleTrackingFields:
+    """Test TDD cycle tracking fields in state management.
+
+    Issue #146: State management correctly initializes/clears cycle fields.
+    """
+
+    @pytest.fixture
+    def workspace_root(self, tmp_path: Path) -> Path:
+        """Create temporary workspace.
+
+        Args:
+            tmp_path: Pytest tmp_path fixture
+
+        Returns:
+            Path to temporary workspace root
+        """
+        return tmp_path
+
+    @pytest.fixture
+    def project_manager(self, workspace_root: Path) -> ProjectManager:
+        """Create ProjectManager instance.
+
+        Args:
+            workspace_root: Path to workspace root
+
+        Returns:
+            ProjectManager instance
+        """
+        return ProjectManager(workspace_root=workspace_root)
+
+    @pytest.fixture
+    def engine(self, workspace_root: Path, project_manager: ProjectManager) -> PhaseStateEngine:
+        """Create PhaseStateEngine instance.
+
+        Args:
+            workspace_root: Path to workspace root
+            project_manager: ProjectManager instance
+
+        Returns:
+            PhaseStateEngine instance
+        """
+        return PhaseStateEngine(workspace_root=workspace_root, project_manager=project_manager)
+
+    def test_initialize_branch_creates_tdd_cycle_fields(
+        self, engine: PhaseStateEngine, project_manager: ProjectManager
+    ) -> None:
+        """Test initialize_branch creates tdd_cycle_* fields.
+
+        Issue #146: current_tdd_cycle, last_tdd_cycle, tdd_cycle_history must be initialized.
+        """
+        # Setup - create project
+        project_manager.initialize_project(
+            issue_number=146, issue_title="TDD Cycle Tracking", workflow_name="feature"
+        )
+
+        # Execute - initialize branch
+        result = engine.initialize_branch(
+            branch="feature/146-tdd-cycle-tracking", issue_number=146, initial_phase="research"
+        )
+
+        # Verify - result contains success
+        assert result["success"] is True
+
+        # Verify - state.json contains tdd_cycle_* fields
+        state = engine.get_state("feature/146-tdd-cycle-tracking")
+        assert "current_tdd_cycle" in state
+        assert "last_tdd_cycle" in state
+        assert "tdd_cycle_history" in state
+
+        # Verify - initial values
+        assert state["current_tdd_cycle"] is None
+        assert state["last_tdd_cycle"] is None
+        assert state["tdd_cycle_history"] == []
+
+    def test_reconstruct_state_includes_tdd_cycle_fields(
+        self, engine: PhaseStateEngine, project_manager: ProjectManager, workspace_root: Path
+    ) -> None:
+        """Test auto-recovery includes tdd_cycle_* fields.
+
+        Issue #146: Reconstructed state must include TDD cycle tracking fields.
+        """
+        # Setup - create project
+        project_manager.initialize_project(
+            issue_number=146, issue_title="TDD Cycle Tracking", workflow_name="feature"
+        )
+
+        # Simulate cross-machine: delete state.json
+        state_file = workspace_root / ".st3" / "state.json"
+        if state_file.exists():
+            state_file.unlink()
+
+        # Execute - get_state triggers auto-recovery
+        state = engine.get_state("feature/146-tdd-cycle-tracking")
+
+        # Verify - reconstructed flag
+        assert state["reconstructed"] is True
+
+        # Verify - tdd_cycle_* fields present
+        assert "current_tdd_cycle" in state
+        assert "last_tdd_cycle" in state
+        assert "tdd_cycle_history" in state
+
+        # Verify - initial values (None/[])
+        assert state["current_tdd_cycle"] is None
+        assert state["last_tdd_cycle"] is None
+        assert state["tdd_cycle_history"] == []
+
+
+class TestCycleValidationLogic:
+    """Test TDD cycle validation helpers.
+
+    Issue #146 Cycle 2: Validation logic for cycle transitions.
+    """
+
+    @pytest.fixture
+    def workspace_root(self, tmp_path: Path) -> Path:
+        """Create temporary workspace.
+
+        Args:
+            tmp_path: Pytest tmp_path fixture
+
+        Returns:
+            Path to temporary workspace root
+        """
+        return tmp_path
+
+    @pytest.fixture
+    def project_manager(self, workspace_root: Path) -> ProjectManager:
+        """Create ProjectManager instance.
+
+        Args:
+            workspace_root: Path to workspace root
+
+        Returns:
+            ProjectManager instance
+        """
+        return ProjectManager(workspace_root=workspace_root)
+
+    @pytest.fixture
+    def engine(self, workspace_root: Path, project_manager: ProjectManager) -> PhaseStateEngine:
+        """Create PhaseStateEngine instance.
+
+        Args:
+            workspace_root: Path to workspace root
+            project_manager: ProjectManager instance
+
+        Returns:
+            PhaseStateEngine instance
+        """
+        return PhaseStateEngine(workspace_root=workspace_root, project_manager=project_manager)
+
+    def test_validate_cycle_number_range_rejects_zero(
+        self, engine: PhaseStateEngine, project_manager: ProjectManager
+    ) -> None:
+        """Test cycle number validation rejects zero.
+
+        Issue #146 Cycle 2: cycle_number must be in range [1..total].
+        """
+        # Setup - create project with 4 cycles
+        project_manager.initialize_project(
+            issue_number=146, issue_title="TDD Cycle Tracking", workflow_name="feature"
+        )
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": i,
+                        "deliverables": [f"Deliverable {i}"],
+                        "exit_criteria": f"Criteria {i}",
+                    }
+                    for i in range(1, 5)
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(146, planning_deliverables)
+
+        # Act & Assert - cycle_number 0 should raise
+        with pytest.raises(ValueError, match="cycle_number must be in range \\[1\\.\\.4\\]"):
+            engine._validate_cycle_number_range(cycle_number=0, issue_number=146)
+
+    def test_validate_cycle_number_range_rejects_negative(
+        self, engine: PhaseStateEngine, project_manager: ProjectManager
+    ) -> None:
+        """Test cycle number validation rejects negative numbers.
+
+        Issue #146 Cycle 2: cycle_number must be positive.
+        """
+        # Setup
+        project_manager.initialize_project(
+            issue_number=146, issue_title="TDD Cycle Tracking", workflow_name="feature"
+        )
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": i,
+                        "deliverables": [f"Deliverable {i}"],
+                        "exit_criteria": f"Criteria {i}",
+                    }
+                    for i in range(1, 5)
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(146, planning_deliverables)
+
+        # Act & Assert - negative cycle_number should raise
+        with pytest.raises(ValueError, match="cycle_number must be in range \\[1\\.\\.4\\]"):
+            engine._validate_cycle_number_range(cycle_number=-1, issue_number=146)
+
+    def test_validate_cycle_number_range_rejects_exceeds_total(
+        self, engine: PhaseStateEngine, project_manager: ProjectManager
+    ) -> None:
+        """Test cycle number validation rejects numbers exceeding total.
+
+        Issue #146 Cycle 2: cycle_number must not exceed total planned cycles.
+        """
+        # Setup
+        project_manager.initialize_project(
+            issue_number=146, issue_title="TDD Cycle Tracking", workflow_name="feature"
+        )
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": i,
+                        "deliverables": [f"Deliverable {i}"],
+                        "exit_criteria": f"Criteria {i}",
+                    }
+                    for i in range(1, 5)
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(146, planning_deliverables)
+
+        # Act & Assert - cycle_number 5 (> 4) should raise
+        with pytest.raises(ValueError, match="cycle_number must be in range \\[1\\.\\.4\\]"):
+            engine._validate_cycle_number_range(cycle_number=5, issue_number=146)
+
+    def test_validate_cycle_number_range_accepts_valid_range(
+        self, engine: PhaseStateEngine, project_manager: ProjectManager
+    ) -> None:
+        """Test cycle number validation accepts valid range [1..total].
+
+        Issue #146 Cycle 2: Valid cycle numbers should pass without error.
+        """
+        # Setup
+        project_manager.initialize_project(
+            issue_number=146, issue_title="TDD Cycle Tracking", workflow_name="feature"
+        )
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": i,
+                        "deliverables": [f"Deliverable {i}"],
+                        "exit_criteria": f"Criteria {i}",
+                    }
+                    for i in range(1, 5)
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(146, planning_deliverables)
+
+        # Act & Assert - all valid cycle numbers should pass
+        for cycle_num in [1, 2, 3, 4]:
+            engine._validate_cycle_number_range(
+                cycle_number=cycle_num, issue_number=146
+            )  # Should not raise
+
+    def test_validate_planning_deliverables_exist_raises_if_missing(
+        self, engine: PhaseStateEngine, project_manager: ProjectManager
+    ) -> None:
+        """Test validation raises if planning_deliverables not found.
+
+        Issue #146 Cycle 2: Cannot transition cycles without planning deliverables.
+        """
+        # Setup - project WITHOUT planning deliverables
+        project_manager.initialize_project(
+            issue_number=147, issue_title="No Planning", workflow_name="bug"
+        )
+
+        # Act & Assert - should raise descriptive error
+        with pytest.raises(ValueError, match="Planning deliverables not found for issue 147"):
+            engine._validate_planning_deliverables_exist(issue_number=147)
+
+    def test_validate_planning_deliverables_exist_passes_if_present(
+        self, engine: PhaseStateEngine, project_manager: ProjectManager
+    ) -> None:
+        """Test validation passes if planning_deliverables exist.
+
+        Issue #146 Cycle 2: Should not raise if deliverables are present.
+        """
+        # Setup - project WITH planning deliverables
+        project_manager.initialize_project(
+            issue_number=146, issue_title="TDD Cycle Tracking", workflow_name="feature"
+        )
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": i,
+                        "deliverables": [f"Deliverable {i}"],
+                        "exit_criteria": f"Criteria {i}",
+                    }
+                    for i in range(1, 5)
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(146, planning_deliverables)
+
+        # Act & Assert - should not raise
+        engine._validate_planning_deliverables_exist(issue_number=146)

--- a/tests/unit/mcp_server/managers/test_phase_state_engine_c2.py
+++ b/tests/unit/mcp_server/managers/test_phase_state_engine_c2.py
@@ -1,0 +1,226 @@
+"""Tests for PhaseStateEngine gate relocation (Issue #229 Cycle 2).
+
+GAP-01: Planning exit is silent — add on_exit_planning_phase hard gate.
+GAP-02: planning_deliverables check in on_enter_tdd_phase is wrong layer —
+        remove it there; gate belongs at planning exit, not TDD entry.
+
+C2 Deliverables:
+  D2.1: on_exit_planning_phase wired to WorkphasesConfig + DeliverableChecker (Option B).
+  D2.2: on_enter_tdd_phase no longer raises when planning_deliverables absent.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from mcp_server.managers.phase_state_engine import PhaseStateEngine
+from mcp_server.managers.project_manager import ProjectManager
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> Path:
+    """Temporary workspace root with .st3/workphases.yaml providing exit_requires."""
+    st3 = tmp_path / ".st3"
+    st3.mkdir()
+    (st3 / "workphases.yaml").write_text(
+        """
+phases:
+  planning:
+    display_name: "Planning"
+    exit_requires:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown"
+  tdd:
+    display_name: "TDD"
+    entry_expects:
+      - key: "planning_deliverables"
+        description: "Expected from planning"
+  design:
+    display_name: "Design"
+"""
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def project_manager(workspace_root: Path) -> ProjectManager:
+    """ProjectManager bound to tmp workspace."""
+    return ProjectManager(workspace_root=workspace_root)
+
+
+@pytest.fixture
+def engine(workspace_root: Path, project_manager: ProjectManager) -> PhaseStateEngine:
+    """PhaseStateEngine bound to tmp workspace."""
+    return PhaseStateEngine(workspace_root=workspace_root, project_manager=project_manager)
+
+
+# ---------------------------------------------------------------------------
+# C2 — on_exit_planning_phase (GAP-01)
+# ---------------------------------------------------------------------------
+
+
+class TestOnExitPlanningPhase:
+    """on_exit_planning_phase uses WorkphasesConfig + DeliverableChecker (Option B)."""
+
+    def test_on_exit_planning_phase_raises_when_planning_deliverables_absent(
+        self,
+        engine: PhaseStateEngine,
+        project_manager: ProjectManager,
+    ) -> None:
+        """on_exit_planning_phase raises ValueError when planning_deliverables absent.
+
+        Issue #229 C2 — GAP-01: gate must fire at planning exit, not silently pass.
+        """
+        project_manager.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        # No planning_deliverables saved → exit_requires key missing → should raise
+        with pytest.raises(ValueError, match="planning_deliverables"):
+            engine.on_exit_planning_phase(branch="feature/229-test", issue_number=229)
+
+    def test_on_exit_planning_phase_passes_when_planning_deliverables_present(
+        self,
+        engine: PhaseStateEngine,
+        project_manager: ProjectManager,
+    ) -> None:
+        """on_exit_planning_phase passes silently when planning_deliverables present.
+
+        Issue #229 C2: gate must not block valid transitions.
+        """
+        project_manager.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        project_manager.save_planning_deliverables(
+            229,
+            {
+                "tdd_cycles": {
+                    "total": 1,
+                    "cycles": [{"cycle_number": 1, "deliverables": ["D1"], "exit_criteria": "x"}],
+                }
+            },
+        )
+        # Should not raise
+        engine.on_exit_planning_phase(branch="feature/229-test", issue_number=229)
+
+    def test_on_exit_planning_phase_uses_workphases_config_for_required_keys(
+        self,
+        engine: PhaseStateEngine,
+        project_manager: ProjectManager,
+        workspace_root: Path,
+    ) -> None:
+        """on_exit_planning_phase reads exit_requires from workphases.yaml, not hardcoded.
+
+        Issue #229 C2 — D2.1: gate is WorkphasesConfig-driven (Option B).
+        A phase with no exit_requires in workphases.yaml must pass unconditionally.
+        """
+        # Write workphases.yaml WITHOUT exit_requires on planning
+        (workspace_root / ".st3" / "workphases.yaml").write_text(
+            "phases:\n  planning:\n    display_name: Planning\n"
+        )
+        project_manager.initialize_project(
+            issue_number=230,
+            issue_title="No planning gate",
+            workflow_name="feature",
+        )
+        # No planning_deliverables AND no exit_requires → must NOT raise
+        engine.on_exit_planning_phase(branch="feature/230-test", issue_number=230)
+
+    def test_on_exit_planning_phase_runs_deliverable_checker_on_validates_entries(
+        self,
+        engine: PhaseStateEngine,
+        project_manager: ProjectManager,
+    ) -> None:
+        """on_exit_planning_phase runs DeliverableChecker on planning_deliverables.validates.
+
+        Issue #229 C2 — D2.1: wired to structural checker (Option B full flow).
+        A validates entry that fails must propagate as DeliverableCheckError (ValueError).
+        """
+        project_manager.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        # planning_deliverables exists but has a failing validates entry
+        project_manager.save_planning_deliverables(
+            229,
+            {
+                "tdd_cycles": {
+                    "total": 1,
+                    "cycles": [{"cycle_number": 1, "deliverables": ["D1"], "exit_criteria": "x"}],
+                },
+                "validates": [
+                    {
+                        "id": "gate-check",
+                        "type": "file_exists",
+                        "file": "nonexistent/missing.py",
+                    }
+                ],
+            },
+        )
+        # DeliverableChecker must raise on the failing file_exists
+        with pytest.raises(ValueError, match="gate-check"):
+            engine.on_exit_planning_phase(branch="feature/229-test", issue_number=229)
+
+
+# ---------------------------------------------------------------------------
+# C2 — on_enter_tdd_phase no longer checks planning_deliverables (GAP-02)
+# ---------------------------------------------------------------------------
+
+
+class TestOnEnterTddPhaseGateRemoved:
+    """on_enter_tdd_phase must not check planning_deliverables (gate moved to exit)."""
+
+    def test_on_enter_tdd_phase_does_not_raise_when_planning_deliverables_absent(
+        self,
+        engine: PhaseStateEngine,
+        project_manager: ProjectManager,
+    ) -> None:
+        """on_enter_tdd_phase no longer raises when planning_deliverables absent.
+
+        Issue #229 C2 — GAP-02: planning gate moved to on_exit_planning_phase.
+        TDD entry only initializes cycle state; it must not re-validate planning.
+        """
+        project_manager.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        engine.initialize_branch(
+            branch="feature/229-test",
+            issue_number=229,
+            initial_phase="tdd",
+        )
+        # No planning_deliverables → must NOT raise after GAP-02 fix
+        engine.on_enter_tdd_phase(branch="feature/229-test", issue_number=229)
+
+    def test_transition_from_planning_calls_exit_planning_gate(
+        self,
+        engine: PhaseStateEngine,
+        project_manager: ProjectManager,
+    ) -> None:
+        """transition() from planning calls on_exit_planning_phase gate.
+
+        Issue #229 C2: gate is wired into transition() dispatch so it cannot be
+        bypassed by callers who call transition() directly.
+        """
+        project_manager.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        engine.initialize_branch(
+            branch="feature/229-test",
+            issue_number=229,
+            initial_phase="planning",
+        )
+        # No planning_deliverables → transition from planning must raise via gate
+        with pytest.raises(ValueError, match="planning_deliverables"):
+            engine.transition(branch="feature/229-test", to_phase="design")

--- a/tests/unit/mcp_server/managers/test_phase_state_engine_c3.py
+++ b/tests/unit/mcp_server/managers/test_phase_state_engine_c3.py
@@ -1,0 +1,276 @@
+"""Tests for PhaseStateEngine force_transition skipped-gate warning (Issue #229 Cycle 3).
+
+GAP-03: Forced transitions bypass all hooks and deliverable checks with no warning.
+
+C3 Deliverables:
+  D3.1: force_transition logs warning listing skipped_gates when gates exist.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from mcp_server.managers.phase_state_engine import PhaseStateEngine
+from mcp_server.managers.project_manager import ProjectManager
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> Path:
+    """Workspace root with workphases.yaml containing exit_requires + entry_expects."""
+    st3 = tmp_path / ".st3"
+    st3.mkdir()
+    (st3 / "workphases.yaml").write_text(
+        """
+phases:
+  planning:
+    display_name: "Planning"
+    exit_requires:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown"
+  tdd:
+    display_name: "TDD"
+    entry_expects:
+      - key: "planning_deliverables"
+        description: "Expected from planning"
+  design:
+    display_name: "Design"
+  research:
+    display_name: "Research"
+"""
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def workspace_root_no_gates(tmp_path: Path) -> Path:
+    """Workspace root with workphases.yaml where phases have no gates."""
+    st3 = tmp_path / ".st3"
+    st3.mkdir()
+    (st3 / "workphases.yaml").write_text(
+        """
+phases:
+  research:
+    display_name: "Research"
+  planning:
+    display_name: "Planning"
+  design:
+    display_name: "Design"
+"""
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def project_manager_with_gates(workspace_root: Path) -> ProjectManager:
+    return ProjectManager(workspace_root=workspace_root)
+
+
+@pytest.fixture
+def engine_with_gates(
+    workspace_root: Path, project_manager_with_gates: ProjectManager
+) -> PhaseStateEngine:
+    return PhaseStateEngine(
+        workspace_root=workspace_root, project_manager=project_manager_with_gates
+    )
+
+
+@pytest.fixture
+def project_manager_no_gates(workspace_root_no_gates: Path) -> ProjectManager:
+    return ProjectManager(workspace_root=workspace_root_no_gates)
+
+
+@pytest.fixture
+def engine_no_gates(
+    workspace_root_no_gates: Path, project_manager_no_gates: ProjectManager
+) -> PhaseStateEngine:
+    return PhaseStateEngine(
+        workspace_root=workspace_root_no_gates, project_manager=project_manager_no_gates
+    )
+
+
+# ---------------------------------------------------------------------------
+# C3 — forced transition skipped-gate warning (GAP-03)
+# ---------------------------------------------------------------------------
+
+
+class TestForceTransitionSkippedGateWarning:
+    """force_transition logs warning when it bypasses exit or entry gates (GAP-03)."""
+
+    def test_force_transition_logs_warning_for_skipped_exit_gate(
+        self,
+        engine_with_gates: PhaseStateEngine,
+        project_manager_with_gates: ProjectManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """force_transition logs warning when from_phase has exit_requires (GAP-03).
+
+        Forcing planning → design bypasses the planning exit gate.
+        Warning must mention skipped_gates.
+        """
+        project_manager_with_gates.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        engine_with_gates.initialize_branch(
+            branch="feature/229-c3",
+            issue_number=229,
+            initial_phase="planning",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mcp_server.managers.phase_state_engine"):
+            engine_with_gates.force_transition(
+                branch="feature/229-c3",
+                to_phase="design",
+                skip_reason="test: skip exit gate",
+                human_approval="tester approved",
+            )
+
+        assert "skipped_gates" in caplog.text
+
+    def test_force_transition_logs_warning_for_skipped_entry_expects(
+        self,
+        engine_with_gates: PhaseStateEngine,
+        project_manager_with_gates: ProjectManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """force_transition logs warning when to_phase has entry_expects (GAP-03).
+
+        Forcing research → tdd bypasses the tdd entry expects check.
+        Warning must mention skipped_gates.
+        """
+        project_manager_with_gates.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        engine_with_gates.initialize_branch(
+            branch="feature/229-c3b",
+            issue_number=229,
+            initial_phase="research",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mcp_server.managers.phase_state_engine"):
+            engine_with_gates.force_transition(
+                branch="feature/229-c3b",
+                to_phase="tdd",
+                skip_reason="test: skip entry expects",
+                human_approval="tester approved",
+            )
+
+        assert "skipped_gates" in caplog.text
+
+    def test_force_transition_without_gates_logs_no_warning(
+        self,
+        engine_no_gates: PhaseStateEngine,
+        project_manager_no_gates: ProjectManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """force_transition stays silent when neither phase has gates (GAP-03).
+
+        Forcing research → planning when neither has exit_requires or entry_expects
+        must not produce a skipped_gates warning.
+        """
+        project_manager_no_gates.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        engine_no_gates.initialize_branch(
+            branch="feature/229-c3c",
+            issue_number=229,
+            initial_phase="research",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mcp_server.managers.phase_state_engine"):
+            engine_no_gates.force_transition(
+                branch="feature/229-c3c",
+                to_phase="planning",
+                skip_reason="test: no gates present",
+                human_approval="tester approved",
+            )
+
+        assert "skipped_gates" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# C3 bugfix: warning must be silent when deliverables ARE present in projects.json
+# ---------------------------------------------------------------------------
+
+
+class TestForceTransitionNoWarningWhenDeliverablesPresent:
+    """Warning must NOT fire when the gated deliverable key exists in projects.json (GAP-03 bugfix).
+
+    The original implementation warned based on config presence alone.
+    The correct behaviour: only warn when the key is actually absent from projects.json.
+    """
+
+    def _setup(
+        self, workspace_root: Path, initial_phase: str
+    ) -> tuple[ProjectManager, PhaseStateEngine, str]:
+        """Initialize project + branch and inject planning_deliverables directly."""
+        pm = ProjectManager(workspace_root=workspace_root)
+        pm.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        # Inject the key directly (bypasses schema validation — tests engine check logic only)
+        projects = json.loads(pm.projects_file.read_text(encoding="utf-8"))
+        projects["229"]["planning_deliverables"] = {"tdd_cycles": {"total": 1, "cycles": []}}
+        pm.projects_file.write_text(json.dumps(projects, indent=2))
+
+        engine = PhaseStateEngine(workspace_root=workspace_root, project_manager=pm)
+        branch = "feature/229-bugfix"
+        engine.initialize_branch(branch=branch, issue_number=229, initial_phase=initial_phase)
+        return pm, engine, branch
+
+    def test_force_transition_no_warning_when_exit_key_present(
+        self,
+        workspace_root: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No skipped_gates warning when exit_requires key exists in projects.json.
+
+        Scenario: planning → design forced, planning_deliverables IS saved.
+        Expected: transition succeeds silently (no ⚠️).
+        """
+        _, engine, branch = self._setup(workspace_root, initial_phase="planning")
+
+        with caplog.at_level(logging.WARNING, logger="mcp_server.managers.phase_state_engine"):
+            engine.force_transition(
+                branch=branch,
+                to_phase="design",
+                skip_reason="test: deliverables present",
+                human_approval="tester approved",
+            )
+
+        assert "skipped_gates" not in caplog.text
+
+    def test_force_transition_no_warning_when_entry_key_present(
+        self,
+        workspace_root: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No skipped_gates warning when entry_expects key exists in projects.json.
+
+        Scenario: planning → tdd forced, planning_deliverables IS saved.
+        Expected: transition succeeds silently (no ⚠️).
+        """
+        _, engine, branch = self._setup(workspace_root, initial_phase="planning")
+
+        with caplog.at_level(logging.WARNING, logger="mcp_server.managers.phase_state_engine"):
+            engine.force_transition(
+                branch=branch,
+                to_phase="tdd",
+                skip_reason="test: deliverables present, entry gate should be silent",
+                human_approval="tester approved",
+            )
+
+        assert "skipped_gates" not in caplog.text

--- a/tests/unit/mcp_server/managers/test_phase_state_engine_recovery.py
+++ b/tests/unit/mcp_server/managers/test_phase_state_engine_recovery.py
@@ -10,6 +10,7 @@ Tests verify:
 5. Reconstructed flag set for audit
 6. Safe fallback to first phase
 """
+
 from pathlib import Path
 from unittest.mock import patch
 
@@ -34,9 +35,7 @@ class TestPhaseStateEngineMode2:
         manager = ProjectManager(workspace_root=workspace_root)
         # Initialize project for testing
         manager.initialize_project(
-            issue_number=39,
-            issue_title="Test auto-recovery",
-            workflow_name="bug"
+            issue_number=39, issue_title="Test auto-recovery", workflow_name="bug"
         )
         return manager
 
@@ -45,10 +44,7 @@ class TestPhaseStateEngineMode2:
         self, workspace_root: Path, project_manager: ProjectManager
     ) -> PhaseStateEngine:
         """Create PhaseStateEngine instance."""
-        return PhaseStateEngine(
-            workspace_root=workspace_root,
-            project_manager=project_manager
-        )
+        return PhaseStateEngine(workspace_root=workspace_root, project_manager=project_manager)
 
     @pytest.mark.asyncio
     async def test_missing_state_triggers_reconstruction(
@@ -65,11 +61,11 @@ class TestPhaseStateEngineMode2:
             state_file.unlink()
 
         # Mock git to return commits with phase labels
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = [
                 "phase:design - Complete technical specifications",
                 "phase:planning - Define implementation goals",
-                "phase:research - Analyze problem"
+                "phase:research - Analyze problem",
             ]
 
             # Call get_state - should auto-recover
@@ -97,9 +93,9 @@ class TestPhaseStateEngineMode2:
             state_file.unlink()
 
         # Mock commits with phase:label format (labels.yaml SSOT)
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = [
-                "phase:integration - Test cross-machine scenario",
+                "phase:validation - Test cross-machine scenario",
                 "phase:green - Implement feature",
                 "phase:red - Write failing test",
                 "phase:design - Complete design",
@@ -108,7 +104,7 @@ class TestPhaseStateEngineMode2:
             state = state_engine.get_state("fix/39-test")
 
             # Should detect most recent phase
-            assert state["current_phase"] == "integration"
+            assert state["current_phase"] == "validation"
 
     @pytest.mark.asyncio
     async def test_tdd_phases_map_to_tdd(
@@ -119,11 +115,11 @@ class TestPhaseStateEngineMode2:
         if state_file.exists():
             state_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = [
                 "phase:green - Implement Mode 1",
                 "phase:red - Write failing tests",
-                "phase:design - Complete specs"
+                "phase:design - Complete specs",
             ]
 
             state = state_engine.get_state("fix/39-test")
@@ -142,11 +138,11 @@ class TestPhaseStateEngineMode2:
         if state_file.exists():
             state_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = [
                 "Initial commit",
                 "Add README",
-                "Setup project"
+                "Setup project",
             ]
 
             state = state_engine.get_state("fix/39-test")
@@ -166,7 +162,7 @@ class TestPhaseStateEngineMode2:
         if state_file.exists():
             state_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = ["phase:planning - Define goals"]
 
             # Should not raise any exceptions
@@ -184,7 +180,7 @@ class TestPhaseStateEngineMode2:
         if state_file.exists():
             state_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = ["phase:research - Start work"]
 
             state = state_engine.get_state("fix/39-test-recovery")
@@ -206,7 +202,7 @@ class TestPhaseStateEngineMode2:
         if projects_file.exists():
             projects_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = ["phase:research - Start"]
 
             # Should raise ValueError with helpful message
@@ -222,7 +218,7 @@ class TestPhaseStateEngineMode2:
         if state_file.exists():
             state_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = ["phase:research - Start"]
 
             # Invalid branch name (no issue number)
@@ -238,7 +234,7 @@ class TestPhaseStateEngineMode2:
         if state_file.exists():
             state_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.side_effect = RuntimeError("Git command failed")
 
             # Should not crash, fallback to first phase
@@ -258,7 +254,7 @@ class TestPhaseStateEngineMode2:
         if state_file.exists():
             state_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             mock_git.return_value = ["phase:design - Complete specs"]
 
             # First call - reconstruction
@@ -281,11 +277,11 @@ class TestPhaseStateEngineMode2:
         if state_file.exists():
             state_file.unlink()
 
-        with patch.object(state_engine, '_get_git_commits') as mock_git:
+        with patch.object(state_engine, "_get_git_commits") as mock_git:
             # phase:invalid not in bug workflow
             mock_git.return_value = [
                 "phase:invalid - This should be ignored",
-                "phase:design - Valid phase"
+                "phase:design - Valid phase",
             ]
 
             state = state_engine.get_state("fix/39-test")

--- a/tests/unit/mcp_server/tools/test_force_phase_transition_tool.py
+++ b/tests/unit/mcp_server/tools/test_force_phase_transition_tool.py
@@ -4,7 +4,9 @@ Issue #50 - Step 4: Force Transition Tool
 
 Tests MCP tool that exposes PhaseStateEngine.force_transition() to users.
 Allows non-sequential phase transitions with skip_reason and approval.
+Issue #229 Cycle 10: GAP-17 — blocking gates must appear BEFORE ✅ in response.
 """
+
 from pathlib import Path
 
 import pytest
@@ -35,9 +37,7 @@ class TestForcePhaseTransitionTool:
         self, workspace_root: Path, project_manager: ProjectManager
     ) -> PhaseStateEngine:
         """Create PhaseStateEngine instance."""
-        return PhaseStateEngine(
-            workspace_root=workspace_root, project_manager=project_manager
-        )
+        return PhaseStateEngine(workspace_root=workspace_root, project_manager=project_manager)
 
     @pytest.fixture
     def tool(self, workspace_root: Path) -> ForcePhaseTransitionTool:
@@ -49,14 +49,12 @@ class TestForcePhaseTransitionTool:
         self,
         project_manager: ProjectManager,
         phase_engine: PhaseStateEngine,
-        feature_phases: list[str]
+        feature_phases: list[str],
     ) -> str:
         """Initialize a project and branch for testing."""
         # Initialize project
         project_manager.initialize_project(
-            issue_number=42,
-            issue_title="Test feature",
-            workflow_name="feature"
+            issue_number=42, issue_title="Test feature", workflow_name="feature"
         )
 
         # Initialize branch
@@ -64,7 +62,7 @@ class TestForcePhaseTransitionTool:
         phase_engine.initialize_branch(
             branch=branch,
             issue_number=42,
-            initial_phase=feature_phases[0]  # discovery
+            initial_phase=feature_phases[0],  # discovery
         )
 
         return branch
@@ -75,7 +73,7 @@ class TestForcePhaseTransitionTool:
         tool: ForcePhaseTransitionTool,
         initialized_branch: str,
         phase_engine: PhaseStateEngine,
-        feature_phases: list[str]
+        feature_phases: list[str],
     ) -> None:
         """Test successful forced transition (discovery → design, skips planning)."""
         # Execute tool (force skip planning)
@@ -83,7 +81,7 @@ class TestForcePhaseTransitionTool:
             branch=initialized_branch,
             to_phase=feature_phases[2],  # design
             skip_reason="Planning already done in previous project",
-            human_approval="Approved: Skip planning phase"
+            human_approval="Approved: Skip planning phase",
         )
 
         result = await tool.execute(params)
@@ -104,9 +102,7 @@ class TestForcePhaseTransitionTool:
         assert transition["skip_reason"] == "Planning already done in previous project"
 
     def test_force_phase_transition_tool_requires_skip_reason(
-        self,
-        initialized_branch: str,
-        feature_phases: list[str]
+        self, initialized_branch: str, feature_phases: list[str]
     ) -> None:
         """Test tool requires skip_reason parameter."""
         # Empty skip_reason should be rejected
@@ -115,13 +111,11 @@ class TestForcePhaseTransitionTool:
                 branch=initialized_branch,
                 to_phase=feature_phases[2],  # design
                 skip_reason="",
-                human_approval="Approved"
+                human_approval="Approved",
             )
 
     def test_force_phase_transition_tool_requires_human_approval(
-        self,
-        initialized_branch: str,
-        feature_phases: list[str]
+        self, initialized_branch: str, feature_phases: list[str]
     ) -> None:
         """Test tool requires human_approval parameter."""
         with pytest.raises(ValueError, match="cannot be empty"):
@@ -129,21 +123,19 @@ class TestForcePhaseTransitionTool:
                 branch=initialized_branch,
                 to_phase=feature_phases[2],  # design
                 skip_reason="Planning done",
-                human_approval=""
+                human_approval="",
             )
 
     @pytest.mark.asyncio
     async def test_force_phase_transition_tool_unknown_branch(
-        self,
-        tool: ForcePhaseTransitionTool,
-        feature_phases: list[str]
+        self, tool: ForcePhaseTransitionTool, feature_phases: list[str]
     ) -> None:
         """Test tool handles unknown branch gracefully."""
         params = ForcePhaseTransitionInput(
             branch="feature/999-unknown",
             to_phase=feature_phases[2],  # design
             skip_reason="Testing error handling",
-            human_approval="Approved"
+            human_approval="Approved",
         )
 
         result = await tool.execute(params)
@@ -158,14 +150,14 @@ class TestForcePhaseTransitionTool:
         tool: ForcePhaseTransitionTool,
         initialized_branch: str,
         phase_engine: PhaseStateEngine,
-        feature_phases: list[str]
+        feature_phases: list[str],
     ) -> None:
         """Test tool allows any transition (even backward)."""
         # Move to planning first
         phase_engine.transition(
             branch=initialized_branch,
             to_phase=feature_phases[1],  # planning
-            human_approval="Normal transition"
+            human_approval="Normal transition",
         )
 
         # Force backward transition (planning → discovery)
@@ -173,7 +165,7 @@ class TestForcePhaseTransitionTool:
             branch=initialized_branch,
             to_phase=feature_phases[0],  # discovery (Backward!)
             skip_reason="Need to revisit discovery phase",
-            human_approval="Approved: Return to discovery"
+            human_approval="Approved: Return to discovery",
         )
 
         result = await tool.execute(params)
@@ -183,8 +175,7 @@ class TestForcePhaseTransitionTool:
         assert phase_engine.get_current_phase(initialized_branch) == feature_phases[0]  # discovery
 
     def test_force_phase_transition_tool_input_model_validation(
-        self,
-        feature_phases: list[str]
+        self, feature_phases: list[str]
     ) -> None:
         """Test input model has correct field types and requirements."""
         # Valid input
@@ -192,10 +183,243 @@ class TestForcePhaseTransitionTool:
             branch="feature/42-test",
             to_phase=feature_phases[2],  # design
             skip_reason="Valid reason",
-            human_approval="Approved"
+            human_approval="Approved",
         )
 
         assert valid.branch == "feature/42-test"
         assert valid.to_phase == feature_phases[2]  # design
         assert valid.skip_reason == "Valid reason"
         assert valid.human_approval == "Approved"
+
+
+# ---------------------------------------------------------------------------
+# C3 extension: skipped-gates warning surfaced in tool response (GAP-03 Optie 1)
+# ---------------------------------------------------------------------------
+
+
+class TestForcePhaseTransitionToolSkippedGatesResponse:
+    """Test that tool response includes skipped-gates warning when gates are bypassed."""
+
+    @pytest.fixture
+    def workspace_with_gates(self, tmp_path: Path) -> Path:
+        """Workspace with workphases.yaml that has exit_requires on planning."""
+        st3 = tmp_path / ".st3"
+        st3.mkdir()
+        (st3 / "workphases.yaml").write_text(
+            """
+phases:
+  planning:
+    display_name: "Planning"
+    exit_requires:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown"
+  design:
+    display_name: "Design"
+"""
+        )
+        return tmp_path
+
+    @pytest.fixture
+    def workspace_no_gates(self, tmp_path: Path) -> Path:
+        """Workspace with workphases.yaml that has no gates defined."""
+        st3 = tmp_path / ".st3"
+        st3.mkdir()
+        (st3 / "workphases.yaml").write_text(
+            """
+phases:
+  planning:
+    display_name: "Planning"
+  design:
+    display_name: "Design"
+"""
+        )
+        return tmp_path
+
+    def _init_branch(self, workspace: Path, branch: str, phase: str) -> None:
+        """Helper: initialize project + branch state."""
+        pm = ProjectManager(workspace_root=workspace)
+        pm.initialize_project(issue_number=42, issue_title="Test", workflow_name="feature")
+        engine = PhaseStateEngine(workspace_root=workspace, project_manager=pm)
+        engine.initialize_branch(branch=branch, issue_number=42, initial_phase=phase)
+
+    @pytest.mark.asyncio
+    async def test_force_transition_tool_response_includes_skipped_gates_warning(
+        self, workspace_with_gates: Path
+    ) -> None:
+        """Tool response includes ⚠️ skipped gates line when gates are bypassed (GAP-03)."""
+        branch = "feature/42-test"
+        self._init_branch(workspace_with_gates, branch, "planning")
+
+        tool = ForcePhaseTransitionTool(workspace_root=workspace_with_gates)
+        params = ForcePhaseTransitionInput(
+            branch=branch,
+            to_phase="design",
+            skip_reason="Emergency skip",
+            human_approval="Michel approved on 2026-02-19",
+        )
+
+        result = await tool.execute(params)
+
+        text = result.content[0]["text"]
+        assert "✅" in text
+        assert "⚠️" in text
+        assert "skipped" in text.lower()
+        assert "planning_deliverables" in text
+
+    @pytest.mark.asyncio
+    async def test_force_transition_tool_response_no_warning_when_no_gates(
+        self, workspace_no_gates: Path
+    ) -> None:
+        """Tool response has no ⚠️ when neither phase has gates (GAP-03)."""
+        branch = "feature/42-test"
+        self._init_branch(workspace_no_gates, branch, "planning")
+
+        tool = ForcePhaseTransitionTool(workspace_root=workspace_no_gates)
+        params = ForcePhaseTransitionInput(
+            branch=branch,
+            to_phase="design",
+            skip_reason="Emergency skip",
+            human_approval="Michel approved on 2026-02-19",
+        )
+
+        result = await tool.execute(params)
+
+        text = result.content[0]["text"]
+        assert "✅" in text
+        assert "⚠️" not in text
+
+
+# ---------------------------------------------------------------------------
+# C10: GAP-17 — force transition response: blocking gates BEFORE ✅ (Issue #229)
+# ---------------------------------------------------------------------------
+
+
+class TestForceTransitionResponseFormat:
+    """Blocking gates appear BEFORE ✅; passing gates appear AFTER ✅ (Issue #229 C10, GAP-17).
+
+    D10.1: ⚠️ ACTION REQUIRED block emitted before ✅ when a gate would have blocked.
+    D10.2: ℹ️ informational block emitted after ✅ when a gate would have passed.
+    D10.3: No extra output when no gates defined.
+    """
+
+    def _setup_workspace(
+        self, tmp_path: Path, *, with_gate_key: bool = True
+    ) -> tuple[Path, str]:
+        """Build workspace with workphases.yaml gate + optional planning_deliverables key."""
+        st3 = tmp_path / ".st3"
+        st3.mkdir()
+        (st3 / "workphases.yaml").write_text(
+            """
+phases:
+  planning:
+    display_name: "Planning"
+    exit_requires:
+      - key: "planning_deliverables"
+        description: "TDD cycle breakdown"
+  design:
+    display_name: "Design"
+"""
+        )
+        branch = "feature/42-test"
+        pm = ProjectManager(workspace_root=tmp_path)
+        pm.initialize_project(issue_number=42, issue_title="Test", workflow_name="feature")
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=pm)
+        engine.initialize_branch(branch=branch, issue_number=42, initial_phase="planning")
+
+        if with_gate_key:
+            # Inject planning_deliverables so gate would have PASSED
+            projects_path = tmp_path / ".st3" / "projects.json"
+            import json
+
+            data = json.loads(projects_path.read_text())
+            data["42"]["planning_deliverables"] = {"tdd_cycles": {"total": 1, "cycles": []}}
+            projects_path.write_text(json.dumps(data, indent=2))
+
+        return tmp_path, branch
+
+    @pytest.mark.asyncio
+    async def test_force_phase_transition_response_blocking_gate_appears_before_success(
+        self, tmp_path: Path
+    ) -> None:
+        """Blocking gates (key absent) emit ⚠️ ACTION REQUIRED BEFORE ✅ (GAP-17/D10.1)."""
+        workspace, branch = self._setup_workspace(tmp_path, with_gate_key=False)  # key absent → BLOCKS
+        tool = ForcePhaseTransitionTool(workspace_root=workspace)
+        params = ForcePhaseTransitionInput(
+            branch=branch,
+            to_phase="design",
+            skip_reason="Force test",
+            human_approval="Approved",
+        )
+
+        result = await tool.execute(params)
+        text = result.content[0]["text"]
+
+        assert "ACTION REQUIRED" in text, f"Expected ACTION REQUIRED in response: {text}"
+        assert "✅" in text
+        # Blocking warning must appear BEFORE ✅
+        assert text.index("ACTION REQUIRED") < text.index("✅"), (
+            f"ACTION REQUIRED must precede ✅, got:\n{text}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_force_phase_transition_response_passing_gate_appears_after_success(
+        self, tmp_path: Path
+    ) -> None:
+        """Passing gates (key present) emitted as informational text AFTER ✅ (GAP-17/D10.2)."""
+        workspace, branch = self._setup_workspace(tmp_path, with_gate_key=True)  # key present → passes
+        tool = ForcePhaseTransitionTool(workspace_root=workspace)
+        params = ForcePhaseTransitionInput(
+            branch=branch,
+            to_phase="design",
+            skip_reason="Force test",
+            human_approval="Approved",
+        )
+
+        result = await tool.execute(params)
+        text = result.content[0]["text"]
+
+        assert "✅" in text
+        # planning_deliverables key should appear as informational AFTER ✅
+        assert "planning_deliverables" in text, (
+            f"Expected gate key in informational section: {text}"
+        )
+        assert text.index("✅") < text.index("planning_deliverables"), (
+            f"Informational gate must follow ✅, got:\n{text}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_force_phase_transition_response_no_gates_no_warning(
+        self, tmp_path: Path
+    ) -> None:
+        """No gates defined → only ✅ in response, no ⚠️ or ACTION REQUIRED (GAP-17/D10.3)."""
+        st3 = tmp_path / ".st3"
+        st3.mkdir()
+        (st3 / "workphases.yaml").write_text(
+            """
+phases:
+  planning:
+    display_name: "Planning"
+  design:
+    display_name: "Design"
+"""
+        )
+        branch = "feature/42-test"
+        pm = ProjectManager(workspace_root=tmp_path)
+        pm.initialize_project(issue_number=42, issue_title="Test", workflow_name="feature")
+        engine = PhaseStateEngine(workspace_root=tmp_path, project_manager=pm)
+        engine.initialize_branch(branch=branch, issue_number=42, initial_phase="planning")
+
+        tool = ForcePhaseTransitionTool(workspace_root=tmp_path)
+        params = ForcePhaseTransitionInput(
+            branch=branch,
+            to_phase="design",
+            skip_reason="Force test",
+            human_approval="Approved",
+        )
+
+        result = await tool.execute(params)
+        text = result.content[0]["text"]
+
+        assert "✅" in text
+        assert "ACTION REQUIRED" not in text, f"Unexpected ACTION REQUIRED: {text}"
+        assert "⚠️" not in text, f"Unexpected ⚠️: {text}"

--- a/tests/unit/mcp_server/tools/test_project_tools.py
+++ b/tests/unit/mcp_server/tools/test_project_tools.py
@@ -4,13 +4,28 @@ Issue #79: Tests for parent_branch in InitializeProjectTool.
 - Accepts explicit parent_branch parameter
 - Auto-detects parent_branch from git reflog (best effort)
 - Handles auto-detection failure gracefully
+
+Issue #229 Cycle 4: SavePlanningDeliverablesTool (D4.1/D4.2/D4.3/GAP-04/GAP-06).
+Issue #229 Cycle 5: UpdatePlanningDeliverablesTool (D5.1/D5.2/D5.3/GAP-09).
+Issue #229 Cycle 7: Per-phase deliverables schema in save_planning_deliverables (D7.1).
+Issue #229 Cycle 8: update_planning_deliverables per-phase merge + exit_criteria (D8.1/D8.2/D8.3/GAP-12/GAP-15).
 """
+
+import json
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from mcp_server.tools.project_tools import InitializeProjectInput, InitializeProjectTool
+from mcp_server.managers.project_manager import ProjectManager
+from mcp_server.tools.project_tools import (
+    InitializeProjectInput,
+    InitializeProjectTool,
+    SavePlanningDeliverablesInput,
+    SavePlanningDeliverablesTool,
+    UpdatePlanningDeliverablesInput,
+    UpdatePlanningDeliverablesTool,
+)
 
 
 class TestInitializeProjectToolParentBranch:
@@ -58,7 +73,7 @@ class TestInitializeProjectToolParentBranch:
                     issue_number=79,
                     issue_title="Test",
                     workflow_name="feature",
-                    parent_branch="epic/76-quality-gates"
+                    parent_branch="epic/76-quality-gates",
                 )
             )
 
@@ -69,25 +84,23 @@ class TestInitializeProjectToolParentBranch:
         assert '"parent_branch": "epic/76-quality-gates"' in content_text
 
     @pytest.mark.asyncio
-    async def test_initialize_auto_detects_parent_branch(
-        self, tool: InitializeProjectTool
-    ) -> None:
+    async def test_initialize_auto_detects_parent_branch(self, tool: InitializeProjectTool) -> None:
         """Test auto-detection of parent_branch via git reflog.
 
         Issue #79: If parent_branch not provided, auto-detect from git reflog.
         """
         # Mock git operations
-        with patch.object(tool.git_manager, "get_current_branch") as mock_branch, \
-             patch.object(tool, "_detect_parent_branch_from_reflog") as mock_detect:
+        with (
+            patch.object(tool.git_manager, "get_current_branch") as mock_branch,
+            patch.object(tool, "_detect_parent_branch_from_reflog") as mock_detect,
+        ):
             mock_branch.return_value = "feature/80-test"
             mock_detect.return_value = "main"  # Auto-detected
 
             # Execute - no parent_branch parameter
             result = await tool.execute(
                 InitializeProjectInput(
-                    issue_number=80,
-                    issue_title="Test Auto-detect",
-                    workflow_name="bug"
+                    issue_number=80, issue_title="Test Auto-detect", workflow_name="bug"
                 )
             )
 
@@ -106,17 +119,17 @@ class TestInitializeProjectToolParentBranch:
         Issue #79: If git reflog fails, parent_branch should be None.
         """
         # Mock git operations
-        with patch.object(tool.git_manager, "get_current_branch") as mock_branch, \
-             patch.object(tool, "_detect_parent_branch_from_reflog") as mock_detect:
+        with (
+            patch.object(tool.git_manager, "get_current_branch") as mock_branch,
+            patch.object(tool, "_detect_parent_branch_from_reflog") as mock_detect,
+        ):
             mock_branch.return_value = "feature/81-test"
             mock_detect.return_value = None  # Detection failed
 
             # Execute
             result = await tool.execute(
                 InitializeProjectInput(
-                    issue_number=81,
-                    issue_title="Test Failed Detect",
-                    workflow_name="docs"
+                    issue_number=81, issue_title="Test Failed Detect", workflow_name="docs"
                 )
             )
 
@@ -135,8 +148,10 @@ class TestInitializeProjectToolParentBranch:
         Issue #79: If parent_branch provided, don't call git reflog.
         """
         # Mock git operations
-        with patch.object(tool.git_manager, "get_current_branch") as mock_branch, \
-             patch.object(tool, "_detect_parent_branch_from_reflog") as mock_detect:
+        with (
+            patch.object(tool.git_manager, "get_current_branch") as mock_branch,
+            patch.object(tool, "_detect_parent_branch_from_reflog") as mock_detect,
+        ):
             mock_branch.return_value = "feature/82-test"
 
             # Execute with explicit parent_branch
@@ -145,7 +160,7 @@ class TestInitializeProjectToolParentBranch:
                     issue_number=82,
                     issue_title="Test Override",
                     workflow_name="feature",
-                    parent_branch="epic/special"
+                    parent_branch="epic/special",
                 )
             )
 
@@ -154,3 +169,679 @@ class TestInitializeProjectToolParentBranch:
         content_text = result.content[0]["text"]
         assert '"parent_branch": "epic/special"' in content_text
         mock_detect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_deliverables(validates: dict | None = None) -> dict:
+    """Return a minimal valid planning_deliverables dict with one cycle.
+
+    If *validates* is given it is attached to the single deliverable entry,
+    allowing L2 validation to be exercised.
+    """
+    deliverable: dict = {"id": "D1.1", "description": "placeholder"}
+    if validates is not None:
+        deliverable["validates"] = validates
+    return {
+        "tdd_cycles": {
+            "total": 1,
+            "cycles": [
+                {
+                    "cycle_number": 1,
+                    "deliverables": [deliverable],
+                    "exit_criteria": "Tests pass",
+                }
+            ],
+        }
+    }
+
+
+class TestSavePlanningDeliverablesTool:
+    """Tests for SavePlanningDeliverablesTool.
+
+    Issue #229 Cycle 4 (GAP-04 + GAP-06):
+    - D4.1: tool defined in project_tools.py
+    - D4.2: tool registered in server.py (integration test, see test_server_tool_registration.py)
+    - D4.3: Layer 2 validates-entry schema validation before persisting
+    """
+
+    @pytest.fixture()
+    def tool(self, tmp_path: Path) -> SavePlanningDeliverablesTool:
+        return SavePlanningDeliverablesTool(workspace_root=tmp_path)
+
+    @pytest.fixture()
+    def initialized(self, tmp_path: Path) -> tuple[Path, int]:
+        """Initialize a project so save_planning_deliverables can run."""
+        pm = ProjectManager(workspace_root=tmp_path)
+        pm.initialize_project(
+            issue_number=229,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        return tmp_path, 229
+
+    # ------------------------------------------------------------------
+    # D4.1: basic persistence
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio()
+    async def test_save_planning_deliverables_tool_persists_to_projects_json(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """Happy path: valid payload is written to projects.json. (D4.1)"""
+        workspace_root, issue_number = initialized
+        tool_with_root = SavePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool_with_root.execute(
+            SavePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables=_minimal_deliverables(),
+            )
+        )
+
+        assert not result.is_error, f"Expected success, got: {result.content}"
+        pm = ProjectManager(workspace_root=workspace_root)
+        plan = pm.get_project_plan(issue_number)
+        assert plan is not None
+        assert "planning_deliverables" in plan
+
+    @pytest.mark.asyncio()
+    async def test_save_planning_deliverables_tool_rejects_duplicate(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """Duplicate call is rejected with clear error."""
+        workspace_root, issue_number = initialized
+        tool = SavePlanningDeliverablesTool(workspace_root=workspace_root)
+        params = SavePlanningDeliverablesInput(
+            issue_number=issue_number,
+            planning_deliverables=_minimal_deliverables(),
+        )
+        await tool.execute(params)  # First call succeeds
+        result = await tool.execute(params)  # Second call must fail
+
+        assert result.is_error
+        assert "already exist" in result.content[0]["text"].lower()
+
+    @pytest.mark.asyncio()
+    async def test_save_planning_deliverables_tool_rejects_missing_tdd_cycles(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """Payload without tdd_cycles key is rejected."""
+        workspace_root, issue_number = initialized
+        tool = SavePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            SavePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={"notes": "forgot the tdd_cycles key"},
+            )
+        )
+
+        assert result.is_error
+        assert "tdd_cycles" in result.content[0]["text"]
+
+    # ------------------------------------------------------------------
+    # D4.3: Layer 2 validates-entry schema validation
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio()
+    async def test_save_planning_deliverables_tool_rejects_unknown_validates_type(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """validates entry with unknown type is rejected before persisting. (D4.3)"""
+        workspace_root, issue_number = initialized
+        tool = SavePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            SavePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables=_minimal_deliverables(
+                    validates={"type": "does_not_exist", "file": "x.py"}
+                ),
+            )
+        )
+
+        assert result.is_error
+        text = result.content[0]["text"]
+        assert "does_not_exist" in text
+        assert "D1.1" in text  # deliverable ID surfaced in error
+
+    @pytest.mark.asyncio()
+    async def test_save_planning_deliverables_tool_rejects_validates_missing_required_field(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """validates entry missing required field (text for contains_text) is rejected. (D4.3)"""
+        workspace_root, issue_number = initialized
+        tool = SavePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            SavePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables=_minimal_deliverables(
+                    validates={"type": "contains_text", "file": "x.py"}  # missing 'text'
+                ),
+            )
+        )
+
+        assert result.is_error
+        text = result.content[0]["text"]
+        assert "text" in text  # missing field name surfaced
+
+    @pytest.mark.asyncio()
+    async def test_save_planning_deliverables_tool_error_lists_available_types_and_fields(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """Error on unknown type lists all valid types and their required fields. (D4.3)"""
+        workspace_root, issue_number = initialized
+        tool = SavePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            SavePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables=_minimal_deliverables(validates={"type": "wrong_type"}),
+            )
+        )
+
+        assert result.is_error
+        text = result.content[0]["text"]
+        # Must list all valid types
+        for valid_type in ("file_exists", "file_glob", "contains_text", "absent_text", "key_path"):
+            assert valid_type in text, f"Expected '{valid_type}' listed in error, got: {text}"
+
+
+class TestUpdatePlanningDeliverablesTool:
+    """Tests for UpdatePlanningDeliverablesTool.
+
+    Issue #229 Cycle 5 (GAP-09):
+    - D5.1: tool defined in project_tools.py
+    - D5.2: update_planning_deliverables in project_manager.py
+    - D5.3: tool registered in server.py
+    """
+
+    @pytest.fixture()
+    def initialized(self, tmp_path: Path) -> tuple[Path, int]:
+        """Create workspace with initial planning deliverables already saved."""
+        issue_number = 229
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        manager.save_planning_deliverables(
+            issue_number=issue_number,
+            planning_deliverables=_minimal_deliverables(),
+        )
+        return tmp_path, issue_number
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_tool_appends_new_cycle(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """Sending a new cycle_number appends it to tdd_cycles.cycles. (D5.1)"""
+        workspace_root, issue_number = initialized
+        tool = UpdatePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "tdd_cycles": {
+                        "total": 2,
+                        "cycles": [
+                            {
+                                "cycle_number": 2,
+                                "deliverables": [{"id": "D2.1", "description": "new cycle"}],
+                                "exit_criteria": "Tests pass",
+                            }
+                        ],
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        manager = ProjectManager(workspace_root=workspace_root)
+        data = json.loads(manager.projects_file.read_text())[str(issue_number)]
+        cycles = data["planning_deliverables"]["tdd_cycles"]["cycles"]
+        assert len(cycles) == 2  # original C1 + new C2
+        assert cycles[1]["cycle_number"] == 2
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_tool_merges_deliverable_by_id(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """New deliverable id in existing cycle is appended. (D5.1)"""
+        workspace_root, issue_number = initialized
+        tool = UpdatePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "tdd_cycles": {
+                        "total": 1,
+                        "cycles": [
+                            {
+                                "cycle_number": 1,
+                                "deliverables": [
+                                    {"id": "D1.2", "description": "second deliverable"}
+                                ],
+                                "exit_criteria": "Tests pass",
+                            }
+                        ],
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        manager = ProjectManager(workspace_root=workspace_root)
+        data = json.loads(manager.projects_file.read_text())[str(issue_number)]
+        cycle1 = data["planning_deliverables"]["tdd_cycles"]["cycles"][0]
+        ids = [d["id"] for d in cycle1["deliverables"]]
+        assert "D1.1" in ids  # original preserved
+        assert "D1.2" in ids  # new one appended
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_tool_updates_existing_deliverable_by_id(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """Existing deliverable id in existing cycle is overwritten. (D5.1)"""
+        workspace_root, issue_number = initialized
+        tool = UpdatePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "tdd_cycles": {
+                        "total": 1,
+                        "cycles": [
+                            {
+                                "cycle_number": 1,
+                                "deliverables": [
+                                    {"id": "D1.1", "description": "updated description"}
+                                ],
+                                "exit_criteria": "Tests pass",
+                            }
+                        ],
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        manager = ProjectManager(workspace_root=workspace_root)
+        data = json.loads(manager.projects_file.read_text())[str(issue_number)]
+        cycle1 = data["planning_deliverables"]["tdd_cycles"]["cycles"][0]
+        d1_1 = next(d for d in cycle1["deliverables"] if d["id"] == "D1.1")
+        assert d1_1["description"] == "updated description"
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_tool_rejects_before_initial_save(
+        self, tmp_path: Path
+    ) -> None:
+        """Returns error when called before save_planning_deliverables. (D5.1)"""
+        issue_number = 229
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+        tool = UpdatePlanningDeliverablesTool(workspace_root=tmp_path)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables=_minimal_deliverables(),
+            )
+        )
+
+        assert result.is_error
+        assert "save_planning_deliverables" in result.content[0]["text"]
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_tool_validates_validates_entry_schema(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """Invalid validates entry is rejected before persisting. (D5.1)"""
+        workspace_root, issue_number = initialized
+        tool = UpdatePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables=_minimal_deliverables(validates={"type": "unknown_type"}),
+            )
+        )
+
+        assert result.is_error
+        text = result.content[0]["text"]
+        for valid_type in ("file_exists", "file_glob", "contains_text", "absent_text", "key_path"):
+            assert valid_type in text, f"Expected '{valid_type}' listed in error, got: {text}"
+
+
+class TestPlanningDeliverablesPhaseSchema:
+    """Tests for per-phase deliverables schema in save_planning_deliverables.
+
+    Issue #229 Cycle 7 (GAP-11):
+    - D7.1: save_planning_deliverables accepts phase keys alongside tdd_cycles
+    """
+
+    @pytest.fixture()
+    def initialized(self, tmp_path: Path) -> tuple[Path, int]:
+        """Initialize a project (no deliverables yet)."""
+        issue_number = 229
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Phase deliverables schema test",
+            workflow_name="feature",
+        )
+        return tmp_path, issue_number
+
+    @pytest.mark.asyncio()
+    async def test_save_accepts_design_phase_key(self, initialized: tuple[Path, int]) -> None:
+        """save_planning_deliverables accepts design phase key alongside tdd_cycles. (D7.1)"""
+        workspace_root, issue_number = initialized
+        tool = SavePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            SavePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    **_minimal_deliverables(),
+                    "design": {
+                        "deliverables": [{"id": "D-design-1", "description": "Design doc created"}]
+                    },
+                },
+            )
+        )
+
+        assert not result.is_error
+        data = json.loads((workspace_root / ".st3" / "projects.json").read_text())[
+            str(issue_number)
+        ]
+        assert "design" in data["planning_deliverables"]
+
+    @pytest.mark.asyncio()
+    async def test_save_rejects_unknown_phase_key(self, initialized: tuple[Path, int]) -> None:
+        """save_planning_deliverables rejects unrecognised phase keys. (D7.1)"""
+        workspace_root, issue_number = initialized
+        tool = SavePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            SavePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    **_minimal_deliverables(),
+                    "unknown_phase": {"deliverables": []},
+                },
+            )
+        )
+
+        assert result.is_error
+        text = result.content[0]["text"]
+        assert "unknown_phase" in text
+
+
+class TestUpdatePlanningDeliverablesPerPhase:
+    """Tests for per-phase merge in update_planning_deliverables.
+
+    Issue #229 Cycle 8 (GAP-12 + GAP-15):
+    - D8.1: update merges design/validation/documentation keys
+    - D8.2: per-phase deliverables merged by id
+    - D8.3: exit_criteria on existing cycle overwritten when provided
+    """
+
+    @pytest.fixture()
+    def initialized(self, tmp_path: Path) -> tuple[Path, int]:
+        """Initialize a project with tdd_cycles + design phase deliverables."""
+        issue_number = 229
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Phase deliverables update test",
+            workflow_name="feature",
+        )
+        manager.save_planning_deliverables(
+            issue_number=issue_number,
+            planning_deliverables={
+                **_minimal_deliverables(),
+                "design": {
+                    "deliverables": [
+                        {"id": "Des1", "description": "original design deliverable"}
+                    ]
+                },
+            },
+        )
+        return tmp_path, issue_number
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_merges_design_key(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """update_planning_deliverables with design key updates projects.json. (D8.1/GAP-15)"""
+        workspace_root, issue_number = initialized
+        tool = UpdatePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "design": {
+                        "deliverables": [
+                            {"id": "Des2", "description": "new design deliverable"}
+                        ]
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        data = json.loads(
+            (workspace_root / ".st3" / "projects.json").read_text()
+        )[str(issue_number)]
+        design_ids = [
+            d["id"] for d in data["planning_deliverables"]["design"]["deliverables"]
+        ]
+        assert "Des1" in design_ids  # original preserved
+        assert "Des2" in design_ids  # new one appended (D8.1)
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_merges_validation_key(
+        self, tmp_path: Path
+    ) -> None:
+        """update_planning_deliverables with validation key updates projects.json. (D8.1/GAP-15)"""
+        issue_number = 229
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Validation phase test",
+            workflow_name="feature",
+        )
+        manager.save_planning_deliverables(
+            issue_number=issue_number,
+            planning_deliverables={
+                **_minimal_deliverables(),
+                "validation": {
+                    "deliverables": [
+                        {"id": "Val1", "description": "original validation deliverable"}
+                    ]
+                },
+            },
+        )
+        tool = UpdatePlanningDeliverablesTool(workspace_root=tmp_path)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "validation": {
+                        "deliverables": [
+                            {"id": "Val2", "description": "new validation deliverable"}
+                        ]
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        data = json.loads(
+            (tmp_path / ".st3" / "projects.json").read_text()
+        )[str(issue_number)]
+        val_ids = [
+            d["id"] for d in data["planning_deliverables"]["validation"]["deliverables"]
+        ]
+        assert "Val1" in val_ids
+        assert "Val2" in val_ids
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_merges_documentation_key(
+        self, tmp_path: Path
+    ) -> None:
+        """update_planning_deliverables with documentation key updates projects.json. (D8.1/GAP-15)"""
+        issue_number = 229
+        manager = ProjectManager(workspace_root=tmp_path)
+        manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Documentation phase test",
+            workflow_name="feature",
+        )
+        manager.save_planning_deliverables(
+            issue_number=issue_number,
+            planning_deliverables={
+                **_minimal_deliverables(),
+                "documentation": {
+                    "deliverables": [
+                        {"id": "Doc1", "description": "original doc deliverable"}
+                    ]
+                },
+            },
+        )
+        tool = UpdatePlanningDeliverablesTool(workspace_root=tmp_path)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "documentation": {
+                        "deliverables": [
+                            {"id": "Doc2", "description": "new doc deliverable"}
+                        ]
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        data = json.loads(
+            (tmp_path / ".st3" / "projects.json").read_text()
+        )[str(issue_number)]
+        doc_ids = [
+            d["id"] for d in data["planning_deliverables"]["documentation"]["deliverables"]
+        ]
+        assert "Doc1" in doc_ids
+        assert "Doc2" in doc_ids
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_per_phase_merge_by_id(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """Existing per-phase deliverable id updated in place; new id appended. (D8.2)"""
+        workspace_root, issue_number = initialized
+        tool = UpdatePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "design": {
+                        "deliverables": [
+                            {"id": "Des1", "description": "updated description"},
+                            {"id": "Des2", "description": "brand new"},
+                        ]
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        data = json.loads(
+            (workspace_root / ".st3" / "projects.json").read_text()
+        )[str(issue_number)]
+        deliverables = data["planning_deliverables"]["design"]["deliverables"]
+        by_id = {d["id"]: d for d in deliverables}
+        assert by_id["Des1"]["description"] == "updated description"  # overwritten (D8.2)
+        assert "Des2" in by_id  # appended
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_updates_exit_criteria_on_existing_cycle(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """exit_criteria on existing cycle overwritten when provided in update. (D8.3/GAP-12)"""
+        workspace_root, issue_number = initialized
+        tool = UpdatePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "tdd_cycles": {
+                        "cycles": [
+                            {
+                                "cycle_number": 1,
+                                "deliverables": [],
+                                "exit_criteria": "Updated exit criteria",
+                            }
+                        ]
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        data = json.loads(
+            (workspace_root / ".st3" / "projects.json").read_text()
+        )[str(issue_number)]
+        cycle1 = data["planning_deliverables"]["tdd_cycles"]["cycles"][0]
+        assert cycle1["exit_criteria"] == "Updated exit criteria"  # (D8.3)
+
+    @pytest.mark.asyncio()
+    async def test_update_planning_deliverables_tdd_cycles_backward_compat(
+        self, initialized: tuple[Path, int]
+    ) -> None:
+        """tdd_cycles merge behaviour unchanged after per-phase support added. (D8.1 backward compat)"""
+        workspace_root, issue_number = initialized
+        tool = UpdatePlanningDeliverablesTool(workspace_root=workspace_root)
+
+        result = await tool.execute(
+            UpdatePlanningDeliverablesInput(
+                issue_number=issue_number,
+                planning_deliverables={
+                    "tdd_cycles": {
+                        "cycles": [
+                            {
+                                "cycle_number": 2,
+                                "deliverables": [{"id": "D2.1", "description": "new cycle"}],
+                                "exit_criteria": "Tests pass",
+                            }
+                        ]
+                    }
+                },
+            )
+        )
+
+        assert not result.is_error
+        data = json.loads(
+            (workspace_root / ".st3" / "projects.json").read_text()
+        )[str(issue_number)]
+        cycles = data["planning_deliverables"]["tdd_cycles"]["cycles"]
+        assert len(cycles) == 2  # original C1 + new C2 appended
+        assert cycles[0]["cycle_number"] == 1  # original C1 untouched
+        assert cycles[1]["cycle_number"] == 2  # C2 appended

--- a/tests/unit/tools/test_transition_tools.py
+++ b/tests/unit/tools/test_transition_tools.py
@@ -1,0 +1,1343 @@
+"""Tests for Transition Tools (transition_cycle, force_cycle_transition).
+
+Issue #146 Cycle 4: TDD Cycle transition management.
+Issue #146 Cycle 6: Spec alignment - audit schema, history entries, exit criteria.
+Issue #229 Cycle 10: GAP-17 — blocking deliverables must appear BEFORE ✅ in response.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_server.managers.phase_state_engine import PhaseStateEngine
+from mcp_server.managers.project_manager import ProjectManager
+from mcp_server.tools.transition_tools import (
+    ForceCycleTransitionInput,
+    ForceCycleTransitionTool,
+    TransitionCycleInput,
+    TransitionCycleTool,
+)
+
+
+class TestTransitionCycleTool:
+    """Tests for transition_cycle tool.
+
+    Issue #146 Cycle 4: Sequential cycle progressions with validation.
+    """
+
+    @pytest.fixture()
+    def tool(self) -> TransitionCycleTool:
+        """Fixture to instantiate TransitionCycleTool."""
+        return TransitionCycleTool()
+
+    @pytest.fixture()
+    def setup_project(self, tmp_path: Path) -> tuple[Path, int]:
+        """Create project with planning deliverables and state."""
+        workspace_root = tmp_path
+        issue_number = 146
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        # Initialize project
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="TDD Cycle Tracking",
+            workflow_name="feature",
+        )
+
+        # Save planning deliverables (4 cycles)
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": 1,
+                        "name": "Schema & Storage",
+                        "deliverables": ["Schema"],
+                        "exit_criteria": "Tests pass",
+                    },
+                    {
+                        "cycle_number": 2,
+                        "name": "Validation Logic",
+                        "deliverables": ["Validators"],
+                        "exit_criteria": "All scenarios covered",
+                    },
+                    {
+                        "cycle_number": 3,
+                        "name": "Discovery Tools",
+                        "deliverables": ["get_work_context"],
+                        "exit_criteria": "Tools return cycle info",
+                    },
+                    {
+                        "cycle_number": 4,
+                        "name": "Transition Tools",
+                        "deliverables": ["transition_cycle"],
+                        "exit_criteria": "All transitions working",
+                    },
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(issue_number, planning_deliverables)
+
+        # Initialize TDD phase with cycle 1
+        state_engine.initialize_branch(
+            branch="feature/146-tdd-cycle-tracking",
+            issue_number=issue_number,
+            initial_phase="tdd",
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        state["current_tdd_cycle"] = 1
+        state_engine._save_state("feature/146-tdd-cycle-tracking", state)
+
+        return workspace_root, issue_number
+
+    @pytest.mark.asyncio
+    async def test_transition_to_next_cycle_succeeds(
+        self, tool: TransitionCycleTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Test successful forward transition from cycle 1 to 2.
+
+        Issue #146 Cycle 4: Sequential progression validation.
+        """
+        workspace_root, _ = setup_project
+
+        # Mock git and settings
+        with (
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(TransitionCycleInput(to_cycle=2))
+
+        # Assert successful transition
+        assert not result.is_error, f"Expected success: {result.content}"
+
+        # Check state updated
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        assert state["current_tdd_cycle"] == 2, "Current cycle should be 2"
+        assert state["last_tdd_cycle"] == 1, "Last cycle should be preserved"
+
+    @pytest.mark.asyncio
+    async def test_transition_blocks_backward_transition(
+        self, tool: TransitionCycleTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Test that backward transitions are blocked.
+
+        Issue #146 Cycle 4: Forward-only enforcement.
+        """
+        workspace_root, _ = setup_project
+
+        # Set current cycle to 2
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        state["current_tdd_cycle"] = 2
+        state_engine._save_state("feature/146-tdd-cycle-tracking", state)
+
+        #  Mock git
+        with (
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(TransitionCycleInput(to_cycle=1))
+
+        # Assert blocked
+        assert result.is_error, "Expected backward transition to be blocked"
+        text = result.content[0]["text"]
+        assert "backwards" in text.lower() or "forward-only" in text.lower()
+        assert "force_cycle_transition" in text
+
+    @pytest.mark.asyncio
+    async def test_transition_blocks_non_sequential_jump(
+        self, tool: TransitionCycleTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Test that skipping cycles requires force_cycle_transition.
+
+        Issue #146 Cycle 4: Sequential validation.
+        """
+        workspace_root, _ = setup_project
+
+        # Mock git
+        with (
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+
+            mock_settings.server.workspace_root = workspace_root
+
+            # Try to jump from cycle 1 to 3 (skipping 2)
+            result = await tool.execute(TransitionCycleInput(to_cycle=3))
+
+        # Assert blocked
+        assert result.is_error, "Expected non-sequential jump to be blocked"
+        text = result.content[0]["text"]
+        assert "sequential" in text.lower() or "skip" in text.lower()
+        assert "force_cycle_transition" in text
+
+    @pytest.mark.asyncio
+    async def test_transition_blocks_outside_tdd_phase(
+        self, tool: TransitionCycleTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Test that transition only works during TDD phase.
+
+        Issue #146 Cycle 4: Phase enforcement.
+        """
+        workspace_root, _ = setup_project
+
+        # Change phase to design
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        state["current_phase"] = "design"
+        state_engine._save_state("feature/146-tdd-cycle-tracking", state)
+
+        # Mock git
+        with (
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(TransitionCycleInput(to_cycle=2))
+
+        # Assert blocked
+        assert result.is_error, "Expected transition to be blocked outside TDD phase"
+        text = result.content[0]["text"]
+        assert "tdd phase" in text.lower()
+
+
+class TestForceCycleTransitionTool:
+    """Tests for force_cycle_transition tool.
+
+    Issue #146 Cycle 4: Forced transitions with audit trail.
+    """
+
+    @pytest.fixture()
+    def tool(self) -> ForceCycleTransitionTool:
+        """Fixture to instantiate ForceCycleTransitionTool."""
+        return ForceCycleTransitionTool()
+
+    @pytest.fixture()
+    def setup_forced_project(self, tmp_path: Path) -> tuple[Path, int]:
+        """Create project in TDD phase at cycle 2 for forced transitions."""
+        workspace_root = tmp_path
+        issue_number = 146
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        # Initialize project
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="TDD Cycle Tracking",
+            workflow_name="feature",
+        )
+
+        # Save planning deliverables (4 cycles)
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": 1,
+                        "name": "Schema & Storage",
+                        "deliverables": ["Schema"],
+                        "exit_criteria": "Tests pass",
+                    },
+                    {
+                        "cycle_number": 2,
+                        "name": "Validation Logic",
+                        "deliverables": ["Validators"],
+                        "exit_criteria": "All scenarios covered",
+                    },
+                    {
+                        "cycle_number": 3,
+                        "name": "Discovery Tools",
+                        "deliverables": ["get_work_context"],
+                        "exit_criteria": "Tools return cycle info",
+                    },
+                    {
+                        "cycle_number": 4,
+                        "name": "Transition Tools",
+                        "deliverables": ["transition_cycle", "force_cycle_transition"],
+                        "exit_criteria": "All transitions working",
+                    },
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(
+            issue_number=issue_number, planning_deliverables=planning_deliverables
+        )
+
+        # Transition to TDD phase and set cycle to 2
+        branch = "feature/146-tdd-cycle-tracking"
+        state = state_engine.get_state(branch)
+        state["current_phase"] = "tdd"
+        state["current_tdd_cycle"] = 2
+        state["last_tdd_cycle"] = 1
+        state["tdd_cycle_history"] = []
+        state_engine._save_state(branch, state)
+
+        return workspace_root, issue_number
+
+    @pytest.mark.asyncio()
+    async def test_force_backward_transition_succeeds(
+        self, tool: ForceCycleTransitionTool, setup_forced_project: tuple[Path, int]
+    ) -> None:
+        """Test that forced backward transition (2→1) works with approval."""
+        workspace_root, _ = setup_forced_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=1,
+                    skip_reason="Re-testing schema changes",
+                    human_approval="John approved on 2026-02-17",
+                )
+            )
+
+        # Assert success
+        assert not result.is_error, f"Expected success, got error: {result.content}"
+        text = result.content[0]["text"]
+        assert "✅" in text or "Forced" in text
+        assert "1" in text
+
+        # Verify state updated
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        assert state["current_tdd_cycle"] == 1
+        assert state["last_tdd_cycle"] == 2
+
+        # Verify audit trail
+        history = state.get("tdd_cycle_history", [])
+        assert len(history) > 0, "Expected audit trail entry"
+        last_entry = history[-1]
+        assert last_entry.get("cycle_number") == 1
+        assert last_entry.get("forced") is True
+        assert "Re-testing schema changes" in last_entry.get("skip_reason", "")
+        assert "John approved" in last_entry.get("human_approval", "")
+
+    @pytest.mark.asyncio()
+    async def test_force_skip_transition_succeeds(
+        self, tool: ForceCycleTransitionTool, setup_forced_project: tuple[Path, int]
+    ) -> None:
+        """Test that forced skip transition (2→4) works with approval."""
+        workspace_root, _ = setup_forced_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=4,
+                    skip_reason="Cycle 3 covered by integration tests",
+                    human_approval="Jane approved on 2026-02-17",
+                )
+            )
+
+        # Assert success
+        assert not result.is_error, f"Expected success, got error: {result.content}"
+        text = result.content[0]["text"]
+        assert "✅" in text or "Forced" in text
+        assert "4" in text
+
+        # Verify state
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        assert state["current_tdd_cycle"] == 4
+
+    @pytest.mark.asyncio()
+    async def test_force_blocks_without_skip_reason(
+        self, tool: ForceCycleTransitionTool, setup_forced_project: tuple[Path, int]
+    ) -> None:
+        """Test that forced transition blocks when skip_reason is empty."""
+        workspace_root, _ = setup_forced_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=1,
+                    skip_reason="",  # Empty reason
+                    human_approval="John approved on 2026-02-17",
+                )
+            )
+
+        # Assert blocked
+        assert result.is_error, "Expected error when skip_reason is empty"
+        text = result.content[0]["text"]
+        assert "skip_reason" in text.lower() or "reason" in text.lower()
+
+    @pytest.mark.asyncio()
+    async def test_force_blocks_without_human_approval(
+        self, tool: ForceCycleTransitionTool, setup_forced_project: tuple[Path, int]
+    ) -> None:
+        """Test that forced transition blocks when human_approval is empty."""
+        workspace_root, _ = setup_forced_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=1,
+                    skip_reason="Re-testing schema changes",
+                    human_approval="",  # Empty approval
+                )
+            )
+
+        # Assert blocked
+        assert result.is_error, "Expected error when human_approval is empty"
+        text = result.content[0]["text"]
+        assert "approval" in text.lower() or "human" in text.lower()
+
+
+class TestForceCycleTransitionSkippedDeliverables:
+    """Tests for force_cycle_transition ⚠️ warning on unvalidated skipped cycle deliverables.
+
+    Issue #229 Cycle 3 D3.2 (GAP-08): When force_cycle_transition skips cycles whose
+    deliverables fail DeliverableChecker, the tool response must include a ⚠️ warning
+    listing the unvalidated items. The transition itself still succeeds.
+    """
+
+    @pytest.fixture()
+    def tool(self) -> ForceCycleTransitionTool:
+        """Fixture to instantiate ForceCycleTransitionTool."""
+        return ForceCycleTransitionTool()
+
+    def _setup_project_with_validates_deliverables(
+        self, tmp_path: Path, cycle3_file_contains: str | None
+    ) -> tuple[Path, int]:
+        """Set up a project in TDD phase C2 where cycle 3 has a contains_text deliverable.
+
+        Args:
+            tmp_path: Workspace root.
+            cycle3_file_contains: Text to write in the validated file, or None to omit file.
+        """
+        workspace_root = tmp_path
+        issue_number = 229
+        branch = "feature/229-phase-deliverables-enforcement"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+
+        # Create the target file for the check (or not, to simulate failure)
+        target_file = workspace_root / "mcp_server" / "tools" / "transition_tools.py"
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+        if cycle3_file_contains is not None:
+            target_file.write_text(cycle3_file_contains)
+        # If None: leave file absent → contains_text check fails
+
+        # Save planning deliverables: 4 cycles, cycle 3 has a validates spec
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": 1,
+                        "deliverables": [{"id": "D1.1", "description": "placeholder"}],
+                        "exit_criteria": "C1 done",
+                    },
+                    {
+                        "cycle_number": 2,
+                        "deliverables": [{"id": "D2.1", "description": "placeholder"}],
+                        "exit_criteria": "C2 done",
+                    },
+                    {
+                        "cycle_number": 3,
+                        "deliverables": [
+                            {
+                                "id": "D3.2",
+                                "description": "transition_tools.py contains warning text",
+                                "validates": {
+                                    "type": "contains_text",
+                                    "file": "mcp_server/tools/transition_tools.py",
+                                    "text": "Unvalidated cycle deliverables",
+                                },
+                            }
+                        ],
+                        "exit_criteria": "D3.2 passes",
+                    },
+                    {
+                        "cycle_number": 4,
+                        "deliverables": [{"id": "D4.1", "description": "placeholder"}],
+                        "exit_criteria": "C4 done",
+                    },
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(
+            issue_number=issue_number, planning_deliverables=planning_deliverables
+        )
+
+        # Set state: TDD phase, cycle 2
+        state = state_engine.get_state(branch)
+        state["current_phase"] = "tdd"
+        state["current_tdd_cycle"] = 2
+        state["last_tdd_cycle"] = 1
+        state["tdd_cycle_history"] = []
+        state_engine._save_state(branch, state)
+
+        return workspace_root, issue_number
+
+    @pytest.mark.asyncio()
+    async def test_force_cycle_transition_warns_unvalidated_skipped_cycle_deliverables(
+        self, tool: ForceCycleTransitionTool, tmp_path: Path
+    ) -> None:
+        """When skipping C2→C4, cycle 3 D3.2 fails check → ⚠️ in tool response.
+
+        The transition still succeeds (forced = unconditional). Only the warning is added.
+        Issue #229 D3.2 (GAP-08).
+        """
+        workspace_root, _ = self._setup_project_with_validates_deliverables(
+            tmp_path,
+            cycle3_file_contains=None,  # File absent → check fails
+        )
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/229-phase-deliverables-enforcement"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=4,
+                    skip_reason="Cycle 3 handled elsewhere",
+                    human_approval="Michel approved on 2026-02-19",
+                    issue_number=229,
+                )
+            )
+
+        assert not result.is_error, f"Expected success, got error: {result.content}"
+        text = result.content[0]["text"]
+        assert "⚠️" in text, f"Expected warning in response, got: {text}"
+        assert "cycle:3:D3.2" in text, f"Expected cycle:3:D3.2 in warning, got: {text}"
+        assert "Unvalidated cycle deliverables" in text
+
+    @pytest.mark.asyncio()
+    async def test_force_cycle_transition_no_warning_when_skipped_cycles_pass_checks(
+        self, tool: ForceCycleTransitionTool, tmp_path: Path
+    ) -> None:
+        """When skipping C2→C4 and cycle 3 D3.2 passes check → no ⚠️ in response.
+
+        Issue #229 D3.2 (GAP-08).
+        """
+        workspace_root, _ = self._setup_project_with_validates_deliverables(
+            tmp_path,
+            cycle3_file_contains="def warn():\n    msg = 'Unvalidated cycle deliverables'\n",
+        )
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/229-phase-deliverables-enforcement"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=4,
+                    skip_reason="Cycle 3 fully validated",
+                    human_approval="Michel approved on 2026-02-19",
+                    issue_number=229,
+                )
+            )
+
+        assert not result.is_error, f"Expected success, got error: {result.content}"
+        text = result.content[0]["text"]
+        assert "Unvalidated cycle deliverables" not in text, (
+            f"Expected no warning when checks pass, got: {text}"
+        )
+
+
+class TestForceCycleAuditSchema:
+    """Tests for force_cycle_transition audit schema alignment.
+
+    Issue #146 Cycle 6 D1: force_cycle_transition should produce
+    {cycle_number, forced: True, skipped_cycles: [...]} not {from_cycle, to_cycle}.
+    Design.md:340-354.
+    """
+
+    @pytest.fixture()
+    def tool(self) -> ForceCycleTransitionTool:
+        """Fixture to instantiate ForceCycleTransitionTool."""
+        return ForceCycleTransitionTool()
+
+    @pytest.fixture()
+    def setup_project(self, tmp_path: Path) -> tuple[Path, int]:
+        """Create project in TDD phase at cycle 2."""
+        workspace_root = tmp_path
+        issue_number = 146
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="TDD Cycle Tracking",
+            workflow_name="feature",
+        )
+
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {
+                        "cycle_number": 1,
+                        "name": "Schema",
+                        "deliverables": ["Schema"],
+                        "exit_criteria": "Tests pass",
+                    },
+                    {
+                        "cycle_number": 2,
+                        "name": "Validation",
+                        "deliverables": ["Validators"],
+                        "exit_criteria": "All scenarios covered",
+                    },
+                    {
+                        "cycle_number": 3,
+                        "name": "Discovery",
+                        "deliverables": ["get_work_context"],
+                        "exit_criteria": "Tools work",
+                    },
+                    {
+                        "cycle_number": 4,
+                        "name": "Transition",
+                        "deliverables": ["transition_cycle"],
+                        "exit_criteria": "Transitions work",
+                    },
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(issue_number, planning_deliverables)
+
+        branch = "feature/146-tdd-cycle-tracking"
+        state_engine.initialize_branch(
+            branch=branch,
+            issue_number=issue_number,
+            initial_phase="tdd",
+        )
+        state = state_engine.get_state(branch)
+        state["current_phase"] = "tdd"
+        state["current_tdd_cycle"] = 2
+        state["last_tdd_cycle"] = 1
+        state["tdd_cycle_history"] = []
+        state_engine._save_state(branch, state)
+
+        return workspace_root, issue_number
+
+    @pytest.mark.asyncio()
+    async def test_force_audit_entry_has_cycle_number_not_from_to(
+        self, tool: ForceCycleTransitionTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Audit entry must use cycle_number (not from_cycle/to_cycle).
+
+        Issue #146 Cycle 6 D1: Design.md:344 requires cycle_number field.
+        """
+        workspace_root, _ = setup_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=4,
+                    skip_reason="Cycles 3 covered by parent",
+                    human_approval="John approved on 2026-02-17",
+                )
+            )
+
+        assert not result.is_error, f"Expected success: {result.content}"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        history = state.get("tdd_cycle_history", [])
+
+        assert len(history) > 0, "Expected audit entry in tdd_cycle_history"
+        entry = history[-1]
+
+        assert "cycle_number" in entry, "Audit entry must have cycle_number field"
+        assert entry["cycle_number"] == 4, "cycle_number must be the target cycle"
+        assert "from_cycle" not in entry, "Audit entry must not use from_cycle (old schema)"
+        assert "to_cycle" not in entry, "Audit entry must not use to_cycle (old schema)"
+
+    @pytest.mark.asyncio()
+    async def test_force_audit_entry_has_forced_true(
+        self, tool: ForceCycleTransitionTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Audit entry must explicitly set forced=True.
+
+        Issue #146 Cycle 6 D1: Design.md:344 requires forced: true.
+        """
+        workspace_root, _ = setup_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=1,
+                    skip_reason="Re-testing",
+                    human_approval="John approved",
+                )
+            )
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        history = state.get("tdd_cycle_history", [])
+
+        assert len(history) > 0
+        entry = history[-1]
+        assert "forced" in entry, "Audit entry must have forced field"
+        assert entry["forced"] is True, "forced must be True for force_cycle_transition"
+        assert "transition_type" not in entry, "Must not use transition_type (old schema)"
+
+    @pytest.mark.asyncio()
+    async def test_force_audit_entry_has_skipped_cycles(
+        self, tool: ForceCycleTransitionTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Audit entry must include list of skipped_cycles.
+
+        Issue #146 Cycle 6 D1: Design.md:346 requires skipped_cycles field.
+        Skipping from cycle 2 -> cycle 4 means cycles [3] are skipped.
+        """
+        workspace_root, _ = setup_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=4,
+                    skip_reason="Cycles 3 covered by parent tests",
+                    human_approval="Jane approved on 2026-02-17",
+                )
+            )
+
+        assert not result.is_error
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        history = state.get("tdd_cycle_history", [])
+
+        assert len(history) > 0
+        entry = history[-1]
+        assert "skipped_cycles" in entry, "Audit entry must have skipped_cycles field"
+        assert entry["skipped_cycles"] == [3], f"Expected [3], got {entry['skipped_cycles']}"
+
+
+class TestTransitionCycleHistory:
+    """Tests for transition_cycle history entry (forced=False).
+
+    Issue #146 Cycle 6 D2: Normal transition_cycle should write
+    {cycle_number, forced: False} to tdd_cycle_history. Design.md:291-297.
+    """
+
+    @pytest.fixture()
+    def tool(self) -> TransitionCycleTool:
+        """Fixture to instantiate TransitionCycleTool."""
+        return TransitionCycleTool()
+
+    @pytest.fixture()
+    def setup_project(self, tmp_path: Path) -> tuple[Path, int]:
+        """Create project in TDD phase at cycle 1."""
+        workspace_root = tmp_path
+        issue_number = 146
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="TDD Cycle Tracking",
+            workflow_name="feature",
+        )
+
+        planning_deliverables = {
+            "tdd_cycles": {
+                "total": 3,
+                "cycles": [
+                    {
+                        "cycle_number": 1,
+                        "name": "Cycle One",
+                        "deliverables": ["D1"],
+                        "exit_criteria": "EC1",
+                    },
+                    {
+                        "cycle_number": 2,
+                        "name": "Cycle Two",
+                        "deliverables": ["D2"],
+                        "exit_criteria": "EC2",
+                    },
+                    {
+                        "cycle_number": 3,
+                        "name": "Cycle Three",
+                        "deliverables": ["D3"],
+                        "exit_criteria": "EC3",
+                    },
+                ],
+            }
+        }
+        project_manager.save_planning_deliverables(issue_number, planning_deliverables)
+
+        branch = "feature/146-tdd-cycle-tracking"
+        state_engine.initialize_branch(
+            branch=branch,
+            issue_number=issue_number,
+            initial_phase="tdd",
+        )
+        state = state_engine.get_state(branch)
+        state["current_phase"] = "tdd"
+        state["current_tdd_cycle"] = 1
+        state["last_tdd_cycle"] = None
+        state["tdd_cycle_history"] = []
+        state_engine._save_state(branch, state)
+
+        return workspace_root, issue_number
+
+    @pytest.mark.asyncio()
+    async def test_normal_transition_writes_history_entry(
+        self, tool: TransitionCycleTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Normal transition_cycle must write a history entry with forced=False.
+
+        Issue #146 Cycle 6 D2: Design.md:291-297.
+        """
+        workspace_root, _ = setup_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(TransitionCycleInput(to_cycle=2))
+
+        assert not result.is_error, f"Expected success: {result.content}"
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        history = state.get("tdd_cycle_history", [])
+
+        assert len(history) == 1, f"Expected 1 history entry, got {len(history)}"
+        entry = history[0]
+        assert "cycle_number" in entry, "History entry must have cycle_number"
+        assert entry["cycle_number"] == 2, "cycle_number must be the target cycle"
+        assert "forced" in entry, "History entry must have forced field"
+        assert entry["forced"] is False, "forced must be False for normal transition"
+
+    @pytest.mark.asyncio()
+    async def test_multiple_transitions_accumulate_history(
+        self, tool: TransitionCycleTool, setup_project: tuple[Path, int]
+    ) -> None:
+        """Multiple normal transitions accumulate in tdd_cycle_history.
+
+        Issue #146 Cycle 6 D2: History is cumulative.
+        """
+        workspace_root, _ = setup_project
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result1 = await tool.execute(TransitionCycleInput(to_cycle=2))
+            assert not result1.is_error
+
+            result2 = await tool.execute(TransitionCycleInput(to_cycle=3))
+            assert not result2.is_error
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+        state = state_engine.get_state("feature/146-tdd-cycle-tracking")
+        history = state.get("tdd_cycle_history", [])
+
+        assert len(history) == 2, f"Expected 2 history entries, got {len(history)}"
+        assert history[0]["cycle_number"] == 2
+        assert history[1]["cycle_number"] == 3
+        assert history[0]["forced"] is False
+        assert history[1]["forced"] is False
+
+
+class TestTransitionCycleExitCriteria:
+    """Tests for transition_cycle exit criteria validation.
+
+    Issue #146 Cycle 6 D3: transition_cycle must validate that the current cycle
+    has a non-empty exit_criteria before allowing transition to next cycle.
+    Design.md:287 (validate_exit_criteria(current_tdd_cycle)).
+    """
+
+    @pytest.fixture()
+    def tool(self) -> TransitionCycleTool:
+        """Fixture to instantiate TransitionCycleTool."""
+        return TransitionCycleTool()
+
+    def _make_project(
+        self,
+        tmp_path: Path,
+        cycles: list[dict],
+        current_cycle: int = 1,
+        *,
+        bypass_validation: bool = False,
+    ) -> Path:
+        """Helper to create a project with given cycle definitions.
+
+        Args:
+            bypass_validation: If True, writes cycle data directly to state file,
+                bypassing save_planning_deliverables validation. Used to test edge cases
+                where external/corrupt state has invalid exit_criteria.
+        """
+        workspace_root = tmp_path
+        issue_number = 146
+
+        project_manager = ProjectManager(workspace_root=workspace_root)
+        state_engine = PhaseStateEngine(
+            workspace_root=workspace_root, project_manager=project_manager
+        )
+
+        project_manager.initialize_project(
+            issue_number=issue_number,
+            issue_title="TDD Cycle Tracking",
+            workflow_name="feature",
+        )
+
+        if bypass_validation:
+            # Write planning deliverables directly to bypass schema validation
+            # Used to simulate corrupt/external state for testing robustness
+            projects_file = workspace_root / ".st3" / "projects.json"
+            with projects_file.open() as f:
+                projects = json.load(f)
+
+            projects[str(issue_number)]["planning_deliverables"] = {
+                "tdd_cycles": {"total": len(cycles), "cycles": cycles}
+            }
+            with projects_file.open("w") as f:
+                json.dump(projects, f, indent=2)
+        else:
+            planning_deliverables = {
+                "tdd_cycles": {
+                    "total": len(cycles),
+                    "cycles": cycles,
+                }
+            }
+            project_manager.save_planning_deliverables(issue_number, planning_deliverables)
+
+        branch = "feature/146-tdd-cycle-tracking"
+        state_engine.initialize_branch(
+            branch=branch,
+            issue_number=issue_number,
+            initial_phase="tdd",
+        )
+        state = state_engine.get_state(branch)
+        state["current_phase"] = "tdd"
+        state["current_tdd_cycle"] = current_cycle
+        state["last_tdd_cycle"] = None
+        state["tdd_cycle_history"] = []
+        state_engine._save_state(branch, state)
+
+        return workspace_root
+
+    @pytest.mark.asyncio()
+    async def test_transition_blocked_when_current_cycle_has_empty_exit_criteria(
+        self, tool: TransitionCycleTool, tmp_path: Path
+    ) -> None:
+        """transition_cycle must block when current cycle has empty exit_criteria.
+
+        Issue #146 Cycle 6 D3: Design.md:287 - validate_exit_criteria before transition.
+        """
+        workspace_root = self._make_project(
+            tmp_path,
+            bypass_validation=True,
+            cycles=[
+                {
+                    "cycle_number": 1,
+                    "name": "Schema",
+                    "deliverables": ["Schema"],
+                    "exit_criteria": "",  # Empty - bypasses save_planning_deliverables validation
+                },
+                {
+                    "cycle_number": 2,
+                    "name": "Validation",
+                    "deliverables": ["Validators"],
+                    "exit_criteria": "All validators pass",
+                },
+            ],
+        )
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(TransitionCycleInput(to_cycle=2))
+
+        assert result.is_error, "Must block when exit_criteria is empty"
+        text = result.content[0]["text"]
+        assert "exit" in text.lower() or "criteria" in text.lower()
+
+    @pytest.mark.asyncio()
+    async def test_transition_blocked_when_current_cycle_missing_exit_criteria(
+        self, tool: TransitionCycleTool, tmp_path: Path
+    ) -> None:
+        """transition_cycle must block when current cycle is missing exit_criteria key.
+
+        Issue #146 Cycle 6 D3: exit_criteria key is mandatory.
+        """
+        workspace_root = self._make_project(
+            tmp_path,
+            bypass_validation=True,
+            cycles=[
+                {
+                    "cycle_number": 1,
+                    "name": "Schema",
+                    "deliverables": ["Schema"],
+                    # No exit_criteria key at all
+                },
+                {
+                    "cycle_number": 2,
+                    "name": "Validation",
+                    "deliverables": ["Validators"],
+                    "exit_criteria": "All validators pass",
+                },
+            ],
+        )
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(TransitionCycleInput(to_cycle=2))
+
+        assert result.is_error, "Must block when exit_criteria key is missing"
+        text = result.content[0]["text"]
+        assert "exit" in text.lower() or "criteria" in text.lower()
+
+    @pytest.mark.asyncio()
+    async def test_transition_succeeds_when_exit_criteria_present(
+        self, tool: TransitionCycleTool, tmp_path: Path
+    ) -> None:
+        """transition_cycle must succeed when current cycle has non-empty exit_criteria.
+
+        Issue #146 Cycle 6 D3: Normal path - exit criteria defined means transition allowed.
+        """
+        workspace_root = self._make_project(
+            tmp_path,
+            cycles=[
+                {
+                    "cycle_number": 1,
+                    "name": "Schema",
+                    "deliverables": ["Schema"],
+                    "exit_criteria": "All schema tests pass",
+                },
+                {
+                    "cycle_number": 2,
+                    "name": "Validation",
+                    "deliverables": ["Validators"],
+                    "exit_criteria": "All validators pass",
+                },
+            ],
+        )
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/146-tdd-cycle-tracking"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(TransitionCycleInput(to_cycle=2))
+
+        assert not result.is_error, f"Must succeed when exit_criteria present: {result.content}"
+
+
+# ---------------------------------------------------------------------------
+# C10: GAP-17 — force_cycle_transition: blocking deliverables BEFORE ✅ (Issue #229)
+# ---------------------------------------------------------------------------
+
+
+class TestForceCycleTransitionResponseFormat:
+    """Blocking deliverables appear BEFORE ✅; passing deliverables appear AFTER ✅.
+
+    Issue #229 Cycle 10 (GAP-17):
+    D10.4: Unvalidated (blocking) deliverables emitted before ✅ in force_cycle_transition.
+    D10.5: Validated (passing) deliverables listed informatively after ✅.
+    """
+
+    @pytest.fixture()
+    def tool(self) -> ForceCycleTransitionTool:
+        """Fixture to instantiate ForceCycleTransitionTool."""
+        return ForceCycleTransitionTool()
+
+    def _setup_for_cycle_transition(
+        self, tmp_path: Path, *, cycle3_file_present: bool
+    ) -> tuple[Path, int, str]:
+        """Build project in TDD phase C2; cycle 3 has a file_glob deliverable."""
+        workspace_root = tmp_path
+        issue_number = 229
+        branch = "feature/229-phase-deliverables-enforcement"
+
+        pm = ProjectManager(workspace_root=workspace_root)
+        se = PhaseStateEngine(workspace_root=workspace_root, project_manager=pm)
+
+        pm.initialize_project(
+            issue_number=issue_number,
+            issue_title="Phase deliverables enforcement",
+            workflow_name="feature",
+        )
+
+        if cycle3_file_present:
+            target_dir = workspace_root / "mcp_server" / "tools"
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "transition_tools.py").write_text("# validated content")
+
+        planning_deliverables: dict = {
+            "tdd_cycles": {
+                "total": 4,
+                "cycles": [
+                    {"cycle_number": 1, "deliverables": [{"id": "D1.1", "description": "p"}], "exit_criteria": "C1"},
+                    {"cycle_number": 2, "deliverables": [{"id": "D2.1", "description": "p"}], "exit_criteria": "C2"},
+                    {
+                        "cycle_number": 3,
+                        "deliverables": [
+                            {
+                                "id": "D3.2",
+                                "description": "transition_tools.py exists",
+                                "validates": {
+                                    "type": "file_glob",
+                                    "dir": "mcp_server/tools",
+                                    "pattern": "transition_tools.py",
+                                },
+                            }
+                        ],
+                        "exit_criteria": "D3.2 passes",
+                    },
+                    {"cycle_number": 4, "deliverables": [{"id": "D4.1", "description": "p"}], "exit_criteria": "C4"},
+                ],
+            }
+        }
+        pm.save_planning_deliverables(
+            issue_number=issue_number, planning_deliverables=planning_deliverables
+        )
+
+        state = se.get_state(branch)
+        state["current_phase"] = "tdd"
+        state["current_tdd_cycle"] = 2
+        state["last_tdd_cycle"] = 1
+        state["tdd_cycle_history"] = []
+        se._save_state(branch, state)
+
+        return workspace_root, issue_number, branch
+
+    @pytest.mark.asyncio()
+    async def test_force_cycle_transition_response_blocking_deliverable_appears_before_success(
+        self, tool: ForceCycleTransitionTool, tmp_path: Path
+    ) -> None:
+        """Unvalidated (blocking) deliverables appear BEFORE ✅ in response (GAP-17/D10.4)."""
+        workspace_root, issue_number, _branch = self._setup_for_cycle_transition(
+            tmp_path, cycle3_file_present=False  # file absent → deliverable FAILS → blocks
+        )
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/229-phase-deliverables-enforcement"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=4,
+                    skip_reason="Force skip C3",
+                    human_approval="Approved",
+                    issue_number=issue_number,
+                )
+            )
+
+        assert not result.is_error, f"Forced transition must succeed: {result.content}"
+        text = result.content[0]["text"]
+
+        assert "Unvalidated" in text, f"Expected 'Unvalidated' in response: {text}"
+        assert "✅" in text
+        # Blocking warning MUST appear BEFORE ✅
+        assert text.index("Unvalidated") < text.index("✅"), (
+            f"Blocking warning must precede ✅, got:\n{text}"
+        )
+
+    @pytest.mark.asyncio()
+    async def test_force_cycle_transition_response_passing_deliverable_appears_after_success(
+        self, tool: ForceCycleTransitionTool, tmp_path: Path
+    ) -> None:
+        """Validated (passing) deliverables listed informatively AFTER ✅ (GAP-17/D10.5)."""
+        workspace_root, issue_number, _branch = self._setup_for_cycle_transition(
+            tmp_path, cycle3_file_present=True  # file present → deliverable PASSES
+        )
+
+        with (
+            patch("mcp_server.tools.transition_tools.settings") as mock_settings,
+            patch("mcp_server.tools.transition_tools.GitManager") as mock_git_class,
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "feature/229-phase-deliverables-enforcement"
+            mock_git_class.return_value = mock_git
+            mock_settings.server.workspace_root = workspace_root
+
+            result = await tool.execute(
+                ForceCycleTransitionInput(
+                    to_cycle=4,
+                    skip_reason="Force skip C3 (validated)",
+                    human_approval="Approved",
+                    issue_number=issue_number,
+                )
+            )
+
+        assert not result.is_error, f"Forced transition must succeed: {result.content}"
+        text = result.content[0]["text"]
+
+        assert "✅" in text
+        # Validated deliverable D3.2 should be reported informatively AFTER ✅
+        assert "cycle:3:D3.2" in text, (
+            f"Expected cycle:3:D3.2 in informational section: {text}"
+        )
+        assert text.index("✅") < text.index("cycle:3:D3.2"), (
+            f"Informational deliverable info must follow ✅, got:\n{text}"
+        )


### PR DESCRIPTION
## Summary

Integration branch for merging `feature/146-tdd-cycle-tracking` into `main`, after resolving divergence from two parallel merges on main:
- PR #224: `feature/149-redesign-create-issue-tool` (new `CreateIssueInput` API)
- `refactor/135-ssot-template-introspection`

This branch was created from `main` and `feature/146-tdd-cycle-tracking` was merged into it, with conflicts resolved here so `main` stays protected.

---

## Issue #146: TDD Cycle Tracking & Validation

**All acceptance criteria met ✅**

### Implemented (C1–C8 + feature/229):
| Cycle | Scope |
|-------|-------|
| C1 | `TDDCycleTracker` — basic state machine (red/green/refactor) |
| C2 | `PlanningDeliverables` schema + DTO parsing |
| C3 | Entry validation (blocking gates) |
| C4 | Exit validation (blocking gates) |
| C5 | Warning gates (non-blocking) |
| C6 | Tracker integration in `transition_cycle` tool |
| C7 | `force_cycle_transition` with audit trail |
| C8 | Phase rename `integration` → `validation` across all workflows |
| #229 | Phase deliverables enforcement: hard exit gate + soft entry warning |

**Test results (on this branch):** 2308 passed, 11 skipped, 2 xfailed, 0 failures

---

## Conflict Resolution

### `.st3/projects.json`
- Kept all 4 project entries: `"149"`, `"135"` (from main) + `"146"`, `"229"` (from feature/146)
- Updated `"integration"` → `"validation"` in 149/135 entries (C8 phase rename)

### `tests/unit/mcp_server/integration/test_all_tools.py`
- Took HEAD (main) version: new `CreateIssueInput(issue_type=..., priority=..., scope=..., body=IssueBody(...))` API from PR #224

### `mcp_server/server.py`
- Auto-merged successfully, no manual intervention needed

---

## Quality Gates
- Ruff Format ✅
- Ruff Strict Lint ✅
- Imports ✅
- Line Length ✅
- Pyright ✅

---

**⚠️ Human approval required before merging.**
Closes #146