### PR TITLE
chore: initialize refactor/103 research phase (superseded by #247)

### DIFF
--- a/.st3/projects.json
+++ b/.st3/projects.json
@@ -990,5 +990,20 @@
         ]
       }
     }
+  },
+  "103": {
+    "issue_title": "Enhance run_tests tool for large test suites (1000+ tests)",
+    "workflow_name": "refactor",
+    "execution_mode": "interactive",
+    "required_phases": [
+      "research",
+      "planning",
+      "tdd",
+      "validation",
+      "documentation"
+    ],
+    "skip_reason": null,
+    "parent_branch": "main",
+    "created_at": "2026-02-21T19:43:38.843635+00:00"
   }
 }


### PR DESCRIPTION
## Summary

Research phase initialization for #103 (enhance run_tests tool). During research, discovery of mixed test structure led to creation of #247 (test structure separation) which will be tackled first.

This branch contains only the workflow initialization commit — no code changes. User's manual deletions verified: 2318 passed, 0 failed.

## Notes

- Issue #247 created: Strict test structure separation backend/ vs mcp_server/
- #247 will be tackled first; #103 implementation follows on clean structure
- `mcp_server/tools/test_tools.py` rename identified as part of #103 scope