### PR TITLE
fix(#237): exclude integration marker from default pytest run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ addopts = [
     "-v",
     "--strict-markers",
     "--tb=short",
+    "-m", "not integration",
 ]
 # Coverage decoupled from default pytest runs per TODO 6 (Issue #131)
 # Coverage is enforced separately via Gate 6 (branch coverage >= 90%)

--- a/tests/unit/test_pytest_config.py
+++ b/tests/unit/test_pytest_config.py
@@ -1,0 +1,34 @@
+"""
+@module: tests.unit.test_pytest_config
+@layer: Test Infrastructure
+@responsibilities:
+  - Verify that pytest addopts excludes integration tests from the default run
+  - Prevents regression where integration-marked tests run against live GitHub API
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def _load_addopts() -> list[str]:
+    pyproject = Path(__file__).parent.parent.parent / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    return data["tool"]["pytest"]["ini_options"]["addopts"]
+
+
+def test_addopts_excludes_integration_marker() -> None:
+    """Default pytest run must never execute integration-marked tests.
+
+    Integration tests call the live GitHub API and create real issues.
+    Exclusion via -m 'not integration' in addopts is the fix for #237.
+    """
+    addopts = _load_addopts()
+    addopts_str = " ".join(addopts)
+    assert "not integration" in addopts_str, (
+        "addopts must contain '-m not integration' to prevent integration tests "
+        "from running in the default suite. "
+        f"Current addopts: {addopts}"
+    )


### PR DESCRIPTION
## Problem

`tests/integration/test_create_issue_e2e.py` is marked `@pytest.mark.integration` but the `integration` marker was never excluded from the default pytest run. Every `pytest` invocation (CI, local full suite) created 2 real GitHub issues via the live GitHub API.

## Fix

Added `-m not integration` to `addopts` in `pyproject.toml`:

```toml
addopts = [
    "-v",
    "--strict-markers",
    "--tb=short",
    "-m", "not integration",
]
```

Integration tests now only run when explicitly invoked:
```
pytest -m integration
```

## Test

`tests/unit/test_pytest_config.py` — reads `pyproject.toml` via `tomllib` and asserts `not integration` is present in `addopts`. Prevents regression.

## References
- Issue #237
- Identified in issue #236 research (docs/development/issue236/research.md, F1 context)